### PR TITLE
Improve compute_model_stats table

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Hardware Related
   * [Start Exploration](#start-exploration)
   * [Inspect and Monitor Best Val Losses](#inspect-and-monitor-best-val-losses)
   * [Start Tensorboard Logging](#start-tensorboard-logging)
+  * [Model Stats Table](#model-stats-table)
   * [Troubleshooting](#troubleshooting)
   * [Creating New Features and Exploration Scripts](#creating-new-features-and-exploration-scripts)
 * [Contributing](#contributing)
@@ -205,6 +206,21 @@ run a second tensorboard, use the script and specify a different port e.g. 6007:
 ```bash
 source ./logging/start_tensorboard.sh 6007
 ```
+
+## Model Stats Table
+
+The training script can output a per‑tensor statistics table to a CSV file with
+``--print_model_stats_table``. A helper script then visualizes the table or
+compares two runs with colour‑coded deltas.
+
+```bash
+python3 train.py --print_model_stats_table run1_stats.csv
+python3 train.py --optimizer adamw --print_model_stats_table run2_stats.csv
+python3 view_model_stats.py run1_stats.csv run2_stats.csv
+```
+
+See [documentation/Model_Stats_Table.md](documentation/Model_Stats_Table.md)
+for more details.
 
 ## TODO Section:
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -16,3 +16,8 @@ Example for calling from repo root directory:
 python3 demos/check_ckpt_for_gelu_shift.py \
         --ckpt_path out/ckpt.pt
 ```
+
+## Optimizer Comparison
+
+`adam_vs_adamw.sh` trains two tiny Shakespeare models, one with Adam and one
+with AdamW, then compares their statistics using `view_model_stats.py`.

--- a/demos/adam_vs_adamw.sh
+++ b/demos/adam_vs_adamw.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# adam_vs_adamw.sh
+# Demonstration comparing Adam and AdamW optimizers on the shakespeare_char dataset.
+
+set -e
+
+pushd data/shakespeare_char
+bash get_dataset.sh
+popd
+
+# Train a small model with Adam
+python3 train.py \
+  --dataset shakespeare_char \
+  --optimizer adam \
+  --out_dir out_adam_demo \
+  --max_iters 500 \
+  --block_size 128 \
+  --learning_rate 3e-4 \
+  --compile \
+  --print_model_stats_table adam_stats.csv
+
+# Train a similar model with AdamW
+python3 train.py \
+  --dataset shakespeare_char \
+  --optimizer adamw \
+  --out_dir out_adamw_demo \
+  --max_iters 500 \
+  --block_size 128 \
+  --learning_rate 3e-4 \
+  --compile \
+  --print_model_stats_table adamw_stats.csv
+
+# Display the coloured delta between the two runs
+python3 view_model_stats.py adam_stats.csv adamw_stats.csv

--- a/documentation/Model_Stats_Table.md
+++ b/documentation/Model_Stats_Table.md
@@ -1,0 +1,36 @@
+# Model Stats Table
+
+The training script can report statistics for every tensor in the model.
+Values include standard deviation, kurtosis, maximum, minimum and absolute
+maximum for both weights and activations.
+
+## Saving Statistics During Training
+
+Add the `--print_model_stats_table <CSV_PATH>` argument when running
+`train.py`. At each statistics evaluation step a table is printed and the raw
+numbers are written to the specified CSV file.
+
+```bash
+python3 train.py --print_model_stats_table my_stats.csv
+```
+
+## Viewing Tables and Comparing Runs
+
+Use `view_model_stats.py` to render a CSV as a colourised table or to compare
+two CSV files. Deltas and percentages are shown with green for improvements and
+red for regressions.
+
+```bash
+# Display a single table
+python3 view_model_stats.py my_stats.csv
+
+# Compare two tables and focus on stdev and abs_max columns
+python3 view_model_stats.py run1.csv run2.csv --stats stdev,abs_max
+```
+
+Colour scales are computed per column. NaN values are highlighted in orange.
+For kurtosis the gradient uses a logarithmic scale so that wide ranges remain
+readable.
+
+See the demo script [demos/adam_vs_adamw.sh](../demos/adam_vs_adamw.sh) for a
+complete example that trains two models and compares their statistics.

--- a/train.py
+++ b/train.py
@@ -38,7 +38,11 @@ from utils.statistic_plots import (
     create_statistics,
 )
 
-from utils.model_stats import compute_weight_stats, compute_activation_stats
+from utils.model_stats import (
+    compute_weight_stats,
+    compute_activation_stats,
+    print_model_stats_table,
+)
 
 from sample import (
     sample_with_existing_model,
@@ -124,6 +128,8 @@ class Trainer:
         # The CLI flag is optional; fall back to CPU if it isn’t present.
         stats_dev_flag  = getattr(self.args, "model_stats_device", "cpu")
         self.stats_device = torch.device("cuda") if stats_dev_flag == "gpu" else torch.device("cpu")
+
+        self.stats_csv_path = getattr(self.args, "print_model_stats_table", None)
 
         # calculation on end time via eval cycle
         self.eval_cycle_window = deque(maxlen=self.args.eval_cycle_window)
@@ -902,18 +908,7 @@ class Trainer:
             self.latest_overall_weight_stats     = overall_wt
             self.latest_overall_activation_stats = overall_act
 
-            print("Weight Statistics per tensor:")
-            for name, s in weight_stats.items():
-                print(
-                    f"{name}: stdev {s['stdev']:.6f}, kurtosis {s['kurtosis']:.6f}, "
-                    f"max {s['max']:.6f}, min {s['min']:.6f}, abs_max {s['abs_max']:.6f}"
-                )
-            print("Activation Statistics per tensor:")
-            for name, s in act_stats.items():
-                print(
-                    f"{name}: stdev {s['stdev']:.6f}, kurtosis {s['kurtosis']:.6f}, "
-                    f"max {s['max']:.6f}, min {s['min']:.6f}, abs_max {s['abs_max']:.6f}"
-                )
+            print_model_stats_table(weight_stats, act_stats, csv_path=self.stats_csv_path)
         else:
             act_stats  = {}   # keep API intact
             weight_stats = {}

--- a/train_args.py
+++ b/train_args.py
@@ -1003,6 +1003,14 @@ def parse_args():
             "'gpu' avoids host‑RAM spikes; 'cpu' saves VRAM."
             )
 
+    training_group.add_argument(
+            '--print_model_stats_table',
+            type=str,
+            default=None,
+            metavar='CSV_PATH',
+            help='If set, also save the printed model statistics table to this CSV file.'
+            )
+
     ## Export Model graph
     logging_group.add_argument('--export_model_graph', default=False, action=argparse.BooleanOptionalAction, help="exports tensorboard model of graph")
 

--- a/utils/model_stats.py
+++ b/utils/model_stats.py
@@ -1,7 +1,18 @@
 # utils/model_stats.py
 import torch
 from torch import Tensor
-from typing import Dict, Tuple
+from typing import Dict, Tuple, List, Optional
+from rich.table import Table
+from rich.console import Console
+import math
+import csv
+
+_console = Console()
+
+
+def _valid_float(val: Optional[float]) -> bool:
+    """Return True if ``val`` is a finite float."""
+    return isinstance(val, float) and math.isfinite(val)
 
 def _moments(t: Tensor) -> Dict[str, float]:
     """
@@ -33,8 +44,9 @@ def _moments(t: Tensor) -> Dict[str, float]:
 @torch.no_grad()
 def compute_weight_stats(model: torch.nn.Module, device: torch.device) -> Tuple[Dict[str, Dict], Dict[str, float]]:
     per_tensor: Dict[str, Dict] = {}
-    accum      = {k:0.0 for k in ["stdev","kurtosis","max","min","abs_max"]}
-    n          = 0
+    keys = ["stdev", "kurtosis", "max", "min", "abs_max"]
+    accum  = {k: 0.0 for k in keys}
+    counts = {k: 0 for k in keys}
 
     for name, p in model.named_parameters():
         if p.requires_grad:                       # skip buffers etc.
@@ -42,10 +54,13 @@ def compute_weight_stats(model: torch.nn.Module, device: torch.device) -> Tuple[
             s = _moments(t)
             per_tensor[name] = s
             for k in accum:                       # running mean over tensors
-                accum[k] += s[k]
-            n += 1
+                val = s[k]
+                if not _valid_float(val):
+                    continue
+                accum[k] += val
+                counts[k] += 1
 
-    overall = {k: v/n for k,v in accum.items()}
+    overall = {k: (accum[k] / counts[k]) if counts[k] > 0 else float("nan") for k in accum}
     return per_tensor, overall
 
 @torch.no_grad()
@@ -64,21 +79,24 @@ def compute_activation_stats(
     Returns a dict keyed by module‑path and an overall average.
     """
     act_stats: Dict[str, Dict] = {}
-    overall   = {k: 0.0 for k in ["stdev", "kurtosis", "max", "min", "abs_max"]}
-    n         = 0
+    keys = ["stdev", "kurtosis", "max", "min", "abs_max"]
+    sums   = {k: 0.0 for k in keys}
+    counts = {k: 0 for k in keys}
 
     def make_hook(mod_name: str):
         def _hook(_module, _inp, out):
-            nonlocal n
             # Work with first tensor output if module returns tuple
             t = out[0] if isinstance(out, (tuple, list)) else out
             if not torch.is_tensor(t):
                 return                          # skip non‑tensor outputs
             s = _moments(t.detach().to(device))
             act_stats[mod_name] = s
-            for k in overall:
-                overall[k] += s[k]
-            n += 1
+            for k in sums:
+                val = s[k]
+                if not _valid_float(val):
+                    continue
+                sums[k] += val
+                counts[k] += 1
             # free ASAP
             del t
         return _hook
@@ -96,9 +114,140 @@ def compute_activation_stats(
     for h in handles:
         h.remove()
 
-    # Guard against empty hook collection
-    if n == 0:
-        return {}, {k: 0.0 for k in overall}
+    # Guard against empty hook collection or no valid stats
+    if all(c == 0 for c in counts.values()):
+        return act_stats, {k: float("nan") for k in sums}
 
-    overall = {k: v / n for k, v in overall.items()}
+    overall = {k: (sums[k] / counts[k]) if counts[k] > 0 else float("nan") for k in sums}
     return act_stats, overall
+
+
+def model_stats_rows(weight_stats: Dict[str, Dict], act_stats: Dict[str, Dict]) -> Tuple[List[str], List[List[float]]]:
+    """Return headers and raw rows for the stats table."""
+    stat_keys = ["stdev", "kurtosis", "max", "min", "abs_max"]
+    headers = ["tensor"] + [f"W {k}" for k in stat_keys] + [f"A {k}" for k in stat_keys]
+    rows: List[List[float]] = []
+    printed = set()
+    for w_name, ws in weight_stats.items():
+        module = w_name.rsplit(".", 1)[0]
+        as_ = act_stats.get(module)
+        row = [w_name]
+        for key in stat_keys:
+            row.append(ws.get(key, float("nan")))
+        for key in stat_keys:
+            row.append(as_.get(key, float("nan")) if as_ else float("nan"))
+        rows.append(row)
+        printed.add(module)
+
+    for mod, as_ in act_stats.items():
+        if mod in printed:
+            continue
+        row = [mod]
+        row.extend([float("nan")] * len(stat_keys))
+        for key in stat_keys:
+            row.append(as_.get(key, float("nan")))
+        rows.append(row)
+
+    return headers, rows
+
+
+def write_model_stats_csv(weight_stats: Dict[str, Dict], act_stats: Dict[str, Dict], path: str) -> None:
+    """Save stats table to *path* as CSV."""
+    headers, rows = model_stats_rows(weight_stats, act_stats)
+    with open(path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(headers)
+        for row in rows:
+            writer.writerow(row)
+
+
+def print_model_stats_table(
+    weight_stats: Dict[str, Dict],
+    act_stats: Dict[str, Dict],
+    csv_path: Optional[str] = None,
+) -> None:
+    """Pretty print weight and activation stats side by side using rich.Table.
+
+    If *csv_path* is provided, also save the raw values to that CSV file.
+    """
+    stat_keys = ["stdev", "kurtosis", "max", "min", "abs_max"]
+
+    # --- compute extremes for colouring ---
+    def collect_extremes(stats: Dict[str, Dict]) -> Dict[str, Tuple[float, float]]:
+        ext: Dict[str, Tuple[float, float]] = {}
+        for key in stat_keys:
+            vals: List[float] = []
+            for d in stats.values():
+                v = d.get(key)
+                if not _valid_float(v):
+                    continue
+                if key in {"stdev", "max", "abs_max"}:
+                    vals.append(abs(v))
+                else:
+                    vals.append(v)
+            if not vals:
+                ext[key] = (0.0, 0.0)
+            else:
+                ext[key] = (min(vals), max(vals))
+        return ext
+
+    w_extremes = collect_extremes(weight_stats)
+    a_extremes = collect_extremes(act_stats)
+
+    # --- helper for colouring values
+    def colour(val: Optional[float], key: str, col_ext: Dict[str, Tuple[float, float]]) -> str:
+        if not _valid_float(val):
+            return "[orange3]nan[/]"
+
+        lo, hi = col_ext[key]
+
+        if hi == lo:
+            t = 0.5
+        else:
+            if key == "min":
+                # largest value should be green, smallest most red
+                t = (hi - val) / (hi - lo)
+            elif key == "kurtosis":
+                # negative -> green, positive -> red. Use log scaling for
+                # smoother gradation over wide ranges.
+                abs_max = max(abs(lo), abs(hi))
+                if abs_max == 0:
+                    t = 0.5
+                else:
+                    norm = math.log(1 + abs(val)) / math.log(1 + abs_max)
+                    if val >= 0:
+                        t = 0.5 + 0.5 * norm
+                    else:
+                        t = 0.5 - 0.5 * norm
+            else:
+                base = abs(val)
+                t = (base - lo) / (hi - lo)
+
+            t = max(0.0, min(1.0, t))
+
+        r = int(255 * t)
+        g = int(255 * (1 - t))
+        color = f"#{r:02x}{g:02x}00"
+        return f"[{color}]{val:.6f}[/]"
+
+    headers, raw_rows = model_stats_rows(weight_stats, act_stats)
+
+    if csv_path:
+        write_model_stats_csv(weight_stats, act_stats, csv_path)
+
+    table = Table(title="Model Statistics", header_style="bold magenta")
+    for head in headers:
+        table.add_column(head, justify="right" if head != "tensor" else "left", no_wrap=head=="tensor")
+
+    for raw in raw_rows:
+        row: List[str] = [str(raw[0])]
+        for key_idx, key in enumerate(stat_keys, start=1):
+            row.append(colour(raw[key_idx], key, w_extremes))
+        offset = 1 + len(stat_keys)
+        for key_idx, key in enumerate(stat_keys, start=offset):
+            row.append(colour(raw[key_idx], key, a_extremes))
+        table.add_row(*row)
+
+    _console.print(table)
+
+

--- a/view_model_stats.py
+++ b/view_model_stats.py
@@ -7,7 +7,7 @@ import argparse
 import csv
 import math
 from pathlib import Path
-from typing import Dict, Tuple, List
+from typing import Dict, Tuple, List, Iterable
 
 from rich.console import Console
 from rich.table import Table
@@ -25,8 +25,9 @@ def _f(val: str) -> float:
         return float("nan")
 
 
-def load_csv(path: Path) -> Tuple[Dict[str, Dict], Dict[str, Dict]]:
-    """Return weight and activation stats from *path*."""
+def load_csv(path: Path) -> Tuple[List[str], Dict[str, Dict], Dict[str, Dict]]:
+    """Return row order, weight stats, and activation stats from *path*."""
+    row_order: List[str] = []
     w_stats: Dict[str, Dict] = {}
     a_stats: Dict[str, Dict] = {}
     with path.open() as f:
@@ -34,6 +35,7 @@ def load_csv(path: Path) -> Tuple[Dict[str, Dict], Dict[str, Dict]]:
         _ = next(reader, None)  # header
         for row in reader:
             name = row[0]
+            row_order.append(name)
             w_vals = [_f(v) for v in row[1 : 1 + len(STAT_KEYS)]]
             a_vals = [_f(v) for v in row[1 + len(STAT_KEYS) :]]
 
@@ -44,23 +46,21 @@ def load_csv(path: Path) -> Tuple[Dict[str, Dict], Dict[str, Dict]]:
 
             if any(math.isfinite(v) for v in a_vals):
                 a_stats[module] = {k: v for k, v in zip(STAT_KEYS, a_vals)}
-    return w_stats, a_stats
+    return row_order, w_stats, a_stats
 
 
-def _collect_extremes(diff_w: Dict[str, Dict], diff_a: Dict[str, Dict]) -> Dict[str, Tuple[float, float]]:
+def _collect_extremes(stats: Dict[str, Dict], keys: Iterable[str]) -> Dict[str, Tuple[float, float]]:
+    """Return min/max extremes for each *key* over ``stats``."""
     ext: Dict[str, Tuple[float, float]] = {}
-    for key in STAT_KEYS:
+    for key in keys:
         vals: List[float] = []
-        for d in list(diff_w.values()) + list(diff_a.values()):
+        for d in stats.values():
             v = d.get(key)
             if not isinstance(v, float) or not math.isfinite(v):
                 continue
             trans = -v if key != "min" else v
             vals.append(trans)
-        if vals:
-            ext[key] = (min(vals), max(vals))
-        else:
-            ext[key] = (0.0, 0.0)
+        ext[key] = (min(vals), max(vals)) if vals else (0.0, 0.0)
     return ext
 
 
@@ -79,52 +79,96 @@ def _colour_delta(val: float, key: str, lo: float, hi: float) -> str:
     return f"[{color}]{val:.6f}[/]"
 
 
-def print_delta(w1: Dict[str, Dict], a1: Dict[str, Dict], w2: Dict[str, Dict], a2: Dict[str, Dict]) -> None:
+def print_delta(
+    row_order: List[str],
+    w1: Dict[str, Dict],
+    a1: Dict[str, Dict],
+    w2: Dict[str, Dict],
+    a2: Dict[str, Dict],
+    stats: Iterable[str],
+) -> None:
+    """Display differences between two model stats tables."""
+
+    # compute diffs
     diff_w: Dict[str, Dict] = {}
     diff_a: Dict[str, Dict] = {}
 
     for name in set(w1) | set(w2):
         diff_w[name] = {}
-        for k in STAT_KEYS:
+        for k in stats:
             v1 = w1.get(name, {}).get(k, float("nan"))
             v2 = w2.get(name, {}).get(k, float("nan"))
             diff_w[name][k] = v2 - v1
 
     for name in set(a1) | set(a2):
         diff_a[name] = {}
-        for k in STAT_KEYS:
+        for k in stats:
             v1 = a1.get(name, {}).get(k, float("nan"))
             v2 = a2.get(name, {}).get(k, float("nan"))
             diff_a[name][k] = v2 - v1
 
-    ext = _collect_extremes(diff_w, diff_a)
+    w_ext = _collect_extremes(diff_w, stats)
+    a_ext = _collect_extremes(diff_a, stats)
 
     console = Console()
     table = Table(title="Δ Model Statistics", header_style="bold magenta")
     table.add_column("Tensor", no_wrap=True)
-    for key in STAT_KEYS:
-        table.add_column(f"W {key}", justify="right")
-        table.add_column(f"A {key}", justify="right")
+    for key in stats:
+        table.add_column(f"W {key} 1", justify="right")
+        table.add_column(f"W {key} 2", justify="right")
+        table.add_column(f"ΔW {key}", justify="right")
+    for key in stats:
+        table.add_column(f"A {key} 1", justify="right")
+        table.add_column(f"A {key} 2", justify="right")
+        table.add_column(f"ΔA {key}", justify="right")
 
+    # Ensure deterministic row ordering
+    all_names = list(row_order)
+    for n in set(w2) | set(w1):
+        if n not in row_order:
+            all_names.append(n)
     printed = set()
-    for name in set(w2) | set(w1):
+
+    for name in all_names:
         module = name.rsplit(".", 1)[0]
         row = [name]
-        dw = diff_w.get(name, {})
-        da = diff_a.get(module, {})
-        for k in STAT_KEYS:
-            row.append(_colour_delta(dw.get(k, float("nan")), k, *ext[k]))
-            row.append(_colour_delta(da.get(k, float("nan")), k, *ext[k]))
+        for k in stats:
+            w_v1 = w1.get(name, {}).get(k, float("nan"))
+            w_v2 = w2.get(name, {}).get(k, float("nan"))
+            delta_w = diff_w.get(name, {}).get(k, float("nan"))
+            row.append(f"{w_v1:.6f}" if math.isfinite(w_v1) else "nan")
+            row.append(f"{w_v2:.6f}" if math.isfinite(w_v2) else "nan")
+            row.append(_colour_delta(delta_w, k, *w_ext[k]))
+
+        for k in stats:
+            a_v1 = a1.get(module, {}).get(k, float("nan"))
+            a_v2 = a2.get(module, {}).get(k, float("nan"))
+            delta_a = diff_a.get(module, {}).get(k, float("nan"))
+            row.append(f"{a_v1:.6f}" if math.isfinite(a_v1) else "nan")
+            row.append(f"{a_v2:.6f}" if math.isfinite(a_v2) else "nan")
+            row.append(_colour_delta(delta_a, k, *a_ext[k]))
+
         table.add_row(*row)
         printed.add(module)
 
+    # Add activation-only modules not seen above
     for mod in diff_a.keys():
         if mod in printed:
             continue
         row = [mod]
-        for k in STAT_KEYS:
-            row.append(_colour_delta(float("nan"), k, *ext[k]))
-            row.append(_colour_delta(diff_a[mod].get(k, float("nan")), k, *ext[k]))
+        for k in stats:
+            row.extend([
+                "nan",
+                "nan",
+                _colour_delta(float("nan"), k, *w_ext[k]),
+            ])
+        for k in stats:
+            a_v1 = a1.get(mod, {}).get(k, float("nan"))
+            a_v2 = a2.get(mod, {}).get(k, float("nan"))
+            delta_a = diff_a.get(mod, {}).get(k, float("nan"))
+            row.append(f"{a_v1:.6f}" if math.isfinite(a_v1) else "nan")
+            row.append(f"{a_v2:.6f}" if math.isfinite(a_v2) else "nan")
+            row.append(_colour_delta(delta_a, k, *a_ext[k]))
         table.add_row(*row)
 
     console.print(table)
@@ -133,15 +177,30 @@ def print_delta(w1: Dict[str, Dict], a1: Dict[str, Dict], w2: Dict[str, Dict], a
 def main() -> None:
     ap = argparse.ArgumentParser(description="View model stats CSV")
     ap.add_argument("csv", nargs="+", help="One or two CSV files")
+    ap.add_argument(
+        "--stats",
+        default="all",
+        help="Comma-separated list of stats to compare (default: all)",
+    )
     args = ap.parse_args()
 
+    selected = (
+        STAT_KEYS
+        if args.stats.lower() == "all"
+        else [s for s in args.stats.split(",") if s in STAT_KEYS]
+    )
+
     if len(args.csv) == 1:
-        w, a = load_csv(Path(args.csv[0]))
+        _, w, a = load_csv(Path(args.csv[0]))
         print_model_stats_table(w, a)
     else:
-        w1, a1 = load_csv(Path(args.csv[0]))
-        w2, a2 = load_csv(Path(args.csv[1]))
-        print_delta(w1, a1, w2, a2)
+        rows1, w1, a1 = load_csv(Path(args.csv[0]))
+        rows2, w2, a2 = load_csv(Path(args.csv[1]))
+        row_order = rows1
+        for r in rows2:
+            if r not in row_order:
+                row_order.append(r)
+        print_delta(row_order, w1, a1, w2, a2, selected)
 
 
 if __name__ == "__main__":

--- a/view_model_stats.py
+++ b/view_model_stats.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Utility for displaying model statistics CSV files."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+from pathlib import Path
+from typing import Dict, Tuple, List
+
+from rich.console import Console
+from rich.table import Table
+
+from utils.model_stats import print_model_stats_table
+
+STAT_KEYS = ["stdev", "kurtosis", "max", "min", "abs_max"]
+
+
+def _f(val: str) -> float:
+    try:
+        fval = float(val)
+        return fval if math.isfinite(fval) else float("nan")
+    except Exception:
+        return float("nan")
+
+
+def load_csv(path: Path) -> Tuple[Dict[str, Dict], Dict[str, Dict]]:
+    """Return weight and activation stats from *path*."""
+    w_stats: Dict[str, Dict] = {}
+    a_stats: Dict[str, Dict] = {}
+    with path.open() as f:
+        reader = csv.reader(f)
+        _ = next(reader, None)  # header
+        for row in reader:
+            name = row[0]
+            w_vals = [_f(v) for v in row[1 : 1 + len(STAT_KEYS)]]
+            a_vals = [_f(v) for v in row[1 + len(STAT_KEYS) :]]
+
+            module = name
+            if any(math.isfinite(v) for v in w_vals):
+                w_stats[name] = {k: v for k, v in zip(STAT_KEYS, w_vals)}
+                module = name.rsplit(".", 1)[0]
+
+            if any(math.isfinite(v) for v in a_vals):
+                a_stats[module] = {k: v for k, v in zip(STAT_KEYS, a_vals)}
+    return w_stats, a_stats
+
+
+def _collect_extremes(diff_w: Dict[str, Dict], diff_a: Dict[str, Dict]) -> Dict[str, Tuple[float, float]]:
+    ext: Dict[str, Tuple[float, float]] = {}
+    for key in STAT_KEYS:
+        vals: List[float] = []
+        for d in list(diff_w.values()) + list(diff_a.values()):
+            v = d.get(key)
+            if not isinstance(v, float) or not math.isfinite(v):
+                continue
+            trans = -v if key != "min" else v
+            vals.append(trans)
+        if vals:
+            ext[key] = (min(vals), max(vals))
+        else:
+            ext[key] = (0.0, 0.0)
+    return ext
+
+
+def _colour_delta(val: float, key: str, lo: float, hi: float) -> str:
+    if not isinstance(val, float) or not math.isfinite(val):
+        return "[orange3]nan[/]"
+    trans = -val if key != "min" else val
+    if hi == lo:
+        t = 0.5
+    else:
+        t = 1 - (trans - lo) / (hi - lo)
+        t = max(0.0, min(1.0, t))
+    r = int(255 * t)
+    g = int(255 * (1 - t))
+    color = f"#{r:02x}{g:02x}00"
+    return f"[{color}]{val:.6f}[/]"
+
+
+def print_delta(w1: Dict[str, Dict], a1: Dict[str, Dict], w2: Dict[str, Dict], a2: Dict[str, Dict]) -> None:
+    diff_w: Dict[str, Dict] = {}
+    diff_a: Dict[str, Dict] = {}
+
+    for name in set(w1) | set(w2):
+        diff_w[name] = {}
+        for k in STAT_KEYS:
+            v1 = w1.get(name, {}).get(k, float("nan"))
+            v2 = w2.get(name, {}).get(k, float("nan"))
+            diff_w[name][k] = v2 - v1
+
+    for name in set(a1) | set(a2):
+        diff_a[name] = {}
+        for k in STAT_KEYS:
+            v1 = a1.get(name, {}).get(k, float("nan"))
+            v2 = a2.get(name, {}).get(k, float("nan"))
+            diff_a[name][k] = v2 - v1
+
+    ext = _collect_extremes(diff_w, diff_a)
+
+    console = Console()
+    table = Table(title="Δ Model Statistics", header_style="bold magenta")
+    table.add_column("Tensor", no_wrap=True)
+    for key in STAT_KEYS:
+        table.add_column(f"W {key}", justify="right")
+        table.add_column(f"A {key}", justify="right")
+
+    printed = set()
+    for name in set(w2) | set(w1):
+        module = name.rsplit(".", 1)[0]
+        row = [name]
+        dw = diff_w.get(name, {})
+        da = diff_a.get(module, {})
+        for k in STAT_KEYS:
+            row.append(_colour_delta(dw.get(k, float("nan")), k, *ext[k]))
+            row.append(_colour_delta(da.get(k, float("nan")), k, *ext[k]))
+        table.add_row(*row)
+        printed.add(module)
+
+    for mod in diff_a.keys():
+        if mod in printed:
+            continue
+        row = [mod]
+        for k in STAT_KEYS:
+            row.append(_colour_delta(float("nan"), k, *ext[k]))
+            row.append(_colour_delta(diff_a[mod].get(k, float("nan")), k, *ext[k]))
+        table.add_row(*row)
+
+    console.print(table)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="View model stats CSV")
+    ap.add_argument("csv", nargs="+", help="One or two CSV files")
+    args = ap.parse_args()
+
+    if len(args.csv) == 1:
+        w, a = load_csv(Path(args.csv[0]))
+        print_model_stats_table(w, a)
+    else:
+        w1, a1 = load_csv(Path(args.csv[0]))
+        w2, a2 = load_csv(Path(args.csv[1]))
+        print_delta(w1, a1, w2, a2)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- present weight and activation statistics together
- colorize values with Rich table
- refine color scheme for NaNs, kurtosis, and min column
- ignore invalid float values when computing overall stats
- compute color scales separately for weight and activation columns
- use logarithmic scaling for kurtosis values so differences are more visible
- add option to write model stats to CSV
- implement viewer script that can display CSVs or highlight deltas between two files

## Testing
- `python -m py_compile utils/model_stats.py train.py view_model_stats.py train_args.py`


------
https://chatgpt.com/codex/tasks/task_e_6885029bde3c83268d9c0bb50c65b442