### PR TITLE
Add optional boolq/hellaswag LM-eval

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,6 +65,7 @@ from model import GPT, GPTConfig
 
 # Inference related imports
 import tiktoken
+from benchmarks.gpt_lm_eval_wrapper import NanoGPTLM
 
 from train_args import parse_args
 
@@ -481,6 +482,27 @@ class Trainer:
                     args=self.args,
                 )
 
+        self.model.train()
+
+    @torch.no_grad()
+    def run_lm_eval_tasks(self):
+        if not self.args.lm_eval_tasks:
+            return
+
+        wrapped_model = NanoGPTLM.create_model(
+            model=self.model,
+            encode_fn=self.encode,
+            decode_fn=self.decode,
+            args=self.args,
+        )
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        wrapped_model.evaluate_and_save(
+            tasks=self.args.lm_eval_tasks.split(","),
+            batch_size=self.args.batch_size,
+            out_dir=self.args.out_dir,
+            timestamp=timestamp,
+            results_output=self.args.lm_eval_results_output,
+        )
         self.model.train()
 
     def get_vocab_size_from_meta(self):
@@ -1310,6 +1332,9 @@ class Trainer:
                         # Sample
                         if self.args.max_sample_tokens:
                             self.sample_and_print()
+                        # Optional LM evaluation tasks
+                        if self.args.lm_eval_tasks:
+                            self.run_lm_eval_tasks()
                         # export embedding table to npy file
                         if self.args.export_wte_npy:
                             self.raw_model.export_wte(self.args.export_wte_npy)
@@ -1321,6 +1346,8 @@ class Trainer:
                             # Try model inference (e.g. exploring inference from overfitting)
                             if self.args.max_sample_tokens:
                                 self.sample_and_print()
+                        if self.args.lm_eval_each_eval and self.args.lm_eval_tasks:
+                            self.run_lm_eval_tasks()
                         if self.args.export_wte_each_eval:
                             # export wte table to npy file
                             if self.args.export_wte_npy:

--- a/train_args.py
+++ b/train_args.py
@@ -60,6 +60,18 @@ def parse_args():
     training_group.add_argument('--sample_start_tokens', default='\n', type=str)
     training_group.add_argument('--sample_only', default=False, action=argparse.BooleanOptionalAction, help="Run only the sampling process and exit")
 
+    # LM evaluation args
+    training_group.add_argument('--lm_eval_tasks', type=str, default=None,
+                                help="Comma-separated list of lm-eval tasks (e.g. 'boolq,hellaswag') to run at each eval interval")
+    training_group.add_argument('--lm_eval_each_eval', default=False, action=argparse.BooleanOptionalAction,
+                                help="Run lm-eval tasks at every eval interval even if validation loss did not improve")
+    training_group.add_argument(
+        '--lm_eval_results_output',
+        type=str,
+        default=None,
+        help="Where to save lm-eval results JSON. Defaults to out_dir/<timestamp>_lm_eval_results.json"
+    )
+
     # Checkpoint args
     training_group.add_argument('--save_major_ckpt_interval', default=None, type=int, help="Interval for saving major checkpoints.")
     training_group.add_argument('--only_save_checkpoint_at_end', default=False, action=argparse.BooleanOptionalAction)


### PR DESCRIPTION
## Summary
- add `lm_eval_tasks` option to train_args
- call `NanoGPTLM` from train loop so boolq/hellaswag can run
- support `--lm_eval_each_eval` and results output handling

## Testing
- `python -m py_compile train.py train_args.py`
- `pytest -k ""` *(fails: ModuleNotFoundError: jamo)*

------
https://chatgpt.com/codex/tasks/task_e_6857a55af07c8326a00ac4a328d2aaf4