### PR TITLE
Improve compute_model_stats table

### DIFF
--- a/train.py
+++ b/train.py
@@ -38,7 +38,11 @@ from utils.statistic_plots import (
     create_statistics,
 )
 
-from utils.model_stats import compute_weight_stats, compute_activation_stats
+from utils.model_stats import (
+    compute_weight_stats,
+    compute_activation_stats,
+    print_model_stats_table,
+)
 
 from sample import (
     sample_with_existing_model,
@@ -902,18 +906,7 @@ class Trainer:
             self.latest_overall_weight_stats     = overall_wt
             self.latest_overall_activation_stats = overall_act
 
-            print("Weight Statistics per tensor:")
-            for name, s in weight_stats.items():
-                print(
-                    f"{name}: stdev {s['stdev']:.6f}, kurtosis {s['kurtosis']:.6f}, "
-                    f"max {s['max']:.6f}, min {s['min']:.6f}, abs_max {s['abs_max']:.6f}"
-                )
-            print("Activation Statistics per tensor:")
-            for name, s in act_stats.items():
-                print(
-                    f"{name}: stdev {s['stdev']:.6f}, kurtosis {s['kurtosis']:.6f}, "
-                    f"max {s['max']:.6f}, min {s['min']:.6f}, abs_max {s['abs_max']:.6f}"
-                )
+            print_model_stats_table(weight_stats, act_stats)
         else:
             act_stats  = {}   # keep API intact
             weight_stats = {}

--- a/utils/model_stats.py
+++ b/utils/model_stats.py
@@ -164,8 +164,17 @@ def print_model_stats_table(weight_stats: Dict[str, Dict], act_stats: Dict[str, 
                 # largest value should be green, smallest most red
                 t = (hi - val) / (hi - lo)
             elif key == "kurtosis":
-                # negative -> green, positive -> red
-                t = (val - lo) / (hi - lo)
+                # negative -> green, positive -> red. Use log scaling for
+                # smoother gradation over wide ranges.
+                abs_max = max(abs(lo), abs(hi))
+                if abs_max == 0:
+                    t = 0.5
+                else:
+                    norm = math.log(1 + abs(val)) / math.log(1 + abs_max)
+                    if val >= 0:
+                        t = 0.5 + 0.5 * norm
+                    else:
+                        t = 0.5 - 0.5 * norm
             else:
                 base = abs(val)
                 t = (base - lo) / (hi - lo)


### PR DESCRIPTION
## Summary
- present weight and activation statistics together
- colorize values with Rich table

## Testing
- `python -m py_compile utils/model_stats.py train.py`

------
https://chatgpt.com/codex/tasks/task_e_6885029bde3c83268d9c0bb50c65b442