### PR TITLE
Add RMSNormSingle normalization option

### DIFF
--- a/train_args.py
+++ b/train_args.py
@@ -434,6 +434,7 @@ def parse_args():
             "krmsnorm",
             "prmsnorm",
             "rmsnorm",
+            "rmsnorm_single",
             "layernorm",
             "hyperspherenorm",
             "dact",

--- a/variations/norm_variations.py
+++ b/variations/norm_variations.py
@@ -62,6 +62,17 @@ class RMSNorm(nn.Module):
         rms = x.norm(2, dim=-1, keepdim=True) / math.sqrt(x.size(-1))
         return x / rms * self.gain
 
+class RMSNormSingle(nn.Module):
+    """RMS Normalization with a single global gain parameter."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.gain = nn.Parameter(torch.ones(1))
+
+    def forward(self, x):
+        rms = x.norm(2, dim=-1, keepdim=True) / math.sqrt(x.size(-1))
+        return x / rms * self.gain
+
 class HyperSphereNorm(nn.Module):
     """Normalization to the surface of Hypersphere"""
 
@@ -206,6 +217,7 @@ class IdentityNorm(nn.Module):
 norm_dictionary = {
     "layernorm": LayerNorm,
     "rmsnorm": RMSNorm,
+    "rmsnorm_single": RMSNormSingle,
     "prmsnorm": pRMSNorm,
     "krmsnorm": kRMSNorm,
     "hyperspherenorm": HyperSphereNorm,


### PR DESCRIPTION
## Summary
- implement RMSNormSingle, a global gain RMS normalization layer
- expose new option via CLI and norm dictionary

## Testing
- `python -m compileall -q variations/norm_variations.py train_args.py gpt_conf.py`

------
https://chatgpt.com/codex/tasks/task_e_6882fff50a18832684e33dbb9254109b