### PR TITLE
Add pink trombone IPA mapping prototype

### DIFF
--- a/pink_trombone/README.md
+++ b/pink_trombone/README.md
@@ -1,0 +1,26 @@
+# Pink Trombone Integration
+
+This folder demonstrates how to generate control parameters for the [Pink Trombone](../data/pink_trombone/pink-trombone-master) speech synthesizer using `espeak-ng` to obtain IPA transcriptions.
+
+The workflow is:
+
+1. **IPA Conversion** – Convert English text to IPA with `espeak-ng`.
+2. **Phoneme Mapping** – Map each IPA symbol to a set of Pink Trombone parameters.
+3. **Parameter Emission** – Emit the numeric parameter frames that can be consumed by the Pink Trombone library.
+
+The `ipa_to_params.py` script shows a minimal example of this process. It is intended as a starting point for building a comprehensive dataset that covers the full IPA inventory.
+
+## Requirements
+
+- Python 3.8+
+- `espeak-ng` installed and accessible on the command line
+
+## Example Usage
+
+```bash
+python ipa_to_params.py "hello world"
+```
+
+The script prints a JSON array of parameter frames corresponding to the IPA output for the given text. Each frame is a dictionary whose keys match the control parameters exposed by the Rust implementation.
+
+Extend the `PHONEME_MAP` dictionary in `ipa_to_params.py` to cover additional IPA symbols and adjust parameter values to your needs.

--- a/pink_trombone/ipa_to_params.py
+++ b/pink_trombone/ipa_to_params.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Convert text to Pink Trombone parameters via espeak-ng IPA output.
+
+This script is a small prototype demonstrating how IPA phonemes can be
+translated into numeric values that control the Pink Trombone synthesizer.
+The mapping below is intentionally small and should be extended to cover
+all phonemes of interest.
+"""
+
+import argparse
+import json
+import subprocess
+from typing import List, Dict
+
+# Example mapping from IPA symbols to Pink Trombone parameter values.
+# Values are chosen for demonstration and do not represent a finalized
+# articulatory model.
+PHONEME_MAP: Dict[str, Dict[str, float]] = {
+    "a": {"tongue_index": 20.0, "tongue_diameter": 2.5, "velum_open": False},
+    "i": {"tongue_index": 32.0, "tongue_diameter": 1.5, "velum_open": False},
+    "u": {"tongue_index": 10.0, "tongue_diameter": 2.0, "velum_open": False},
+    "e": {"tongue_index": 27.0, "tongue_diameter": 2.0, "velum_open": False},
+    "o": {"tongue_index": 15.0, "tongue_diameter": 2.4, "velum_open": False},
+    "ə": {"tongue_index": 22.0, "tongue_diameter": 2.3, "velum_open": False},
+    "ʊ": {"tongue_index": 12.0, "tongue_diameter": 2.3, "velum_open": False},
+    "m": {"tongue_index": 12.0, "tongue_diameter": 2.0, "velum_open": True},
+    "l": {"tongue_index": 30.0, "tongue_diameter": 1.8, "velum_open": False},
+    "h": {"tongue_index": 18.0, "tongue_diameter": 2.2, "velum_open": False},
+}
+
+
+def text_to_ipa(text: str) -> str:
+    """Return espeak-ng IPA transcription for ``text``."""
+    result = subprocess.run(
+        ["espeak-ng", "--ipa", "-q", text], capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+def ipa_to_params(ipa: str) -> List[Dict[str, float]]:
+    """Convert an IPA string into a list of parameter dictionaries."""
+    params = []
+    for symbol in ipa.replace(" ", ""):
+        mapping = PHONEME_MAP.get(symbol)
+        if mapping:
+            params.append(mapping)
+    return params
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert text to Pink Trombone parameters")
+    parser.add_argument("text", help="Input text")
+    args = parser.parse_args()
+
+    ipa = text_to_ipa(args.text)
+    frames = ipa_to_params(ipa)
+    print(f"IPA: {ipa}")
+    print(json.dumps(frames, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `pink_trombone` folder with README
- introduce `ipa_to_params.py` script that maps espeak IPA output to sample Pink Trombone parameters

## Testing
- `python3 -m py_compile pink_trombone/ipa_to_params.py`
- `./pink_trombone/ipa_to_params.py "hello world"`

------
https://chatgpt.com/codex/tasks/task_e_687f3172a89883268d992057dde0c314