### PR TITLE
Add KurTail PTQ utilities

### DIFF
--- a/demos/kurtail_minipile_qat.sh
+++ b/demos/kurtail_minipile_qat.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Quantization aware training with KurTail on the Minipile dataset
+python3 train.py \
+  --dataset minipile \
+  --out_dir kurtail_minipile \
+  --n_layer 2 \
+  --n_head 2 \
+  --n_kv_group 2 \
+  --n_embd 60 \
+  --block_size 32 \
+  --max_iters 100 \
+  --eval_iters 50 \
+  --log_interval 20 \
+  --quantization_warmup_iters 0 \
+  --quantize_attn_act \
+  --quantize_mlp_act \
+  --linear_variant_attn quantized_linear \
+  --linear_variant_mlp quantized_linear \
+  --quantize_linear_method kurtail_quant \
+  --activations_quant_method kurtail_quant \
+  --store_activations

--- a/demos/ptq_quantization_demo.sh
+++ b/demos/ptq_quantization_demo.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Train a small model
+python3 train.py \
+  --out_dir ptq_demo_model \
+  --n_layer 2 \
+  --n_head 2 \
+  --n_kv_group 2 \
+  --n_embd 60 \
+  --max_iters 100 \
+  --block_size 32 \
+  --eval_iters 50 \
+  --log_interval 20
+
+# Post-training quantize the checkpoint using KurTail
+python3 quantization/ptq_quantize_ckpt.py \
+  --ckpt_path ptq_demo_model/ckpt.pt \
+  --out_ckpt ptq_demo_model/ckpt_ptq.pt \
+  --bits 4 \
+  --quant_method kurtail_quant
+
+# Run inference from the quantized checkpoint
+cp ptq_demo_model/ckpt_ptq.pt ptq_demo_model/ckpt.pt
+python3 sample.py \
+  --out_dir ptq_demo_model \
+  --init_from resume \
+  --start "Hello" \
+  --num_samples 1 \
+  --max_new_tokens 50

--- a/quantization/README.md
+++ b/quantization/README.md
@@ -181,3 +181,37 @@ python3 quantization/visualize.py \
     - **Purpose**: Allows the model to stabilize before introducing quantization, which can improve training convergence.
 
 ---
+
+## KurTail Rotation
+
+KurTail is an optional rotation step that can be applied to activations
+before quantization. It learns an orthogonal matrix that minimizes the
+kurtosis of the activation distribution which helps mitigate outliers for
+extreme bit-widths.
+
+```python
+from quantization.kurtail import apply_kurtail_quantization
+zpt, scale, q, R = apply_kurtail_quantization(tensor, bits=4)
+```
+
+The learned rotation matrix `R` can be fused into the model weights or
+stored for later use during inference. KurTail relies only on PyTorch and
+does not require multiple GPUs to train the rotation.
+
+## Post-Training Quantization
+
+`quantization/ptq_quantize_ckpt.py` converts a standard checkpoint
+produced by `train.py` into a quantized checkpoint using any of the
+available quantization methods. The quantized checkpoint can then be
+used with `sample.py` for inference.
+
+```bash
+python3 quantization/ptq_quantize_ckpt.py \
+  --ckpt_path out/ckpt.pt \
+  --out_ckpt out/ckpt_ptq.pt \
+  --bits 4 \
+  --quant_method kurtail_quant
+```
+
+See `demos/ptq_quantization_demo.sh` for a complete example.
+

--- a/quantization/kurtail.py
+++ b/quantization/kurtail.py
@@ -1,0 +1,59 @@
+import torch
+
+
+def compute_kurtosis(x: torch.Tensor) -> torch.Tensor:
+    """Return kurtosis of a batch of vectors.
+
+    Args:
+        x: Tensor of shape (N, D)
+
+    Returns:
+        Scalar tensor with mean kurtosis across dimensions.
+    """
+    mean = x.mean(dim=0, keepdim=True)
+    var = x.var(dim=0, unbiased=False, keepdim=True)
+    fourth = ((x - mean) ** 4).mean(dim=0)
+    kurt = fourth / (var.squeeze(0) ** 2 + 1e-5)
+    return kurt.mean()
+
+
+def learn_kurtail_rotation(acts: torch.Tensor, num_iters: int = 100, lr: float = 1e-2,
+                           target: float = 1.8) -> torch.Tensor:
+    """Learn an orthogonal rotation that minimizes kurtosis.
+
+    This is a minimal implementation of the rotation learning scheme
+    described in the KurTail paper. The function performs gradient
+    descent on a rotation matrix so that the transformed activations
+    have kurtosis close to the target kurtosis of a uniform distribution
+    (approximately 1.8).
+    """
+    d = acts.shape[-1]
+    device = acts.device
+    R = torch.eye(d, device=device, dtype=acts.dtype, requires_grad=True)
+    opt = torch.optim.Adam([R], lr=lr)
+    for _ in range(num_iters):
+        transformed = acts @ R
+        loss = (compute_kurtosis(transformed) - target) ** 2
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+        # project back to the orthogonal group via QR decomposition
+        with torch.no_grad():
+            q, _ = torch.linalg.qr(R)
+            R.copy_(q)
+    return R.detach()
+
+
+def apply_kurtail_quantization(tensor: torch.Tensor, bits: int = 4,
+                               num_iters: int = 100) -> tuple:
+    """Quantize ``tensor`` after learning a KurTail rotation.
+
+    Returns the zero point, scale and quantized tensor. The learned
+    rotation matrix is also returned for reference.
+    """
+    R = learn_kurtail_rotation(tensor, num_iters=num_iters)
+    rotated = tensor @ R
+    from .quantize import symmetric_quantize
+    zp, scale, q = symmetric_quantize(rotated, bits)
+    return zp, scale, q, R
+

--- a/quantization/ptq_quantize_ckpt.py
+++ b/quantization/ptq_quantize_ckpt.py
@@ -1,0 +1,64 @@
+import argparse
+import os
+import torch
+
+from model import GPT, GPTConfig
+
+from quantization.quantize import quantize_dictionary
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Post-training quantize a checkpoint")
+    p.add_argument("--ckpt_path", type=str, default=os.path.join("out", "ckpt.pt"),
+                   help="Path to checkpoint produced by train.py")
+    p.add_argument("--out_ckpt", type=str, default=os.path.join("out", "ckpt_ptq.pt"),
+                   help="Where to save the quantized checkpoint")
+    p.add_argument("--bits", type=int, default=4, help="Quantization bit width")
+    p.add_argument("--quant_method", type=str, default="symmetric_quant",
+                   choices=list(quantize_dictionary.keys()),
+                   help="Quantization method for linear weights")
+    p.add_argument("--device", type=str, default="cpu",
+                   help="Device used for quantization computations")
+    return p.parse_args()
+
+
+def load_model(ckpt, device):
+    model_args = ckpt["model_args"]
+    model_args["dropout"] = 0.0
+    model_args["linear_variant_attn"] = "quantized_linear"
+    model_args["linear_variant_mlp"] = "quantized_linear"
+    # configure quantization
+    model_args["quantize_linear_bits"] = args.bits
+    model_args["quantize_linear_method"] = args.quant_method
+    gptconf = GPTConfig(**model_args)
+    model = GPT(gptconf)
+    state = ckpt["model"]
+    unwanted_prefix = "_orig_mod."
+    for k in list(state.keys()):
+        if k.startswith(unwanted_prefix):
+            state[k[len(unwanted_prefix):]] = state.pop(k)
+    model.load_state_dict(state, strict=False)
+    model.to(device)
+    model.eval()
+    return model
+
+
+def quantize_model(model):
+    for module in model.modules():
+        if hasattr(module, "_eval"):
+            module._eval()
+
+
+def main(args):
+    ckpt = torch.load(args.ckpt_path, map_location=args.device)
+    model = load_model(ckpt, args.device)
+    quantize_model(model)
+    ckpt["model"] = model.state_dict()
+    torch.save(ckpt, args.out_ckpt)
+    print(f"Quantized checkpoint saved to {args.out_ckpt}")
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args)
+


### PR DESCRIPTION
## Summary
- implement script `ptq_quantize_ckpt.py` to post-training quantize checkpoints
- add demo for running PTQ with KurTail
- add demo for quantization-aware training with KurTail on Minipile dataset
- document new PTQ script in quantization README

## Testing
- `python3 -m py_compile quantization/kurtail.py quantization/quantize.py quantization/ptq_quantize_ckpt.py`
- `bash tests/test_quantization_cpu.sh` *(fails: can't open dataset and missing files)*

------
https://chatgpt.com/codex/tasks/task_e_686f143846e08326b371acf97ab734aa