### PR TITLE
Add Muon optimizer

### DIFF
--- a/train_args.py
+++ b/train_args.py
@@ -157,6 +157,7 @@ def parse_args():
             "swats",
             "sophiag",
             "soap",
+            "muon",
             "var_adaptive_lr",
             "lookahead",
             ]
@@ -276,6 +277,14 @@ def parse_args():
     training_group.add_argument("--shampoo_momentum", type=float, default=0.0)
     training_group.add_argument("--shampoo_eps", type=float, default=1e-4)
     training_group.add_argument("--shampoo_update_freq", type=int, default=1)
+
+    # Muon
+    training_group.add_argument("--muon_momentum", type=float, default=0.95,
+                                help="Momentum term for Muon optimizer.")
+    training_group.add_argument("--muon_ns_iters", type=int, default=5,
+                                help="Newton-Schulz iteration steps for Muon.")
+    training_group.add_argument("--muon_scale", type=float, default=0.2,
+                                help="Update scaling factor for Muon optimizer.")
 
     # ASGD-like PID
     training_group.add_argument("--pid_momentum",  type=float, default=0.0)


### PR DESCRIPTION
## Summary
- implement Muon optimizer
- add Muon to optimizer choices
- expose Muon CLI flags for momentum, iterations, and scaling factor

## Testing
- `pytest -q` *(fails: MeCab runtime error)*

------
https://chatgpt.com/codex/tasks/task_e_68735eb6e4ec832697929dd127ee86ce