### PR TITLE
Add options for nGPT normalization & SLERP

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -155,6 +155,10 @@ class GPTConfig:
     use_qk_norm: bool = False
     use_qk_norm_scale: bool = False
 
+    # nGPT ablation options
+    ngpt_norm: bool = False
+    ngpt_slerp: bool = False
+
     ## SSM - Attention Varient (same as Hymba)
     ssm_mamba_expand: int = 2
     ssm_conv_kernel_size: int = 3

--- a/model.py
+++ b/model.py
@@ -44,6 +44,22 @@ from initializations.initialization_variations import init_dictionary
 
 from shared_param_utils import SharedParamGroupCreator
 
+# Utility functions for nGPT-style updates
+def _lerp(a, b, alpha):
+    return a + alpha * (b - a)
+
+def _slerp(a, b, alpha):
+    dot = (a * b).sum(dim=-1, keepdim=True).clamp(-1.0, 1.0)
+    omega = torch.acos(dot)
+    so = torch.sin(omega)
+    # avoid division by zero
+    res = torch.where(
+        so == 0,
+        _lerp(a, b, alpha),
+        torch.sin((1 - alpha) * omega) / so * a + torch.sin(alpha * omega) / so * b,
+    )
+    return res
+
 class Block(nn.Module):
     def __init__(self, config, mlp=None, attn=None):
         super().__init__()
@@ -57,6 +73,13 @@ class Block(nn.Module):
         self.use_post_ln = config.use_post_ln
         self.use_parallel_mlp = config.use_parallel_mlp
         self.use_gradient_checkpointing = config.use_gradient_checkpointing
+
+        self.ngpt_norm = config.ngpt_norm
+        self.ngpt_slerp = config.ngpt_slerp
+        if self.ngpt_norm or self.ngpt_slerp:
+            # learnable step sizes for attention and MLP updates
+            self.alpha_attn = nn.Parameter(torch.tensor(0.5))
+            self.alpha_mlp = nn.Parameter(torch.tensor(0.5))
 
         # Allow for sharing attn between blocks
         if attn is None:
@@ -78,21 +101,100 @@ class Block(nn.Module):
 
             if self.use_post_ln:
                 if self.use_parallel_mlp:
-                    x = self.ln_1(x + self.attn(x, iter_num) + self.mlp(x, iter_num))
+                    attn_out = self.attn(x, iter_num)
+                    mlp_out = self.mlp(x, iter_num)
+                    if isinstance(mlp_out, tuple):
+                        mlp_out, mlp_res = mlp_out
+                    if self.ngpt_norm:
+                        attn_out = F.normalize(attn_out, dim=-1)
+                        mlp_out = F.normalize(mlp_out, dim=-1)
+                    if self.ngpt_slerp:
+                        x = _slerp(x, attn_out, torch.clamp(self.alpha_attn, 0.0, 1.0))
+                    else:
+                        x = _lerp(x, attn_out, torch.clamp(self.alpha_attn, 0.0, 1.0))
+                    if self.ngpt_norm:
+                        x = F.normalize(x, dim=-1)
+                    if self.ngpt_slerp:
+                        x = _slerp(x, mlp_out, torch.clamp(self.alpha_mlp, 0.0, 1.0))
+                    else:
+                        x = _lerp(x, mlp_out, torch.clamp(self.alpha_mlp, 0.0, 1.0))
+                    if self.ngpt_norm:
+                        x = F.normalize(x, dim=-1)
+                    x = self.ln_1(x)
                 else:
-                    x = self.ln_1(x + self.attn(x, iter_num))
-                    x = self.ln_2(x + self.mlp(x, iter_num))
+                    attn_out = self.attn(x, iter_num)
+                    if self.ngpt_norm:
+                        attn_out = F.normalize(attn_out, dim=-1)
+                    if self.ngpt_slerp:
+                        x = _slerp(x, attn_out, torch.clamp(self.alpha_attn, 0.0, 1.0))
+                    else:
+                        x = _lerp(x, attn_out, torch.clamp(self.alpha_attn, 0.0, 1.0))
+                    if self.ngpt_norm:
+                        x = F.normalize(x, dim=-1)
+                    mlp_out = self.mlp(x, iter_num)
+                    if isinstance(mlp_out, tuple):
+                        mlp_out, mlp_res = mlp_out
+                    if self.ngpt_norm:
+                        mlp_out = F.normalize(mlp_out, dim=-1)
+                    if self.ngpt_slerp:
+                        x = _slerp(x, mlp_out, torch.clamp(self.alpha_mlp, 0.0, 1.0))
+                    else:
+                        x = _lerp(x, mlp_out, torch.clamp(self.alpha_mlp, 0.0, 1.0))
+                    if self.ngpt_norm:
+                        x = F.normalize(x, dim=-1)
+                    x = self.ln_1(x)
+                    x = self.ln_2(x)
                 return x, mlp_res
             else:
                 if self.use_parallel_mlp:
                     ln_1 = self.ln_1(x)
-                    mlp, mlp_res = self.mlp(ln_1, iter_num)
-                    x = x + self.attn(ln_1, iter_num) + mlp
+                    attn_out = self.attn(ln_1, iter_num)
+                    mlp_ret = self.mlp(ln_1, iter_num)
+                    if isinstance(mlp_ret, tuple):
+                        mlp, mlp_res = mlp_ret
+                    else:
+                        mlp = mlp_ret
+                    if self.ngpt_norm:
+                        attn_out = F.normalize(attn_out, dim=-1)
+                        mlp = F.normalize(mlp, dim=-1)
+                    if self.ngpt_slerp:
+                        x = _slerp(x, attn_out, torch.clamp(self.alpha_attn, 0.0, 1.0))
+                    else:
+                        x = _lerp(x, attn_out, torch.clamp(self.alpha_attn, 0.0, 1.0))
+                    if self.ngpt_norm:
+                        x = F.normalize(x, dim=-1)
+                    if self.ngpt_slerp:
+                        x = _slerp(x, mlp, torch.clamp(self.alpha_mlp, 0.0, 1.0))
+                    else:
+                        x = _lerp(x, mlp, torch.clamp(self.alpha_mlp, 0.0, 1.0))
+                    if self.ngpt_norm:
+                        x = F.normalize(x, dim=-1)
                     return x, mlp_res
                 else:
-                    x = x + self.attn(self.ln_1(x), iter_num)
-                    mlp, mlp_res = self.mlp(self.ln_2(x), iter_num, mlp_res)
-                    x = x + mlp
+                    attn_in = self.ln_1(x)
+                    attn_out = self.attn(attn_in, iter_num)
+                    if self.ngpt_norm:
+                        attn_out = F.normalize(attn_out, dim=-1)
+                    if self.ngpt_slerp:
+                        x = _slerp(x, attn_out, torch.clamp(self.alpha_attn, 0.0, 1.0))
+                    else:
+                        x = _lerp(x, attn_out, torch.clamp(self.alpha_attn, 0.0, 1.0))
+                    if self.ngpt_norm:
+                        x = F.normalize(x, dim=-1)
+                    mlp_in = self.ln_2(x)
+                    mlp_ret = self.mlp(mlp_in, iter_num, mlp_res)
+                    if isinstance(mlp_ret, tuple):
+                        mlp, mlp_res = mlp_ret
+                    else:
+                        mlp = mlp_ret
+                    if self.ngpt_norm:
+                        mlp = F.normalize(mlp, dim=-1)
+                    if self.ngpt_slerp:
+                        x = _slerp(x, mlp, torch.clamp(self.alpha_mlp, 0.0, 1.0))
+                    else:
+                        x = _lerp(x, mlp, torch.clamp(self.alpha_mlp, 0.0, 1.0))
+                    if self.ngpt_norm:
+                        x = F.normalize(x, dim=-1)
                     return x, mlp_res
 
         if self.use_gradient_checkpointing and x.requires_grad:

--- a/train_args.py
+++ b/train_args.py
@@ -573,6 +573,12 @@ def parse_args():
     model_group.add_argument("--use_qk_norm",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="applies the norm to q and k before attn")
     model_group.add_argument("--use_qk_norm_scale",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="applies norm scale, preloads scale for flash attn, post qk multiplication in manual attn")
 
+    ## nGPT ablation options
+    model_group.add_argument('--ngpt_norm', default=False, action=argparse.BooleanOptionalAction,
+                             help='Enable hyperspherical normalization steps from nGPT')
+    model_group.add_argument('--ngpt_slerp', default=False, action=argparse.BooleanOptionalAction,
+                             help='Use SLERP interpolation for residual updates')
+
     ## Flash Lobo
     model_group.add_argument("--use_flash_lobo",   type=bool, default=False, action=argparse.BooleanOptionalAction)
     model_group.add_argument("--use_flash_lobo_per_head",   type=bool, default=False, action=argparse.BooleanOptionalAction)


### PR DESCRIPTION
## Summary
- support normalized GPT ablation flags
- implement SLERP/LERP residual mixing
- expose CLI flags `--ngpt_norm` and `--ngpt_slerp`

## Testing
- `python -m py_compile model.py`
- `python -m py_compile train_args.py gpt_conf.py`


------
https://chatgpt.com/codex/tasks/task_e_686fb2fc3cd88326be5c5e12c71b419b