### PR TITLE
Add sequence length scaled softmax

### DIFF
--- a/model.py
+++ b/model.py
@@ -922,7 +922,10 @@ class GPT(nn.Module):
             if top_k is not None:
                 v, _ = torch.topk(logits, min(top_k, logits.size(-1)))
                 logits[logits < v[:, [-1]]] = -float('Inf')
-            probs = F.softmax(logits, dim=-1)
+            if self.config.softmax_variant_output != 'softmax':
+                probs = self.softmax_layer_output(logits)
+            else:
+                probs = F.softmax(logits, dim=-1)
             idx_next = torch.multinomial(probs, num_samples=1)
             idx = torch.cat((idx, idx_next), dim=1)
 

--- a/tests/test_all_softmax_variations_cpu.sh
+++ b/tests/test_all_softmax_variations_cpu.sh
@@ -15,6 +15,7 @@ softmax_variation=( \
   "sigsoftmax" \
   "exppolymax" \
   "saturatingconsmax" \
+  "seq_len_scaled_softmax" \
   "strongermax")
 
 n_layer="2"

--- a/train_args.py
+++ b/train_args.py
@@ -771,6 +771,7 @@ def parse_args():
         "softmax",
         "softplus",
         "squareplus",
+        "seq_len_scaled_softmax",
         "exppolymax",
         "pfla_softmax",
         ]


### PR DESCRIPTION
## Summary
- add SeqLenScaledSoftmax variation to scale each row by its causal sequence length
- register the variant for CLI usage and tests
- support custom output softmax during generation with stop sequences

## Testing
- `python -m py_compile variations/softmax_variations.py model.py train_args.py`
- `bash tests/test_all_softmax_variations_cpu.sh` *(fails: dataset and scripts missing)*

------
https://chatgpt.com/codex/tasks/task_e_687c081e59b48326a97b0a6b8dc5d17f