### PR TITLE
Add vector movement animation tool

### DIFF
--- a/analysis/vector_movement/README.md
+++ b/analysis/vector_movement/README.md
@@ -1,0 +1,12 @@
+# Vector Movement
+
+This tool simulates the training of a 3‑D vector so that it aligns with a target vector.
+The vectors are initialized from Gaussian distributions by default but may also be
+fixed to one of the coordinate axes or the positive cube corner.
+
+A small training loop in PyTorch is run and the movement of the vector is visualised
+with Plotly as an interactive HTML animation.
+
+```
+python vector_movement.py --help
+```

--- a/analysis/vector_movement/vector_movement.py
+++ b/analysis/vector_movement/vector_movement.py
@@ -1,0 +1,158 @@
+import argparse
+import numpy as np
+import torch
+from torch.optim import AdamW, Adam, SGD
+from torch.optim.lr_scheduler import LambdaLR
+import plotly.graph_objects as go
+from plotly.io import write_html
+
+
+# Utility from vector_distribution_analysis
+
+def add_xyz_axes(fig, length=1.2):
+    axes = {
+        'x': ([0, length], [0, 0], [0, 0], 'red'),
+        'y': ([0, 0], [0, length], [0, 0], 'green'),
+        'z': ([0, 0], [0, 0], [0, length], 'blue'),
+    }
+    for name, (x, y, z, color) in axes.items():
+        fig.add_trace(go.Scatter3d(
+            x=x, y=y, z=z,
+            mode='lines+text',
+            line=dict(color=color, width=4),
+            text=[None, name],
+            textposition='top center',
+            showlegend=False
+        ))
+
+
+def rms_norm_to_unit(vec, eps=1e-8):
+    dim = vec.numel()
+    rms = torch.sqrt(torch.mean(vec ** 2) + eps)
+    gain = 1.0 / np.sqrt(dim)
+    return vec * (gain / rms)
+
+
+def vector_trace(vec, name, color):
+    return go.Scatter3d(
+        x=[0, vec[0]], y=[0, vec[1]], z=[0, vec[2]],
+        mode='lines+markers',
+        line=dict(color=color, width=6),
+        marker=dict(size=4),
+        name=name
+    )
+
+
+def make_animation(history, target, out_html):
+    target_trace = vector_trace(target, 'target', 'green')
+    frames = []
+    for i, (raw_v, norm_v) in enumerate(history):
+        frame = go.Frame(
+            data=[
+                vector_trace(raw_v, 'vector', 'red'),
+                vector_trace(norm_v, 'norm', 'orange'),
+                target_trace
+            ],
+            name=str(i)
+        )
+        frames.append(frame)
+
+    fig = go.Figure(frames=frames)
+    fig.add_traces(frames[0].data)
+    fig.update_layout(
+        updatemenus=[{
+            'type': 'buttons',
+            'buttons': [{'label': 'Play', 'method': 'animate', 'args': [None, {'frame': {'duration': 100, 'redraw': True}, 'fromcurrent': True}]}]
+        }],
+        scene=dict(aspectmode='cube', xaxis=dict(range=[-1.5,1.5]), yaxis=dict(range=[-1.5,1.5]), zaxis=dict(range=[-1.5,1.5]))
+    )
+    add_xyz_axes(fig)
+    write_html(fig, out_html)
+    print(f"Saved animation to {out_html}")
+
+
+def preset_vector(name):
+    if name == 'x':
+        return np.array([1., 0., 0.], dtype=np.float32)
+    if name == 'y':
+        return np.array([0., 1., 0.], dtype=np.float32)
+    if name == 'z':
+        return np.array([0., 0., 1.], dtype=np.float32)
+    if name == 'corner':
+        return np.array([1., 1., 1.], dtype=np.float32) / np.sqrt(3.0)
+    raise ValueError(f"unknown preset {name}")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description='Vector movement toward target')
+    p.add_argument('--init-mean', type=float, default=0.0)
+    p.add_argument('--init-std', type=float, default=1.0)
+    p.add_argument('--target-mean', type=float, default=0.0)
+    p.add_argument('--target-std', type=float, default=1.0)
+    p.add_argument('--init-preset', choices=['x','y','z','corner'])
+    p.add_argument('--target-preset', choices=['x','y','z','corner'])
+    p.add_argument('--steps', type=int, default=100)
+    p.add_argument('--lr', type=float, default=1e-2)
+    p.add_argument('--lr-schedule', choices=['constant','cosine'], default='constant')
+    p.add_argument('--optimizer', choices=['adamw','adam','sgd'], default='adamw')
+    p.add_argument('--loss', choices=['dot','cosine'], default='dot')
+    p.add_argument('--no-norm', action='store_true', help='disable RMS normalization')
+    p.add_argument('--out', default='vector_movement.html')
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    torch.manual_seed(0)
+    np.random.seed(0)
+
+    if args.init_preset:
+        init_v = preset_vector(args.init_preset)
+    else:
+        init_v = np.random.normal(loc=args.init_mean, scale=args.init_std, size=3).astype(np.float32)
+    if args.target_preset:
+        target_v = preset_vector(args.target_preset)
+    else:
+        target_v = np.random.normal(loc=args.target_mean, scale=args.target_std, size=3).astype(np.float32)
+
+    v = torch.tensor(init_v, requires_grad=True)
+    target = torch.tensor(target_v)
+    target_unit = target / (target.norm() + 1e-8)
+
+    if args.optimizer == 'adamw':
+        opt = AdamW([v], lr=args.lr)
+    elif args.optimizer == 'adam':
+        opt = Adam([v], lr=args.lr)
+    else:
+        opt = SGD([v], lr=args.lr)
+
+    if args.lr_schedule == 'cosine':
+        lr_lambda = lambda step: 0.5 * (1 + np.cos(np.pi * step / args.steps))
+        sched = LambdaLR(opt, lr_lambda)
+    else:
+        sched = None
+
+    history = []
+    for step in range(args.steps):
+        opt.zero_grad()
+        vec_for_loss = v
+        if not args.no_norm:
+            vec_for_loss = rms_norm_to_unit(v)
+        if args.loss == 'dot':
+            loss = -torch.dot(vec_for_loss, target_unit)
+        else:
+            loss = 1 - torch.nn.functional.cosine_similarity(vec_for_loss.unsqueeze(0), target_unit.unsqueeze(0))
+            loss = loss.squeeze()
+        loss.backward()
+        opt.step()
+        if sched:
+            sched.step()
+        with torch.no_grad():
+            norm_v = rms_norm_to_unit(v) if not args.no_norm else v.clone()
+            history.append((v.detach().clone().numpy(), norm_v.detach().clone().numpy()))
+
+    make_animation(history, target_unit.numpy(), args.out)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `vector_movement` analysis folder with script and README
- implement vector training toward a target with optional RMS norm and different losses
- produce interactive plotly animation of vector path

## Testing
- `python analysis/vector_movement/vector_movement.py --steps 5 --out test.html`
- `pytest -q` *(fails: ModuleNotFoundError: 'jamo', 'yakinori')*

------
https://chatgpt.com/codex/tasks/task_e_6887f63e336483269476149a6bf08efe