### PR TITLE
Add Fourier Position Embedding variant

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -292,8 +292,9 @@ class GPTConfig:
     shared_fire_embeddings: bool = False
     use_rotary_embeddings: bool = False
     sym_rot_num_angles: int = 512
-    rope_variant: str = "rope" # options: "shortrope", "rope"
+    rope_variant: str = "rope" # options: "shortrope", "rope", "fope"
     rope_length: int = 8 # number of embeddings to use in shortrope
+    rope_fourier_init_norm_gain: float = 1.0
 
     ## Embedding Intialization Options
     embedding_mean_init: float= 0.0

--- a/model.py
+++ b/model.py
@@ -33,7 +33,13 @@ from variations.moe_variations import MoELayer
 from variations.lsv_variations import lsv_dictionary
 from variations.softmax_variations import softmax_dictionary
 from variations.norm_variations import norm_dictionary
-from variations.position_encoding_variations import QuantizedEmbedding, RotaryEmbedding, SymmetricalOverlapAngularPositions, FIRE
+from variations.position_encoding_variations import (
+    QuantizedEmbedding,
+    RotaryEmbedding,
+    SymmetricalOverlapAngularPositions,
+    FIRE,
+    FourierPositionEmbedding,
+)
 from variations.activation_variations import activation_dictionary
 from variations.linear_variations import linear_dictionary
 from variations.router_variations import router_dictionary

--- a/train_args.py
+++ b/train_args.py
@@ -737,7 +737,7 @@ def parse_args():
     # POSITIONAL EMBEDDING VARIATIONS
     model_group.add_argument('--use_rotary_embeddings', default=False, action=argparse.BooleanOptionalAction)
     model_group.add_argument('--sym_rot_num_angles', type=int, default=512, help="number of angles to use for symmetric rope variant")
-    model_group.add_argument("--rope_variant", type=str, default="rope", choices=["rope", "soap"])
+    model_group.add_argument("--rope_variant", type=str, default="rope", choices=["rope", "soap", "fope"])
     model_group.add_argument("--rope_length", type=int, default=None, help="Defaults to all embeddings (if set to None), else must be even.")
     model_group.add_argument('--use_abs_pos_embeddings', default=True, action=argparse.BooleanOptionalAction)
     model_group.add_argument('--use_fire_embeddings', default=False, action=argparse.BooleanOptionalAction)

--- a/variations/attention_variations.py
+++ b/variations/attention_variations.py
@@ -10,7 +10,11 @@ from quantization.quant_utils import create_activation_buffers, set_variant
 from quantization.quantize import fake_quantize_act
 from variations.linear_variations import linear_dictionary
 from variations.position_encoding_variations import (
-    FIRE, RotaryEmbedding, SymmetricalOverlapAngularPositions)
+    FIRE,
+    RotaryEmbedding,
+    SymmetricalOverlapAngularPositions,
+    FourierPositionEmbedding,
+)
 from variations.softmax_variations import softmax_dictionary
 from variations.triadic_modulation_variations import mod_fn_dict
 # Mamba related imports
@@ -103,6 +107,9 @@ class CausalSelfAttention(nn.Module):
             elif config.rope_variant == "rope":
                 self.rotary_emb_q = RotaryEmbedding(config, size=config.n_embd // self.n_head)
                 self.rotary_emb_k = RotaryEmbedding(config, size=config.n_embd // self.n_head)
+            elif config.rope_variant == "fope":
+                self.rotary_emb_q = FourierPositionEmbedding(config, size=config.n_embd // self.n_head)
+                self.rotary_emb_k = FourierPositionEmbedding(config, size=config.n_embd // self.n_head)
 
         # Sliding window size
         self.window_size = config.window_size
@@ -155,6 +162,9 @@ class CausalSelfAttention(nn.Module):
             elif config.rope_variant == "rope":
                 self.rotary_emb_q = RotaryEmbedding(config, size=config.n_embd // self.n_head)
                 self.rotary_emb_k = RotaryEmbedding(config, size=config.n_embd // self.n_head)
+            elif config.rope_variant == "fope":
+                self.rotary_emb_q = FourierPositionEmbedding(config, size=config.n_embd // self.n_head)
+                self.rotary_emb_k = FourierPositionEmbedding(config, size=config.n_embd // self.n_head)
 
         # qk norm factor
         if self.use_qk_norm_scale:
@@ -733,6 +743,9 @@ class InfiniteHeadAttention(nn.Module):
             elif config.rope_variant == "rope":
                 self.rotary_emb_q = RotaryEmbedding(config, size=self.n_qk_head_dim)
                 self.rotary_emb_k = RotaryEmbedding(config, size=self.n_qk_head_dim)
+            elif config.rope_variant == "fope":
+                self.rotary_emb_q = FourierPositionEmbedding(config, size=self.n_qk_head_dim)
+                self.rotary_emb_k = FourierPositionEmbedding(config, size=self.n_qk_head_dim)
 
         # qk norm factor
         if self.use_qk_norm_scale:


### PR DESCRIPTION
## Summary
- implement Fourier Position Embedding (FoPE) as a RoPE extension using Fourier series and frequency clipping
- wire FoPE into attention and configuration via `rope_variant=fope`
- expose CLI flag and config parameter to use FoPE

## Testing
- `pytest` *(fails: Failed initializing MeCab. Please see the README for possible solutions)*

------
https://chatgpt.com/codex/tasks/task_e_688da9e9a14c8326a292fed1d8d9d8b5