### PR TITLE
Add residual aggregation block option

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -21,6 +21,11 @@ class GPTConfig:
     n_v_head_dim_layerlist: List[int] = field(default_factory=list)
     mlp_size_layerlist: List[int] = field(default_factory=list)
 
+    # Aggregated residual options
+    use_aggregate_block: bool = False
+    residual_scale_layerlist: List[float] = field(default_factory=list)
+    learn_residual_scale_layerlist: bool = False
+
     # For multicontext training
     multicontext: bool = False
     vocab_sizes: List[int] = field(default_factory=lambda: []) # Used in place of vocab

--- a/train_args.py
+++ b/train_args.py
@@ -579,6 +579,14 @@ def parse_args():
     model_group.add_argument("--mlp_size_layerlist", nargs='+', action=LayerListAction, default=None, help="Override mlp_size per layer, cycling through the list. " "Example: --mlp_size_layerlist 100 200 300")
     model_group.add_argument("--n_v_head_dim_layerlist", nargs='+', action=LayerListAction, default=None)
 
+    # Residual aggregation options
+    model_group.add_argument('--use_aggregate_block', default=False, action=argparse.BooleanOptionalAction,
+                             help='Run an additional block over aggregated residuals before final norm')
+    model_group.add_argument('--residual_scale_layerlist', nargs='+', action=FlattenListAction, default=None,
+                             help='Scaling factors for each residual summed into aggregate block')
+    model_group.add_argument('--learn_residual_scale_layerlist', default=False, action=argparse.BooleanOptionalAction,
+                             help='Whether residual_scale_layerlist is learnable parameters')
+
     ## Infinite Attention variation
     model_group.add_argument('--n_qk_head_dim', default=None, type=int)
     model_group.add_argument('--n_v_head_dim', default=None, type=int)


### PR DESCRIPTION
## Summary
- make residual aggregation optional via `use_aggregate_block`
- add learnable `residual_scale_layerlist`
- expose new options in config and CLI

## Testing
- `python3 -m py_compile model.py gpt_conf.py train_args.py`

------
https://chatgpt.com/codex/tasks/task_e_6882fa0a3db0832681a1a88523172540