### PR TITLE
Add AdaSplash entmax option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ configurations and modules, catering to a diverse range of use cases.
 
 Key exploration features include:
 
-* `Module Variation`: Explore with different module types -- e.g. Softmax, Softermax, ConSmax, and SigSoftmax -- discover which is best suited (PPA) to your application.
+* `Module Variation`: Explore with different module types -- e.g. Softmax, Softermax, ConSmax, SigSoftmax, and AdaSplash -- discover which is best suited (PPA) to your application.
 * `Flexible Tokenization`: Explore different tokenization: tiktoken, sentencepiece, phonemization, character level, custom tokenization, etc.
 * `Diverse Dataset Performance Testing`: Evaluate model efficacy across various languages and datasets including: csv-timeseries, mathematics, music, lyrics, literature, and webtext.
 * `Standard and Custom Hyperparameters`: Fine-tune models using conventional hyperparameters and explore the impact of custom settings on model performance and PPA impacts.

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -185,8 +185,9 @@ class GPTConfig:
     shared_attn_seq: int = 1
 
     # Softmax Alternatives and Options
-    softmax_variant_attn: str = "softmax" # Choices: "softmax" "softermax" "sigsoftmax" "polymax" "strongermax" "consmax"
-    softmax_variant_output: str = "softmax" # Choices: "softmax" "softermax" "sigsoftmax" "polymax" "strongermax" "consmax"
+    softmax_variant_attn: str = "softmax" # Choices: "softmax" "softermax" "sigsoftmax" "polymax" "strongermax" "consmax" "adasplash"
+    softmax_variant_output: str = "softmax" # Choices: "softmax" "softermax" "sigsoftmax" "polymax" "strongermax" "consmax" "adasplash"
+    adasplash_alpha: float = 1.5  # exponent for AdaSplash (α-entmax) attention
 
 
     ## General Options


### PR DESCRIPTION
## Summary
- add AdaSplash to list of module variations
- support AdaSplash option in GPT configuration
- implement AdaSplash adaptive sparse attention using Halley-bisection

## Testing
- `python -m py_compile gpt_conf.py variations/softmax_variations.py`

------
https://chatgpt.com/codex/tasks/task_e_6876d73f3b3883269e6f887d32327782