### PR TITLE
Add KurTail quantization utility

### DIFF
--- a/demos/kurtail_qat_demo.sh
+++ b/demos/kurtail_qat_demo.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Example Quantization Aware Training using KurTail rotation
+python3 train.py \
+  --out_dir "kurtail_qat_model" \
+  --n_layer "2" \
+  --n_head "2" \
+  --n_kv_group "2" \
+  --n_embd "60" \
+  --max_iters "100" \
+  --block_size "32" \
+  --eval_iters "50" \
+  --log_interval "20" \
+  --quantize_linear_method "kurtail_quant" \
+  --activations_quant_method "kurtail_quant" \
+  --dtype "bfloat16" \
+  --quantization_warmup_iters 0 \
+  --quantize_attn_act \
+  --quantize_mlp_act \
+  --linear_variant_attn "quantized_linear" \
+  --linear_variant_mlp "quantized_linear" \
+  --store_activations
+

--- a/quantization/kurtail.py
+++ b/quantization/kurtail.py
@@ -1,0 +1,59 @@
+import torch
+
+
+def compute_kurtosis(x: torch.Tensor) -> torch.Tensor:
+    """Return kurtosis of a batch of vectors.
+
+    Args:
+        x: Tensor of shape (N, D)
+
+    Returns:
+        Scalar tensor with mean kurtosis across dimensions.
+    """
+    mean = x.mean(dim=0, keepdim=True)
+    var = x.var(dim=0, unbiased=False, keepdim=True)
+    fourth = ((x - mean) ** 4).mean(dim=0)
+    kurt = fourth / (var.squeeze(0) ** 2 + 1e-5)
+    return kurt.mean()
+
+
+def learn_kurtail_rotation(acts: torch.Tensor, num_iters: int = 100, lr: float = 1e-2,
+                           target: float = 1.8) -> torch.Tensor:
+    """Learn an orthogonal rotation that minimizes kurtosis.
+
+    This is a minimal implementation of the rotation learning scheme
+    described in the KurTail paper. The function performs gradient
+    descent on a rotation matrix so that the transformed activations
+    have kurtosis close to the target kurtosis of a uniform distribution
+    (approximately 1.8).
+    """
+    d = acts.shape[-1]
+    device = acts.device
+    R = torch.eye(d, device=device, dtype=acts.dtype, requires_grad=True)
+    opt = torch.optim.Adam([R], lr=lr)
+    for _ in range(num_iters):
+        transformed = acts @ R
+        loss = (compute_kurtosis(transformed) - target) ** 2
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+        # project back to the orthogonal group via QR decomposition
+        with torch.no_grad():
+            q, _ = torch.linalg.qr(R)
+            R.copy_(q)
+    return R.detach()
+
+
+def apply_kurtail_quantization(tensor: torch.Tensor, bits: int = 4,
+                               num_iters: int = 100) -> tuple:
+    """Quantize ``tensor`` after learning a KurTail rotation.
+
+    Returns the zero point, scale and quantized tensor. The learned
+    rotation matrix is also returned for reference.
+    """
+    R = learn_kurtail_rotation(tensor, num_iters=num_iters)
+    rotated = tensor @ R
+    from .quantize import symmetric_quantize
+    zp, scale, q = symmetric_quantize(rotated, bits)
+    return zp, scale, q, R
+

--- a/quantization/ptq_kurtail.py
+++ b/quantization/ptq_kurtail.py
@@ -1,0 +1,31 @@
+import argparse
+import os
+import torch
+from quantization.quantize import kurtail_quantize
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Post-training quantization with KurTail")
+    p.add_argument("--ckpt", type=str, default="out/ckpt.pt", help="Path to checkpoint")
+    p.add_argument("--output", type=str, default="ptq_kurtail.pt", help="Output checkpoint path")
+    p.add_argument("--bits", type=int, default=4, help="Quantization bits")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    ckpt = torch.load(args.ckpt, map_location="cpu")
+    state = ckpt["model"]
+    for name, tensor in list(state.items()):
+        if tensor.dtype in (torch.float32, torch.float16, torch.bfloat16) and tensor.ndim >= 2:
+            zp, scale, q = kurtail_quantize(tensor.float(), args.bits)
+            state[name] = q
+            state[name + "_scale"] = scale
+            state[name + "_zero_point"] = zp
+    torch.save(ckpt, args.output)
+    print(f"Saved quantized checkpoint to {args.output}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/train_args.py
+++ b/train_args.py
@@ -621,7 +621,13 @@ def parse_args():
                              help="Scheduler for change in quant level. When linear is set, the quantization will increase dynamically based on the training step")
 
     ## Quantization Method Options
-    quant_methods = ["ternary_quant", "symmetric_quant", "affine_quant", "stochastic_quant"]
+    quant_methods = [
+        "ternary_quant",
+        "symmetric_quant",
+        "affine_quant",
+        "stochastic_quant",
+        "kurtail_quant",
+    ]
 
     ## WTE
     model_group.add_argument("--quantize_wte", default=None, action=argparse.BooleanOptionalAction, help="Whether the word embedding is quantized")


### PR DESCRIPTION
## Summary
- implement KurTail rotation learning in new `kurtail.py`
- add `kurtail_quantize` helper in `quantize.py`
- register `kurtail_quant` option in training args
- document KurTail usage with demos for QAT and PTQ
- add example QAT script and PTQ helper script

## Testing
- `python3 -m py_compile quantization/kurtail.py quantization/quantize.py quantization/ptq_kurtail.py`
- `bash tests/test_quantization_cpu.sh` *(fails: can't open dataset and missing files)*

------
https://chatgpt.com/codex/tasks/task_e_686f143846e08326b371acf97ab734aa