### PR TITLE
Add docs for recurrent fine-tuning and script improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Hardware Related
   * [Prepare Training and Validation Data Sets](#prepare-training-and-validation-data-sets)
   * [Train Model From Scratch](#train-model-from-scratch)
   * [Perform Inference From Custom Model](#perform-inference-from-custom-model)
+  * [Recurrent Fine-Tuning](#recurrent-fine-tuning)
 * [Explorations](#explorations)
   * [Start Exploration](#start-exploration)
   * [Inspect and Monitor Best Val Losses](#inspect-and-monitor-best-val-losses)
@@ -132,6 +133,16 @@ I thank your eyes against it.
 This looks pretty good for a model which just learned how to spell from scratch.
 Keeping an eye on inference is very important, however, usually one can infer
 levels from validation losses.
+
+### Recurrent Fine-Tuning
+
+To continue training from an existing checkpoint using latent chaining, run
+
+```bash
+python3 train_recurrent.py --resume_ckpt out/ckpt.pt --latent_steps 4
+```
+
+See [Recurrent_Fine_Tuning.md](documentation/Recurrent_Fine_Tuning.md) for more details.
 
 The next section goes over how to do a massive _exploration_ of different models
 and quickly compare their quality using the `validation loss` as a proxy.

--- a/documentation/Recurrent_Fine_Tuning.md
+++ b/documentation/Recurrent_Fine_Tuning.md
@@ -1,0 +1,28 @@
+# Recurrent Fine-Tuning
+
+This guide covers the `train_recurrent.py` script used for latent-chaining fine-tuning.
+
+## Overview
+
+`train_recurrent.py` continues training from a pre-existing checkpoint while feeding the model's hidden state back as the next token for a number of steps. This allows the model to refine its latent representations without using the embedding layer for every position.
+
+## Basic Usage
+
+Assuming you have an existing checkpoint in `out/ckpt.pt`, run:
+
+```bash
+python3 train_recurrent.py --resume_ckpt out/ckpt.pt --latent_steps 4 --max_iters 1000
+```
+
+Important flags include:
+
+- `--latent_steps`: number of hidden states to chain before teacher forcing.
+- `--skip_steps`: ignore loss on the first positions of every block.
+- `--reset_best_val_loss`: begin saving checkpoints immediately regardless of the previous best value.
+
+## Suggested Extensions
+
+- Mixed teacher-forcing schedules instead of a fixed `--latent_steps` value.
+- Support for variable-length recurrent chains driven by the validation loss.
+- Better statistics reporting such as perplexity or gradient norms during training.
+


### PR DESCRIPTION
## Summary
- document recurrent fine-tuning via `train_recurrent.py`
- add an extra flag to reset best validation loss
- describe recurrent training in the README and new doc file

## Testing
- `pytest -q` *(fails: No module named 'yakinori', 'jamo')*

------
https://chatgpt.com/codex/tasks/task_e_687c390ba2a083268880dbac293d693f