### PR TITLE
Add more initialization variants

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -348,6 +348,9 @@ class GPTConfig:
     init_variant: str = "gaussian"
     init_scale: float = 0.01
     init_wte_npy: str = "wte.npy"
+    init_radius: float = 1.0
+    gaussian_min_norm: float = 0.0
+    gaussian_max_norm: float = float('inf')
 
     # Quantizations
     start_quant_level: float = 0

--- a/initializations/README.md
+++ b/initializations/README.md
@@ -36,3 +36,10 @@ python3 gradient_optimization.py \
 [!image](./images/min_angle_dim8.png)
 
 The npy files are saved before and after.
+
+## Additional Variations
+
+- `rand_hypercube`: random ±1 corners, normalized and scaled by `--init_scale`.
+- `angle_hypersphere`: random angle vectors projected on a hypersphere with radius `--init_radius`.
+- `unique_hypercube`: like `rand_hypercube` but ensures no two vectors are opposites.
+- `gaussian_norm_range`: gaussian sampling repeated until each vector norm falls within `[--gaussian_min_norm, --gaussian_max_norm]`.

--- a/initializations/initialization_variations.py
+++ b/initializations/initialization_variations.py
@@ -68,9 +68,84 @@ def numpy_import_init(config):
     except Exception as e:
         raise RuntimeError(f"Error loading NumPy embedding file: {e}")
 
+def random_hypercube_norm(config):
+    """Random +/-1 hypercube corners normalized and scaled."""
+    vocab_size = config.vocab_size
+    n_embd = config.n_embd
+    scale = config.init_scale
+
+    weight = torch.randint(0, 2, (vocab_size, n_embd), dtype=torch.float32)
+    weight = weight * 2 - 1  # convert {0,1} -> {-1,1}
+    weight = weight / weight.norm(dim=1, keepdim=True)
+    return weight * scale
+
+
+def hypersphere_angle_init(config):
+    """Random angles mapped onto a hypersphere surface."""
+    vocab_size = config.vocab_size
+    n_embd = config.n_embd
+    radius = getattr(config, "init_radius", 1.0)
+
+    angles = torch.rand(vocab_size, n_embd) * (2 * np.pi)
+    vec = torch.cos(angles)
+    vec = vec / vec.norm(dim=1, keepdim=True)
+    return vec * radius
+
+
+def unique_hypercube_norm(config):
+    """Random hypercube corners ensuring no opposite pairs."""
+    vocab_size = config.vocab_size
+    n_embd = config.n_embd
+    scale = config.init_scale
+
+    max_unique = 2 ** n_embd // 2
+    if vocab_size > max_unique:
+        raise ValueError("Not enough unique corners without opposites.")
+
+    vectors = []
+    seen = set()
+    while len(vectors) < vocab_size:
+        vec = torch.randint(0, 2, (n_embd,), dtype=torch.float32)
+        vec = vec * 2 - 1
+        tup = tuple(vec.tolist())
+        if tup in seen or tuple((-vec).tolist()) in seen:
+            continue
+        seen.add(tup)
+        vectors.append(vec)
+
+    weight = torch.stack(vectors)
+    weight = weight / weight.norm(dim=1, keepdim=True)
+    return weight * scale
+
+
+def gaussian_norm_range_init(config):
+    """Gaussian init with vector norm constraints."""
+    vocab_size = config.vocab_size
+    n_embd = config.n_embd
+    mean = config.embedding_mean_init
+    std = config.embedding_std_init
+    min_norm = getattr(config, "gaussian_min_norm", 0.0)
+    max_norm = getattr(config, "gaussian_max_norm", float("inf"))
+
+    weight = torch.empty((vocab_size, n_embd), dtype=torch.float32)
+    i = 0
+    while i < vocab_size:
+        vec = torch.randn(n_embd) * std + mean
+        norm = vec.norm().item()
+        if norm < min_norm or norm > max_norm:
+            continue
+        weight[i] = vec
+        i += 1
+    return weight
+
+
 init_dictionary = {
-    "gaussian": None,    # fall back to the default Gaussian in model.py
+    "gaussian": None,  # default Gaussian
     "hypercube": direct_init,
     "onehot": one_hot_init,
-    "numpy_import": numpy_import_init, # New entry
+    "numpy_import": numpy_import_init,
+    "rand_hypercube": random_hypercube_norm,
+    "angle_hypersphere": hypersphere_angle_init,
+    "unique_hypercube": unique_hypercube_norm,
+    "gaussian_norm_range": gaussian_norm_range_init,
 }

--- a/train_args.py
+++ b/train_args.py
@@ -606,11 +606,18 @@ def parse_args():
             "onehot",
             "hypercube",
             "numpy_import",
+            "rand_hypercube",
+            "angle_hypersphere",
+            "unique_hypercube",
+            "gaussian_norm_range",
             ]
 
     model_group.add_argument( "--init_variant", choices=embedding_init_variations, default="gaussian", help="options for embedding initializations")
     model_group.add_argument( "--init_scale", type=float, default=0.01, help="initialization scaling factor with non-gaussian variations")
     model_group.add_argument( "--init_wte_npy", type=str, default="wte.npy", help="npy file for initialization of wte files")
+    model_group.add_argument( "--init_radius", type=float, default=1.0, help="radius for angle_hypersphere initialization")
+    model_group.add_argument( "--gaussian_min_norm", type=float, default=0.0, help="minimum norm for gaussian_norm_range initialization")
+    model_group.add_argument( "--gaussian_max_norm", type=float, default=float('inf'), help="maximum norm for gaussian_norm_range initialization")
 
     # Quantization
     model_group.add_argument("--full_quant_iteration", type=int, default=None,


### PR DESCRIPTION
## Summary
- implement `rand_hypercube`, `angle_hypersphere`, `unique_hypercube`, `gaussian_norm_range` in initialization variations
- expose new init settings in config dataclass and CLI
- document new options in initialization README

## Testing
- `git ls-files '*.py' | grep -v '^data/' | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6861c2a88bf88326818cfff6c3a947d0