### PR TITLE
Add RMSNormSingle and SimpleRMSNorm options

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -311,6 +311,8 @@ class GPTConfig:
     use_post_ln: bool = False
 
     # Layernorm Alternatives and Options
+    # available options defined in variations/norm_variations.py
+    # e.g. "layernorm", "rmsnorm", "rmsnorm_single", "simple_rmsnorm", etc.
     norm_variant_attn: str = "rmsnorm"
     norm_variant_output: str = "rmsnorm"
     bias: bool = False # True: bias in Linears and LayerNorms, like GPT-2. False: a bit better and faster

--- a/train_args.py
+++ b/train_args.py
@@ -434,6 +434,8 @@ def parse_args():
             "krmsnorm",
             "prmsnorm",
             "rmsnorm",
+            "rmsnorm_single",
+            "simple_rmsnorm",
             "layernorm",
             "hyperspherenorm",
             "dact",

--- a/variations/norm_variations.py
+++ b/variations/norm_variations.py
@@ -62,6 +62,27 @@ class RMSNorm(nn.Module):
         rms = x.norm(2, dim=-1, keepdim=True) / math.sqrt(x.size(-1))
         return x / rms * self.gain
 
+class RMSNormSingle(nn.Module):
+    """RMS Normalization with a single learned scale parameter."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.gain = nn.Parameter(torch.ones(1))
+
+    def forward(self, x):
+        rms = x.norm(2, dim=-1, keepdim=True) / math.sqrt(x.size(-1))
+        return x / rms * self.gain
+
+class SimpleRMSNorm(nn.Module):
+    """RMS Normalization without any learnable parameters."""
+
+    def __init__(self, config=None):
+        super().__init__()
+
+    def forward(self, x):
+        rms = x.norm(2, dim=-1, keepdim=True) / math.sqrt(x.size(-1))
+        return x / rms
+
 class HyperSphereNorm(nn.Module):
     """Normalization to the surface of Hypersphere"""
 
@@ -206,6 +227,8 @@ class IdentityNorm(nn.Module):
 norm_dictionary = {
     "layernorm": LayerNorm,
     "rmsnorm": RMSNorm,
+    "rmsnorm_single": RMSNormSingle,
+    "simple_rmsnorm": SimpleRMSNorm,
     "prmsnorm": pRMSNorm,
     "krmsnorm": kRMSNorm,
     "hyperspherenorm": HyperSphereNorm,


### PR DESCRIPTION
## Summary
- add RMSNormSingle and SimpleRMSNorm modules
- expose them via `norm_dictionary`
- allow new normalization variants through CLI
- document norm options in `gpt_conf.py`

## Testing
- `python -m py_compile variations/norm_variations.py train_args.py gpt_conf.py`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_6882fff50a18832684e33dbb9254109b