### PR TITLE
Add infinite attention support to JL transform

### DIFF
--- a/analysis/checkpoint_analysis/README.md
+++ b/analysis/checkpoint_analysis/README.md
@@ -71,8 +71,9 @@ states are removed so training restarts cleanly. Use `--jl_type` to select the
 kind of JL transform (e.g. `sign`, `gaussian`, `sparse`, or `srht`).
 When using the `gaussian` type you may set `--gaussian_mean` and
 `--gaussian_std` to control the distribution of the projection matrix.  The
-optional `--cproj_vertical` flag projects any `c_proj.weight` tensors along their
-first dimension instead of the default behaviour.
+optional `--cproj_vertical` flag projects any `c_proj` weights along their first
+dimension instead of the default behaviour.  This now includes the
+`c_proj_list.*.weight` parameters used by the infinite attention variant.
 The script also resets `best_val_loss` and `best_iter` in the new checkpoint so
 training restarts from scratch after transformation.
 

--- a/analysis/checkpoint_analysis/jl_transform_ckpt.py
+++ b/analysis/checkpoint_analysis/jl_transform_ckpt.py
@@ -173,7 +173,7 @@ def main():
         if key.endswith("mlp.c_fc.weight") and tensor.ndim == 2:
             mlp_sizes.append(tensor.shape[0])
 
-        vertical = args.cproj_vertical and key.endswith("c_proj.weight")
+        vertical = args.cproj_vertical and key.endswith(".weight") and "c_proj" in key
         state_dict[key] = jl_project_tensor(tensor, proj, vertical_only=vertical)
 
     if "model_args" in checkpoint:


### PR DESCRIPTION
## Summary
- handle c_proj_list weights in JL transform
- document c_proj_list support for infinite attention

## Testing
- `pip install jamo yakinori`
- `apt-get install -y mecab libmecab-dev mecab-ipadic-utf8`
- `pytest -q` *(fails: RuntimeError: Failed initializing MeCab)*

------
https://chatgpt.com/codex/tasks/task_e_688ac63e54908326ab25d379109cdbd4