### PR TITLE
Add JL transform checkpoint utility

### DIFF
--- a/analysis/checkpoint_analysis/README.md
+++ b/analysis/checkpoint_analysis/README.md
@@ -72,3 +72,7 @@ written to a new directory.
 python checkpoint_analysis/jl_transform_ckpt.py out \
     --out_dir out_jl --out_embd <new_dim>
 ```
+
+The new embedding dimension must keep the per-head dimension constant, i.e.
+`new_dim // n_head` must equal the original `n_embd // n_head` from the
+checkpoint.

--- a/analysis/checkpoint_analysis/README.md
+++ b/analysis/checkpoint_analysis/README.md
@@ -74,6 +74,3 @@ python checkpoint_analysis/jl_transform_ckpt.py out \
     --out_dir out_jl --out_embd <new_dim> --jl_type sign
 ```
 
-The new embedding dimension must keep the per-head dimension constant, i.e.
-`new_dim // n_head` must equal the original `n_embd // n_head` from the
-checkpoint.

--- a/analysis/checkpoint_analysis/README.md
+++ b/analysis/checkpoint_analysis/README.md
@@ -73,6 +73,8 @@ When using the `gaussian` type you may set `--gaussian_mean` and
 `--gaussian_std` to control the distribution of the projection matrix.  The
 optional `--cproj_vertical` flag projects any `c_proj.weight` tensors along their
 first dimension instead of the default behaviour.
+The script also resets `best_val_loss` and `best_iter` in the new checkpoint so
+training restarts from scratch after transformation.
 
 ```bash
 python checkpoint_analysis/jl_transform_ckpt.py out \

--- a/analysis/checkpoint_analysis/README.md
+++ b/analysis/checkpoint_analysis/README.md
@@ -60,3 +60,13 @@ python checkpoint_analysis/checkpoint_explorer.py out/ckpt.pt --device cuda
 - Ensure the script is run from the **main repository directory**.
 - Verify that the checkpoint file exists at the specified path.
 - Check for dependencies like PyTorch before running the script.
+
+## JL Transforming a Checkpoint
+
+The script `jl_transform_ckpt.py` applies a Johnson-Lindenstrauss transform to
+every weight tensor in a checkpoint. The transformed checkpoint and the original
+`meta.pkl` are written to a new directory.
+
+```bash
+python checkpoint_analysis/jl_transform_ckpt.py out --out_dir out_jl
+```

--- a/analysis/checkpoint_analysis/README.md
+++ b/analysis/checkpoint_analysis/README.md
@@ -63,11 +63,11 @@ python checkpoint_analysis/checkpoint_explorer.py out/ckpt.pt --device cuda
 
 ## JL Transforming a Checkpoint
 
-The script `jl_transform_ckpt.py` applies a Johnson-Lindenstrauss transform to
-every weight tensor in a checkpoint. It also allows changing the model's
-embedding dimension. The transformed checkpoint and the original `meta.pkl` are
-written to a new directory. Use `--jl_type` to select the kind of JL transform
-(e.g. `sign`, `gaussian`, `sparse`, or `srht`).
+The script `jl_transform_ckpt.py` applies a Johnson–Lindenstrauss transform to
+every weight tensor in a checkpoint. It can also change the model’s embedding
+dimension while keeping the MLP sizes intact. The transformed checkpoint and the
+original `meta.pkl` are written to a new directory. Use `--jl_type` to select the
+kind of JL transform (e.g. `sign`, `gaussian`, `sparse`, or `srht`).
 
 ```bash
 python checkpoint_analysis/jl_transform_ckpt.py out \

--- a/analysis/checkpoint_analysis/README.md
+++ b/analysis/checkpoint_analysis/README.md
@@ -66,12 +66,12 @@ python checkpoint_analysis/checkpoint_explorer.py out/ckpt.pt --device cuda
 The script `jl_transform_ckpt.py` applies a Johnson-Lindenstrauss transform to
 every weight tensor in a checkpoint. It also allows changing the model's
 embedding dimension. The transformed checkpoint and the original `meta.pkl` are
-written to a new directory. Use `--wte_only` to only transform the `wte`
-embedding matrix.
+written to a new directory. Use `--jl_type` to select the kind of JL transform
+(e.g. `sign`, `gaussian`, `sparse`, or `srht`).
 
 ```bash
 python checkpoint_analysis/jl_transform_ckpt.py out \
-    --out_dir out_jl --out_embd <new_dim>
+    --out_dir out_jl --out_embd <new_dim> --jl_type sign
 ```
 
 The new embedding dimension must keep the per-head dimension constant, i.e.

--- a/analysis/checkpoint_analysis/README.md
+++ b/analysis/checkpoint_analysis/README.md
@@ -66,7 +66,8 @@ python checkpoint_analysis/checkpoint_explorer.py out/ckpt.pt --device cuda
 The script `jl_transform_ckpt.py` applies a Johnson-Lindenstrauss transform to
 every weight tensor in a checkpoint. It also allows changing the model's
 embedding dimension. The transformed checkpoint and the original `meta.pkl` are
-written to a new directory.
+written to a new directory. Use `--wte_only` to only transform the `wte`
+embedding matrix.
 
 ```bash
 python checkpoint_analysis/jl_transform_ckpt.py out \

--- a/analysis/checkpoint_analysis/README.md
+++ b/analysis/checkpoint_analysis/README.md
@@ -64,9 +64,11 @@ python checkpoint_analysis/checkpoint_explorer.py out/ckpt.pt --device cuda
 ## JL Transforming a Checkpoint
 
 The script `jl_transform_ckpt.py` applies a Johnson-Lindenstrauss transform to
-every weight tensor in a checkpoint. The transformed checkpoint and the original
-`meta.pkl` are written to a new directory.
+every weight tensor in a checkpoint. It also allows changing the model's
+embedding dimension. The transformed checkpoint and the original `meta.pkl` are
+written to a new directory.
 
 ```bash
-python checkpoint_analysis/jl_transform_ckpt.py out --out_dir out_jl
+python checkpoint_analysis/jl_transform_ckpt.py out \
+    --out_dir out_jl --out_embd <new_dim>
 ```

--- a/analysis/checkpoint_analysis/README.md
+++ b/analysis/checkpoint_analysis/README.md
@@ -65,7 +65,7 @@ python checkpoint_analysis/checkpoint_explorer.py out/ckpt.pt --device cuda
 
 The script `jl_transform_ckpt.py` applies a Johnson–Lindenstrauss transform to
 every weight tensor in a checkpoint. It can also change the model’s embedding
-dimension while keeping the MLP sizes intact. The transformed checkpoint and the
+dimension while keeping attention head dimensions and MLP sizes intact. The transformed checkpoint and the
 original `meta.pkl` are written to a new directory. Use `--jl_type` to select the
 kind of JL transform (e.g. `sign`, `gaussian`, `sparse`, or `srht`).
 The optional `--cproj_vertical` flag projects any `c_proj.weight` tensors along

--- a/analysis/checkpoint_analysis/README.md
+++ b/analysis/checkpoint_analysis/README.md
@@ -69,8 +69,10 @@ dimension while keeping attention head dimensions and MLP sizes intact. The tran
 original `meta.pkl` are written to a new directory. Optimizer and scheduler
 states are removed so training restarts cleanly. Use `--jl_type` to select the
 kind of JL transform (e.g. `sign`, `gaussian`, `sparse`, or `srht`).
-The optional `--cproj_vertical` flag projects any `c_proj.weight` tensors along
-their first dimension instead of the default behaviour.
+When using the `gaussian` type you may set `--gaussian_mean` and
+`--gaussian_std` to control the distribution of the projection matrix.  The
+optional `--cproj_vertical` flag projects any `c_proj.weight` tensors along their
+first dimension instead of the default behaviour.
 
 ```bash
 python checkpoint_analysis/jl_transform_ckpt.py out \

--- a/analysis/checkpoint_analysis/README.md
+++ b/analysis/checkpoint_analysis/README.md
@@ -68,6 +68,8 @@ every weight tensor in a checkpoint. It can also change the model’s embedding
 dimension while keeping the MLP sizes intact. The transformed checkpoint and the
 original `meta.pkl` are written to a new directory. Use `--jl_type` to select the
 kind of JL transform (e.g. `sign`, `gaussian`, `sparse`, or `srht`).
+The optional `--cproj_vertical` flag projects any `c_proj.weight` tensors along
+their first dimension instead of the default behaviour.
 
 ```bash
 python checkpoint_analysis/jl_transform_ckpt.py out \

--- a/analysis/checkpoint_analysis/README.md
+++ b/analysis/checkpoint_analysis/README.md
@@ -66,7 +66,8 @@ python checkpoint_analysis/checkpoint_explorer.py out/ckpt.pt --device cuda
 The script `jl_transform_ckpt.py` applies a Johnson–Lindenstrauss transform to
 every weight tensor in a checkpoint. It can also change the model’s embedding
 dimension while keeping attention head dimensions and MLP sizes intact. The transformed checkpoint and the
-original `meta.pkl` are written to a new directory. Use `--jl_type` to select the
+original `meta.pkl` are written to a new directory. Optimizer and scheduler
+states are removed so training restarts cleanly. Use `--jl_type` to select the
 kind of JL transform (e.g. `sign`, `gaussian`, `sparse`, or `srht`).
 The optional `--cproj_vertical` flag projects any `c_proj.weight` tensors along
 their first dimension instead of the default behaviour.

--- a/analysis/checkpoint_analysis/jl_transform_ckpt.py
+++ b/analysis/checkpoint_analysis/jl_transform_ckpt.py
@@ -200,6 +200,11 @@ def main():
             if len(set(mlp_sizes)) > 1:
                 checkpoint["config"]["mlp_size_layerlist"] = mlp_sizes
 
+    # reset training progress so fine-tuning starts fresh
+    checkpoint["iter_num"] = 0
+    checkpoint["best_val_loss"] = 1e9
+    checkpoint["best_iter"] = 0
+
     out_dir = args.out_dir or f"{args.ckpt_dir.rstrip('/').rstrip(os.sep)}_jl"
     os.makedirs(out_dir, exist_ok=True)
 

--- a/analysis/checkpoint_analysis/jl_transform_ckpt.py
+++ b/analysis/checkpoint_analysis/jl_transform_ckpt.py
@@ -1,0 +1,63 @@
+import argparse
+import os
+import shutil
+import torch
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Apply a Johnson-Lindenstrauss transform to all weights in a checkpoint"
+    )
+    parser.add_argument(
+        "ckpt_dir",
+        type=str,
+        help="Directory containing ckpt.pt and meta.pkl from a previous training run",
+    )
+    parser.add_argument(
+        "--out_dir",
+        type=str,
+        default=None,
+        help="Directory to write the transformed checkpoint (defaults to <ckpt_dir>_jl)",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=1337,
+        help="Random seed for the JL transform",
+    )
+    return parser.parse_args()
+
+
+def jl_transform_tensor(tensor: torch.Tensor, generator: torch.Generator) -> torch.Tensor:
+    """Apply a simple JL style sign flip transform."""
+    rnd = torch.randint(0, 2, tensor.shape, generator=generator, device=tensor.device)
+    rnd = rnd * 2 - 1
+    return tensor * rnd
+
+
+def main():
+    args = parse_args()
+
+    ckpt_path = os.path.join(args.ckpt_dir, "ckpt.pt")
+    meta_path = os.path.join(args.ckpt_dir, "meta.pkl")
+
+    checkpoint = torch.load(ckpt_path, map_location="cpu")
+    state_dict = checkpoint.get("model", checkpoint)
+
+    g = torch.Generator()
+    g.manual_seed(args.seed)
+
+    for key, tensor in list(state_dict.items()):
+        if torch.is_floating_point(tensor):
+            state_dict[key] = jl_transform_tensor(tensor, g)
+
+    out_dir = args.out_dir or f"{args.ckpt_dir.rstrip('/').rstrip(os.sep)}_jl"
+    os.makedirs(out_dir, exist_ok=True)
+
+    torch.save(checkpoint, os.path.join(out_dir, "ckpt.pt"))
+    if os.path.exists(meta_path):
+        shutil.copy2(meta_path, os.path.join(out_dir, "meta.pkl"))
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/checkpoint_analysis/jl_transform_ckpt.py
+++ b/analysis/checkpoint_analysis/jl_transform_ckpt.py
@@ -136,7 +136,7 @@ def main():
 
 
     if args.jl_type == "gaussian":
-        proj = torch.empty(args.out_embd, old_embd, generator=g, device="cpu")
+        proj = torch.empty((args.out_embd, old_embd), generator=g, device="cpu")
         proj.normal_(mean=args.gaussian_mean, std=args.gaussian_std)
         proj /= math.sqrt(args.out_embd)
     elif args.jl_type == "sparse":

--- a/analysis/checkpoint_analysis/jl_transform_ckpt.py
+++ b/analysis/checkpoint_analysis/jl_transform_ckpt.py
@@ -97,6 +97,11 @@ def main():
     checkpoint = torch.load(ckpt_path, map_location="cpu")
     state_dict = checkpoint.get("model", checkpoint)
 
+    # optimizer and scheduler states depend on parameter shapes.
+    # They will be invalid after changing the embedding dimension, so drop them.
+    checkpoint.pop("optimizer", None)
+    checkpoint.pop("scheduler", None)
+
     g = torch.Generator()
     g.manual_seed(args.seed)
 

--- a/analysis/checkpoint_analysis/jl_transform_ckpt.py
+++ b/analysis/checkpoint_analysis/jl_transform_ckpt.py
@@ -39,6 +39,18 @@ def parse_args():
         help="Type of JL transform: 'sign' (default), 'gaussian', 'sparse' (Achlioptas), or 'srht'",
     )
     parser.add_argument(
+        "--gaussian_mean",
+        type=float,
+        default=0.0,
+        help="Mean of the normal distribution for the gaussian JL transform",
+    )
+    parser.add_argument(
+        "--gaussian_std",
+        type=float,
+        default=1.0,
+        help="Standard deviation of the normal distribution for the gaussian JL transform",
+    )
+    parser.add_argument(
         "--cproj_vertical",
         action="store_true",
         help="Project c_proj weights along the out_features dimension instead of the in_features dimension",
@@ -124,7 +136,9 @@ def main():
 
 
     if args.jl_type == "gaussian":
-        proj = torch.randn(args.out_embd, old_embd, generator=g, device="cpu") / math.sqrt(args.out_embd)
+        proj = torch.empty(args.out_embd, old_embd, generator=g, device="cpu")
+        proj.normal_(mean=args.gaussian_mean, std=args.gaussian_std)
+        proj /= math.sqrt(args.out_embd)
     elif args.jl_type == "sparse":
         rand = torch.rand(args.out_embd, old_embd, generator=g, device="cpu")
         proj = torch.zeros_like(rand)


### PR DESCRIPTION
## Summary
- add `jl_transform_ckpt.py` utility to perform a sign based JL transform on checkpoint weights
- document new script in checkpoint analysis README

## Testing
- `pytest -q` *(fails: Failed initializing MeCab)*

------
https://chatgpt.com/codex/tasks/task_e_6881c4fd86cc83269901ae9270bb21c8