### PR TITLE
Add simple Flask webapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,17 @@ run a second tensorboard, use the script and specify a different port e.g. 6007:
 source ./logging/start_tensorboard.sh 6007
 ```
 
+### Webapp Front End
+
+A simple Flask app for launching runs is provided in `webapp/`. Start it with:
+
+```bash
+python3 webapp/app.py
+```
+
+The interface lets you configure `run_experiments.py`, run `train.py` with custom arguments and links to TensorBoard.
+
+
 ## TODO Section:
 
 TODO: Add links and descriptions to other Readme's and Demos.

--- a/requirements_cpu.txt
+++ b/requirements_cpu.txt
@@ -23,3 +23,4 @@ sentencepiece==0.1.99
 spacy==3.7.2
 tqdm==4.66.4
 lm_eval==0.4.8
+Flask==3.0.3

--- a/requirements_gpu.txt
+++ b/requirements_gpu.txt
@@ -28,3 +28,4 @@ adabelief-pytorch
 adan-pytorch
 torch_optimizer
 tensorboard
+Flask==3.0.3

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,76 @@
+import subprocess
+import threading
+from flask import Flask, render_template, request, redirect, url_for
+
+app = Flask(__name__)
+
+process_logs = {}
+process_status = {}
+
+
+def run_command(cmd, key):
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    process_status[key] = 'running'
+    lines = []
+    for line in proc.stdout:
+        lines.append(line)
+    proc.wait()
+    process_logs[key] = ''.join(lines)
+    process_status[key] = 'finished'
+
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+
+@app.route('/run_experiments', methods=['POST'])
+def run_experiments():
+    config = request.form['config']
+    fmt = request.form.get('format', 'yaml')
+    output_dir = request.form.get('output_dir', 'out')
+    prefix = request.form.get('prefix', '')
+    use_ts = request.form.get('use_timestamp') == 'on'
+
+    cmd = ['python3', 'optimization_and_search/run_experiments.py',
+           '-c', config, '--config_format', fmt, '-o', output_dir]
+    if prefix:
+        cmd += ['--prefix', prefix]
+    if use_ts:
+        cmd.append('--use_timestamp')
+
+    key = 'run_experiments'
+    thread = threading.Thread(target=run_command, args=(cmd, key))
+    thread.start()
+    return redirect(url_for('output', key=key))
+
+
+@app.route('/run_train', methods=['POST'])
+def run_train():
+    args = request.form['train_args'].split()
+    cmd = ['python3', 'train.py'] + args
+    key = 'train'
+    thread = threading.Thread(target=run_command, args=(cmd, key))
+    thread.start()
+    return redirect(url_for('output', key=key))
+
+
+@app.route('/output/<key>')
+def output(key):
+    log = process_logs.get(key, '')
+    status = process_status.get(key, 'running')
+    return render_template('output.html', log=log, status=status, key=key)
+
+
+@app.route('/tensorboard')
+def tensorboard():
+    logdir = request.args.get('logdir', 'runs')
+    port = request.args.get('port', '6006')
+    if 'tensorboard' not in process_status:
+        subprocess.Popen(['tensorboard', '--logdir', logdir, '--port', str(port)])
+        process_status['tensorboard'] = 'running'
+    return redirect(f'http://localhost:{port}')
+
+
+if __name__ == '__main__':
+    app.run(port=8080)

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+  <head>
+    <title>nanoGPT Webapp</title>
+  </head>
+  <body>
+    <h1>Experiment Runner</h1>
+    <h2>Run Experiments</h2>
+    <form action="/run_experiments" method="post">
+      <label>Config path: <input type="text" name="config"></label><br>
+      <label>Format:
+        <select name="format">
+          <option value="yaml">yaml</option>
+          <option value="json">json</option>
+        </select>
+      </label><br>
+      <label>Output dir: <input type="text" name="output_dir" value="out"></label><br>
+      <label>Prefix: <input type="text" name="prefix"></label><br>
+      <label>Use timestamp: <input type="checkbox" name="use_timestamp"></label><br>
+      <input type="submit" value="Run">
+    </form>
+
+    <h2>Run train.py</h2>
+    <form action="/run_train" method="post">
+      <label>Arguments: <input type="text" name="train_args"></label><br>
+      <input type="submit" value="Run">
+    </form>
+
+    <p><a href="/tensorboard">Open TensorBoard</a></p>
+  </body>
+</html>

--- a/webapp/templates/output.html
+++ b/webapp/templates/output.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Output - {{ key }}</title>
+  </head>
+  <body>
+    <h1>Process {{ key }}</h1>
+    {% if status == 'running' %}
+      <p>Status: running...</p>
+    {% else %}
+      <p>Status: finished</p>
+    {% endif %}
+    <pre>{{ log }}</pre>
+    <p><a href="/">Back</a></p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a small Flask webapp for running `run_experiments.py` and `train.py`
- link to TensorBoard from the web interface
- document webapp usage in README
- include Flask in CPU/GPU requirements

## Testing
- `python3 -m py_compile webapp/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6860db57734483268427d77fedb09d87