### PR TITLE
Add per-type kurtosis stats to metrics

### DIFF
--- a/train.py
+++ b/train.py
@@ -116,6 +116,9 @@ class Trainer:
             'min': 0.0,
             'abs_max': 0.0,
         }
+        # grouped stats by tensor type for latest evaluation
+        self.latest_weight_type_stats = {}
+        self.latest_activation_type_stats = {}
 
         # whether to show all model stats
         self.compute_model_stats = self.args.compute_model_stats
@@ -892,15 +895,17 @@ class Trainer:
         if self.compute_model_stats:
             X_stat, Y_stat, _ = self.get_batch('val')
             # ── Run heavy ops on the selected device (GPU keeps host‑RAM flat) ──
-            act_stats,  overall_act  = compute_activation_stats(
+            act_stats, overall_act, act_type_stats = compute_activation_stats(
                 self.model, X_stat, Y_stat, self.iter_num, device=self.stats_device
             )
-            weight_stats, overall_wt = compute_weight_stats(
+            weight_stats, overall_wt, weight_type_stats = compute_weight_stats(
                 self.model, device=self.stats_device
             )
 
             self.latest_overall_weight_stats     = overall_wt
             self.latest_overall_activation_stats = overall_act
+            self.latest_weight_type_stats = weight_type_stats
+            self.latest_activation_type_stats = act_type_stats
 
             print("Weight Statistics per tensor:")
             for name, s in weight_stats.items():
@@ -914,9 +919,23 @@ class Trainer:
                     f"{name}: stdev {s['stdev']:.6f}, kurtosis {s['kurtosis']:.6f}, "
                     f"max {s['max']:.6f}, min {s['min']:.6f}, abs_max {s['abs_max']:.6f}"
                 )
+            print("Weight Kurtosis by type:")
+            for tname, s in weight_type_stats.items():
+                print(
+                    f"{tname}: mean_kurtosis {s['kurtosis_mean']:.6f}, max_kurtosis {s['kurtosis_max']:.6f}"
+                )
+            print("Activation Kurtosis by type:")
+            for tname, s in act_type_stats.items():
+                print(
+                    f"{tname}: mean_kurtosis {s['kurtosis_mean']:.6f}, max_kurtosis {s['kurtosis_max']:.6f}"
+                )
         else:
-            act_stats  = {}   # keep API intact
+            act_stats = {}   # keep API intact
             weight_stats = {}
+            weight_type_stats = {}
+            act_type_stats = {}
+            self.latest_weight_type_stats = {}
+            self.latest_activation_type_stats = {}
 
         if self.args.tensorboard_log and self.compute_model_stats:
             self.writer.add_scalars(
@@ -1381,26 +1400,29 @@ class Trainer:
                             # Save best validation loss
                             peak_mb = self.peak_gpu_usage / (1024 ** 2)
                             with open(os.path.join(self.args.out_dir, 'best_val_loss_and_iter.txt'), "w") as best_loss_file:
-                                chance_ratio = self.model_args['vocab_size']/math.exp(self.best_val_loss.item())
-                                best_loss_file.write(
-                                    f"{self.best_val_loss.item()},"
-                                    f" {self.iter_num},"
-                                    f" {self.model.num_param},"
-                                    f" {chance_ratio:.3e},"
-                                    f" {chance_ratio/self.model.num_param:.3e},"
-                                    f" {peak_mb:.1f},"
-                                    f" {self.iter_latency_avg:.1f},"
-                                    f" {self.latest_overall_weight_stats['stdev']:.6f},"
-                                    f" {self.latest_overall_weight_stats['kurtosis']:.6f},"
-                                    f" {self.latest_overall_weight_stats['max']:.6f},"
-                                    f" {self.latest_overall_weight_stats['min']:.6f},"
-                                    f" {self.latest_overall_weight_stats['abs_max']:.6f},"
-                                    f" {self.latest_overall_activation_stats['stdev']:.6f},"
-                                    f" {self.latest_overall_activation_stats['kurtosis']:.6f},"
-                                    f" {self.latest_overall_activation_stats['max']:.6f},"
-                                    f" {self.latest_overall_activation_stats['min']:.6f},"
-                                    f" {self.latest_overall_activation_stats['abs_max']:.6f},"
-                                )
+                                chance_ratio = self.model_args['vocab_size'] / math.exp(self.best_val_loss.item())
+                                metrics = {
+                                    "best_val_loss": self.best_val_loss.item(),
+                                    "best_val_iter": self.iter_num,
+                                    "num_params": self.model.num_param,
+                                    "better_than_chance": chance_ratio,
+                                    "btc_per_param": chance_ratio / self.model.num_param,
+                                    "peak_gpu_mb": peak_mb,
+                                    "iter_latency_avg": self.iter_latency_avg,
+                                    "weight_stdev": self.latest_overall_weight_stats['stdev'],
+                                    "weight_kurtosis": self.latest_overall_weight_stats['kurtosis'],
+                                    "weight_max": self.latest_overall_weight_stats['max'],
+                                    "weight_min": self.latest_overall_weight_stats['min'],
+                                    "weight_abs_max": self.latest_overall_weight_stats['abs_max'],
+                                    "activation_stdev": self.latest_overall_activation_stats['stdev'],
+                                    "activation_kurtosis": self.latest_overall_activation_stats['kurtosis'],
+                                    "activation_max": self.latest_overall_activation_stats['max'],
+                                    "activation_min": self.latest_overall_activation_stats['min'],
+                                    "activation_abs_max": self.latest_overall_activation_stats['abs_max'],
+                                    "weight_type_stats": self.latest_weight_type_stats,
+                                    "activation_type_stats": self.latest_activation_type_stats,
+                                }
+                                json.dump(metrics, best_loss_file)
                             # Reset early exit counter
                             num_steps_with_worse_loss = 0
                         if self.iter_num > 0:

--- a/utils/model_stats.py
+++ b/utils/model_stats.py
@@ -1,7 +1,9 @@
 # utils/model_stats.py
 import torch
 from torch import Tensor
-from typing import Dict, Tuple
+from typing import Dict, Tuple, List, DefaultDict
+from collections import defaultdict
+import re
 
 def _moments(t: Tensor) -> Dict[str, float]:
     """
@@ -30,42 +32,71 @@ def _moments(t: Tensor) -> Dict[str, float]:
         abs_max  = abs_max.item(),
     )
 
+
+def _extract_type(name: str) -> str:
+    """Return a simplified tensor type name used for grouping."""
+    name = re.sub(r"^_orig_mod\.", "", name)
+    name = re.sub(r"^module\.", "", name)
+    if name.startswith("transformer."):
+        name = name[len("transformer."):]
+    name = re.sub(r"h\.[0-9]+\.", "", name)
+    name = re.sub(r"\.(weight|bias)$", "", name)
+    return name
+
 @torch.no_grad()
-def compute_weight_stats(model: torch.nn.Module, device: torch.device) -> Tuple[Dict[str, Dict], Dict[str, float]]:
+def compute_weight_stats(
+    model: torch.nn.Module, device: torch.device
+) -> Tuple[Dict[str, Dict], Dict[str, float], Dict[str, Dict[str, float]]]:
+    """Return per-tensor metrics, overall averages, and per-type kurtosis stats."""
     per_tensor: Dict[str, Dict] = {}
-    accum      = {k:0.0 for k in ["stdev","kurtosis","max","min","abs_max"]}
-    n          = 0
+    accum: Dict[str, float] = {k: 0.0 for k in ["stdev", "kurtosis", "max", "min", "abs_max"]}
+    n = 0
+
+    type_groups: DefaultDict[str, List[float]] = defaultdict(list)
 
     for name, p in model.named_parameters():
-        if p.requires_grad:                       # skip buffers etc.
-            t = p.detach().to(device)             # stays on GPU if asked
+        if p.requires_grad:
+            t = p.detach().to(device)
             s = _moments(t)
             per_tensor[name] = s
-            for k in accum:                       # running mean over tensors
+            tp = _extract_type(name)
+            type_groups[tp].append(s["kurtosis"])
+            for k in accum:
                 accum[k] += s[k]
             n += 1
 
-    overall = {k: v/n for k,v in accum.items()}
-    return per_tensor, overall
+    overall = {k: v / n for k, v in accum.items()}
+
+    type_stats = {
+        tp: {
+            "kurtosis_mean": float(sum(vals) / len(vals)),
+            "kurtosis_max": float(max(vals)),
+        }
+        for tp, vals in type_groups.items()
+    }
+
+    return per_tensor, overall, type_stats
 
 @torch.no_grad()
 def compute_activation_stats(
-    model:      torch.nn.Module,
-    x:          Tensor,
-    y:          Tensor,
-    iter_num:   int,
-    device:     torch.device = torch.device("cpu"),
-) -> Tuple[Dict[str, Dict], Dict[str, float]]:
+    model: torch.nn.Module,
+    x: Tensor,
+    y: Tensor,
+    iter_num: int,
+    device: torch.device = torch.device("cpu"),
+) -> Tuple[Dict[str, Dict], Dict[str, float], Dict[str, Dict[str, float]]]:
     """
-    One‑off activation scan used inside `Trainer.estimate_loss`.
-    Performs a *single* forward pass with temporary hooks that:  
-      • run on the requested `device` (GPU keeps host RAM flat)  
-      • compute moments on‑the‑fly and immediately discard the tensor  
-    Returns a dict keyed by module‑path and an overall average.
+    One‑off activation scan used inside ``Trainer.estimate_loss``.
+    Performs a *single* forward pass with temporary hooks that:
+      • run on the requested ``device`` (GPU keeps host RAM flat)
+      • compute moments on‑the‑fly and immediately discard the tensor
+    Returns per-tensor metrics, overall averages, and statistics grouped by
+    tensor type (mean and maximum kurtosis).
     """
     act_stats: Dict[str, Dict] = {}
-    overall   = {k: 0.0 for k in ["stdev", "kurtosis", "max", "min", "abs_max"]}
-    n         = 0
+    overall: Dict[str, float] = {k: 0.0 for k in ["stdev", "kurtosis", "max", "min", "abs_max"]}
+    n = 0
+    type_groups: DefaultDict[str, List[float]] = defaultdict(list)
 
     def make_hook(mod_name: str):
         def _hook(_module, _inp, out):
@@ -76,6 +107,8 @@ def compute_activation_stats(
                 return                          # skip non‑tensor outputs
             s = _moments(t.detach().to(device))
             act_stats[mod_name] = s
+            tp = _extract_type(mod_name)
+            type_groups[tp].append(s["kurtosis"])
             for k in overall:
                 overall[k] += s[k]
             n += 1
@@ -101,4 +134,13 @@ def compute_activation_stats(
         return {}, {k: 0.0 for k in overall}
 
     overall = {k: v / n for k, v in overall.items()}
-    return act_stats, overall
+
+    type_stats = {
+        tp: {
+            "kurtosis_mean": float(sum(vals) / len(vals)),
+            "kurtosis_max": float(max(vals)),
+        }
+        for tp, vals in type_groups.items()
+    }
+
+    return act_stats, overall, type_stats


### PR DESCRIPTION
## Summary
- extend metrics log with activation/weight type statistics
- parse new JSON metrics format in `run_experiments`
- display optional type-stat columns in exploration monitor
- store latest type stats when saving best loss
- show each type's mean & max kurtosis in monitor
- abbreviate per-type columns for compact display

## Testing
- `bash tests/test_run_experiments.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883b3e8e7e88326a8dcb3b7a1afb453