### PR TITLE
Add dataset benchmark utilities

### DIFF
--- a/benchmarks/dataset_quality.py
+++ b/benchmarks/dataset_quality.py
@@ -1,0 +1,40 @@
+import re
+import numpy as np
+from spellchecker import SpellChecker
+
+_spell = SpellChecker()
+
+
+def spelling_correctness(text: str) -> float:
+    """Return fraction of words spelled correctly using pyspellchecker."""
+    words = re.findall(r"[A-Za-z']+", text)
+    if not words:
+        return 0.0
+    misspelled = _spell.unknown([w.lower() for w in words])
+    return 1.0 - len(misspelled) / len(words)
+
+
+def type_token_ratio(text: str) -> float:
+    """Return vocabulary richness (unique words / total words)."""
+    words = re.findall(r"[A-Za-z']+", text.lower())
+    if not words:
+        return 0.0
+    return len(set(words)) / len(words)
+
+
+def average_sentence_length(text: str) -> float:
+    """Average number of words per sentence."""
+    sentences = re.split(r"[.!?]+", text)
+    lengths = [len(re.findall(r"[A-Za-z']+", s)) for s in sentences if s.strip()]
+    if not lengths:
+        return 0.0
+    return float(np.mean(lengths))
+
+
+def run_benchmarks(text: str) -> dict:
+    """Compute all dataset benchmarks for given text."""
+    return {
+        "spelling_correctness": spelling_correctness(text),
+        "type_token_ratio": type_token_ratio(text),
+        "average_sentence_length": average_sentence_length(text),
+    }

--- a/requirements_cpu.txt
+++ b/requirements_cpu.txt
@@ -23,3 +23,4 @@ sentencepiece==0.1.99
 spacy==3.7.2
 tqdm==4.66.4
 lm_eval==0.4.8
+pyspellchecker==0.7.1

--- a/requirements_gpu.txt
+++ b/requirements_gpu.txt
@@ -28,3 +28,4 @@ adabelief-pytorch
 adan-pytorch
 torch_optimizer
 tensorboard
+pyspellchecker==0.7.1

--- a/sample.py
+++ b/sample.py
@@ -413,6 +413,7 @@ def sample_with_existing_model(
     iter_num: Optional[int] = None,
     best_val_loss: Optional[float] = None,
     run_name: Optional[str] = None,
+    return_text: bool = False,
 ):
     """
     Generate text from an already-loaded GPT model.
@@ -446,6 +447,7 @@ def sample_with_existing_model(
 
     valid_modes = ["minmax", "softmax", "softmax_top_k", "dot_product", "rank"]
     modes_to_apply = valid_modes if colorize_mode == "all" else [colorize_mode]
+    generated_texts: List[str] = []
 
 
     for current_k in k_values:
@@ -687,6 +689,12 @@ def sample_with_existing_model(
                     best_val_loss,
                     f"{run_name}_{k_tag}" if run_name else k_tag,
                 )
+
+            if return_text:
+                generated_texts.append(plain_text)
+
+    if return_text:
+        return generated_texts
 
 
 def interactive_generation(model, start_ids, device, max_new_tokens, temperature, top_k, stop_string, decode, encode):

--- a/train.py
+++ b/train.py
@@ -46,6 +46,7 @@ from sample import (
     custom_char_with_byte_fallback_decode as ccwb_decode,
     get_tokenizer_functions,
 )
+from benchmarks.dataset_quality import run_benchmarks
 
 from rich.progress import (
         Progress,
@@ -478,7 +479,7 @@ class Trainer:
             start_ids = torch.tensor(self.encode(self.args.sample_start_tokens), dtype=torch.long, device=self.device)[None, ...]
 
             with torch.no_grad():
-                sample_with_existing_model(
+                texts = sample_with_existing_model(
                     model=self.model,
                     start_ids=start_ids,
                     start_tokens=self.args.sample_start_tokens,
@@ -498,7 +499,13 @@ class Trainer:
                     best_val_loss=self.best_val_loss,
                     run_name=self.args.tensorboard_run_name,
                     args=self.args,
+                    return_text=True,
                 )
+
+            if self.args.run_dataset_benchmarks:
+                for idx, t in enumerate(texts):
+                    results = run_benchmarks(t)
+                    print(f"Benchmark sample {idx}: {results}")
 
         self.model.train()
 

--- a/train_args.py
+++ b/train_args.py
@@ -59,6 +59,7 @@ def parse_args():
     training_group.add_argument('--sample_each_eval', default=False, action=argparse.BooleanOptionalAction, help="Produce sample even if the validation loss did not improve. Allows for testing what overtraining looks like.")
     training_group.add_argument('--sample_start_tokens', default='\n', type=str)
     training_group.add_argument('--sample_only', default=False, action=argparse.BooleanOptionalAction, help="Run only the sampling process and exit")
+    training_group.add_argument('--run_dataset_benchmarks', default=False, action=argparse.BooleanOptionalAction, help='Run simple dataset benchmark metrics on generated samples')
 
     # Checkpoint args
     training_group.add_argument('--save_major_ckpt_interval', default=None, type=int, help="Interval for saving major checkpoints.")


### PR DESCRIPTION
## Summary
- implement simple dataset benchmark module
- integrate dataset benchmarks into training pipeline
- add option `--run_dataset_benchmarks`
- allow `sample_with_existing_model` to return generated text
- require `pyspellchecker`

## Testing
- `pip install pyspellchecker==0.7.1`
- `python -m pytest -q` *(fails: ModuleNotFoundError: mecab)*

------
https://chatgpt.com/codex/tasks/task_e_6882ec58b9ec8326ad5476eadd8bed07