### PR TITLE
Fix gradient checkpointing feature and add CI test

### DIFF
--- a/.github/workflows/cpu-test-gradient-checkpointing.yml
+++ b/.github/workflows/cpu-test-gradient-checkpointing.yml
@@ -1,0 +1,28 @@
+name: Install Then Test Gradient Checkpointing
+on: [push, pull_request]
+jobs:
+  Install-And-Test-Gradient-Checkpointing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - run: echo "${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "Currently on ${{ github.ref }} branch"
+      - name: ls of directory
+        run: |
+          ls ${{ github.workspace }}
+      - name: Install CPU Dependencies
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          python3 -m pip install --upgrade pip
+          python3 -m pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+          python3 -m pip install numpy transformers datasets tiktoken wandb tqdm tensorboard
+          python3 -m pip install -r requirements_cpu.txt
+          python3 -m pip install ml_dtypes
+      - name: Test gradient checkpointing
+        run: |
+          source venv/bin/activate
+          cd tests
+          source test_gradient_checkpointing_cpu.sh
+

--- a/tests/test_gradient_checkpointing_cpu.sh
+++ b/tests/test_gradient_checkpointing_cpu.sh
@@ -1,0 +1,49 @@
+#/bin/bash
+
+# head to repo root
+cd ../
+
+dataset="shakespeare_char"
+bash "data/${dataset}/get_dataset.sh"
+
+n_layer="2"
+n_head="2"
+n_kv_group="2"
+n_embd="60"
+max_iters="50"
+block_size="32"
+eval_iters="50"
+eval_interval="50"
+timestamp="$(date +%F_%T)"
+notes="test_gradient_checkpointing"
+run_name="${dataset}_gc_${max_iters}_${block_size}_${n_layer}_${n_head}_${n_embd}_${notes}"
+output_dir="results/${timestamp}_${notes}"
+
+if [ ! -d "${output_dir}" ]; then
+  mkdir -p "${output_dir}"
+fi
+
+python3 train.py \
+  --max_iters "$max_iters" \
+  --n_layer "$n_layer" \
+  --n_head "$n_head" \
+  --n_kv_group "$n_kv_group" \
+  --n_embd "$n_embd" \
+  --eval_iters "$eval_iters" \
+  --eval_interval "$eval_interval" \
+  --log_interval 10 \
+  --device cpu \
+  --dataset "$dataset" \
+  --tensorboard_run_name "$run_name" \
+  --block_size "$block_size" \
+  --use_gradient_checkpointing \
+  --out_dir "${output_dir}"
+
+python3 sample.py \
+  --out_dir "${output_dir}" \
+  --device "cpu" \
+  --num_samples 1 \
+  --max_new_tokens 100 \
+  --start "Hello world"
+
+sleep 3


### PR DESCRIPTION
## Summary
- fix gradient checkpointing argument handling in `model.py`
- update training loops to return `(x, mlp_res)` when checkpointing
- add gradient checkpointing test script
- add GitHub Actions workflow to run the new test

## Testing
- `python -m py_compile model.py`
- `bash tests/test_gradient_checkpointing_cpu.sh` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686ada339d348326832a08c2e99dabd9