### PR TITLE
Add Mixture of Lookup Experts option

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -130,6 +130,8 @@ class GPTConfig:
     gate: bool = False
     use_moe: bool = False
     moe_layer_freq: int = 2
+    use_mole: bool = False
+    mole_layer_freq: int = 2
     n_experts: int = 8
     moe_top_k: int = 2
     moe_router_scheme: str = "softmax"

--- a/model.py
+++ b/model.py
@@ -30,6 +30,7 @@ import torch.utils.checkpoint as checkpoint
 from variations.attention_variations import attention_dictionary
 from variations.mlp_variations import get_mlp_instance
 from variations.moe_variations import MoELayer
+from variations.mole_variations import MoLELayer
 from variations.lsv_variations import lsv_dictionary
 from variations.softmax_variations import softmax_dictionary
 from variations.norm_variations import norm_dictionary
@@ -70,35 +71,55 @@ class Block(nn.Module):
         else:
             self.mlp = mlp
 
-    def forward(self, x, iter_num, mlp_res=None):
+    def forward(self, x, iter_num, mlp_res=None, embed_tokens=None, input_ids=None):
         def custom_forward(*inputs):
             x = inputs[0]
             iter_num = inputs[1]
             mlp_res = inputs[2]
+            embed_tokens = inputs[3]
+            input_ids = inputs[4]
 
             if self.use_post_ln:
                 if self.use_parallel_mlp:
-                    x = self.ln_1(x + self.attn(x, iter_num) + self.mlp(x, iter_num))
+                    res = self.mlp(x, iter_num, mlp_res, embed_tokens, input_ids) if isinstance(self.mlp, MoLELayer) else self.mlp(x, iter_num)
+                    if isinstance(res, tuple):
+                        mlp_out, mlp_res = res
+                    else:
+                        mlp_out, mlp_res = res, mlp_res
+                    x = self.ln_1(x + self.attn(x, iter_num) + mlp_out)
                 else:
                     x = self.ln_1(x + self.attn(x, iter_num))
-                    x = self.ln_2(x + self.mlp(x, iter_num))
+                    res = self.mlp(x, iter_num, mlp_res, embed_tokens, input_ids) if isinstance(self.mlp, MoLELayer) else self.mlp(x, iter_num)
+                    if isinstance(res, tuple):
+                        mlp_out, mlp_res = res
+                    else:
+                        mlp_out, mlp_res = res, mlp_res
+                    x = self.ln_2(x + mlp_out)
                 return x, mlp_res
             else:
                 if self.use_parallel_mlp:
                     ln_1 = self.ln_1(x)
-                    mlp, mlp_res = self.mlp(ln_1, iter_num)
-                    x = x + self.attn(ln_1, iter_num) + mlp
+                    res = self.mlp(ln_1, iter_num, mlp_res, embed_tokens, input_ids) if isinstance(self.mlp, MoLELayer) else self.mlp(ln_1, iter_num)
+                    if isinstance(res, tuple):
+                        mlp_out, mlp_res = res
+                    else:
+                        mlp_out, mlp_res = res, mlp_res
+                    x = x + self.attn(ln_1, iter_num) + mlp_out
                     return x, mlp_res
                 else:
                     x = x + self.attn(self.ln_1(x), iter_num)
-                    mlp, mlp_res = self.mlp(self.ln_2(x), iter_num, mlp_res)
-                    x = x + mlp
+                    res = self.mlp(self.ln_2(x), iter_num, mlp_res, embed_tokens, input_ids) if isinstance(self.mlp, MoLELayer) else self.mlp(self.ln_2(x), iter_num, mlp_res)
+                    if isinstance(res, tuple):
+                        mlp_out, mlp_res = res
+                    else:
+                        mlp_out, mlp_res = res, mlp_res
+                    x = x + mlp_out
                     return x, mlp_res
 
         if self.use_gradient_checkpointing and x.requires_grad:
-            return checkpoint.checkpoint(custom_forward, x, iter_num, mlp_res, use_reentrant=False)
+            return checkpoint.checkpoint(custom_forward, x, iter_num, mlp_res, embed_tokens, input_ids, use_reentrant=False)
         else:
-            return custom_forward(x, iter_num, mlp_res)
+            return custom_forward(x, iter_num, mlp_res, embed_tokens, input_ids)
 
 class LearnedPositionEmbedding(nn.Module):
     """
@@ -537,13 +558,16 @@ class GPT(nn.Module):
 
             # forward the GPT model itself
             tok_emb = self.transformer.wte(idx) # token embeddings of shape (b, t, n_embd)
+            embed_tokens = tok_emb
             x = None
 
             if self.config.use_embedding_scale:
                 tok_emb = tok_emb * self.embedding_scale
+                embed_tokens = embed_tokens * self.embedding_scale
 
             if self.n_embd_wte:
                 tok_emb = self.transformer.scale_up(tok_emb)
+                embed_tokens = self.transformer.scale_up(embed_tokens)
 
             if self.config.use_abs_pos_embeddings:
                 pos = torch.arange(0, t, dtype=torch.long, device=device) # shape (t)
@@ -576,7 +600,10 @@ class GPT(nn.Module):
             mlp_res = None
             for block in self.transformer.h:
                 # Propagate tokens through layers
-                x, mlp_res = block(x, iter_num, mlp_res=mlp_res)
+                if isinstance(block.mlp, MoLELayer):
+                    x, mlp_res = block(x, iter_num, mlp_res=mlp_res, embed_tokens=embed_tokens, input_ids=idx)
+                else:
+                    x, mlp_res = block(x, iter_num, mlp_res=mlp_res)
 
                 # Intercept for Learned Steering Vectors
                 if self.use_lsv and layer_idx == self.config.apply_lsv_at_layer_idx:

--- a/shared_param_utils.py
+++ b/shared_param_utils.py
@@ -17,6 +17,7 @@ _console = Console()
 from variations.attention_variations import attention_dictionary
 from variations.mlp_variations import get_mlp_instance
 from variations.moe_variations import MoELayer
+from variations.mole_variations import MoLELayer
 from variations.position_encoding_variations import FIRE
 
 class SharedParamGroupCreator:
@@ -233,10 +234,11 @@ class SharedParamGroupCreator:
 def _build_block(layer_type: str, layer_config, fire_pos_enc):
     """Factory wrapper so we don’t repeat the same if/else everywhere."""
     if layer_type == "mlp":
+        if getattr(layer_config, "use_mole", False) and layer_config.layer_idx % layer_config.mole_layer_freq == 0:
+            return MoLELayer(layer_config)
         if layer_config.use_moe and layer_config.layer_idx % layer_config.moe_layer_freq == 0:
             return MoELayer(layer_config)
-        else:
-            block = get_mlp_instance(layer_config)
+        block = get_mlp_instance(layer_config)
         # remember the hidden size for debugging tables
         try:
             block._debug_size = block.c_fc.out_features   # OriginalMLP

--- a/train_args.py
+++ b/train_args.py
@@ -361,6 +361,8 @@ def parse_args():
     model_group.add_argument('--gate', default=False, action=argparse.BooleanOptionalAction, help="option for gated attention see https://arxiv.org/abs/2306.12929")
     model_group.add_argument('--use_moe', default=False,  action=argparse.BooleanOptionalAction, help="option for Mixture of Experts (MoE) architecture")
     model_group.add_argument('--moe_layer_freq', default=2, type=int, help="set frequency for replacing FFNs with MoE layers")
+    model_group.add_argument('--use_mole', default=False,  action=argparse.BooleanOptionalAction, help="option for Mixture of Lookup Experts (MoLE) architecture")
+    model_group.add_argument('--mole_layer_freq', default=2, type=int, help="set frequency for replacing FFNs with MoLE layers")
     model_group.add_argument('--n_experts', default=8, type=int, help="set number of experts per MoE layer")
     model_group.add_argument('--moe_top_k', default=2, type=int)
     model_group.add_argument('--moe_router_scheme', default="softmax", type=str, help="option to set routing scheme for MoE layer, defaults to softmax")

--- a/variations/mole_variations.py
+++ b/variations/mole_variations.py
@@ -1,0 +1,72 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from variations.mlp_variations import get_mlp_instance
+from variations.router_variations import router_dictionary
+from variations.norm_variations import norm_dictionary
+
+class MoLELayer(nn.Module):
+    """Mixture of Lookup Experts layer.
+    During training this behaves similar to an MoE layer but the experts take
+    embedding tokens as input. At inference time the experts can be
+    reparameterized as lookup tables (LUTs) and `use_lut` can be enabled.
+    """
+
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.num_experts = config.n_experts
+
+        # Router used in both training and inference
+        self.router = nn.Linear(config.n_embd, self.num_experts, bias=False)
+
+        # Shared expert operates on hidden states like a standard MLP
+        self.shared_expert = get_mlp_instance(config)
+
+        # Routed experts. During inference their outputs are replaced by a LUT
+        self.routed_experts = nn.ModuleList([
+            get_mlp_instance(config) for _ in range(self.num_experts)
+        ])
+
+        self.expert_norm = norm_dictionary[config.norm_variant_attn](config)
+
+        self.use_lut = False
+        self.register_buffer("lut", None)
+
+        # flag so Block knows to pass embedding tokens and input ids
+        self.requires_embed_tokens = True
+
+    def build_lut(self, embedding_table):
+        """Pre-compute expert outputs for each vocabulary id."""
+        with torch.no_grad():
+            emb = self.expert_norm(embedding_table)
+            outputs = []
+            for expert in self.routed_experts:
+                out, _ = expert(emb)
+                outputs.append(out)
+            lut = torch.stack(outputs, dim=1)  # (V, num_experts, hidden)
+            self.lut = lut
+            self.use_lut = True
+
+    def forward(self, x, iter_num=None, mlp_res=None, embed_tokens=None, input_ids=None):
+        gate = F.softmax(self.router(x), dim=-1)
+        shared_out, mlp_res = self.shared_expert(x, iter_num, mlp_res)
+
+        if self.use_lut:
+            assert input_ids is not None and self.lut is not None
+            b, t = input_ids.shape
+            lut_vals = self.lut[input_ids.view(-1)]  # (b*t, num_experts, hidden)
+            lut_vals = lut_vals.view(b, t, self.num_experts, -1)
+            routed = torch.sum(lut_vals * gate.unsqueeze(-1), dim=2)
+            return shared_out + routed, mlp_res
+        else:
+            assert embed_tokens is not None
+            emb = self.expert_norm(embed_tokens)
+            expert_outs = []
+            for expert in self.routed_experts:
+                out, _ = expert(emb, iter_num)
+                expert_outs.append(out)
+            stacked = torch.stack(expert_outs, dim=2)  # (b,t,num_experts,hidden)
+            routed = torch.sum(stacked * gate.unsqueeze(-1), dim=2)
+            return shared_out + routed, mlp_res


### PR DESCRIPTION
## Summary
- add `MoLELayer` module implementing Mixture of Lookup Experts
- allow building MoLE layers through `SharedParamGroupCreator`
- enable `use_mole` and `mole_layer_freq` options in configuration and CLI
- modify model `Block` and forward pass to support MoLE layers

## Testing
- `python3 -m py_compile variations/mole_variations.py shared_param_utils.py gpt_conf.py train_args.py model.py`

------
https://chatgpt.com/codex/tasks/task_e_6882cc6265888326bc01060ab2a53556