### PR TITLE
Enable normalized Transformer utilities

### DIFF
--- a/train.py
+++ b/train.py
@@ -82,6 +82,7 @@ from model import GPT, GPTConfig
 import tiktoken
 
 from train_args import parse_args
+from utils.ngpt_utils import normalize_module_weights
 
 class Trainer:
 
@@ -1531,6 +1532,11 @@ class Trainer:
 
                 self.scaler.step(self.optimizer)
                 self.scaler.update()
+                if self.args.use_ngpt:
+                    # After each parameter update, project all weight matrices and
+                    # embeddings back onto the unit hypersphere as required by
+                    # the normalized Transformer recipe.
+                    normalize_module_weights(self.model, self.model.config.n_embd)
                 if self.scheduler:
                     if isinstance(self.scheduler, torch.optim.lr_scheduler.ReduceLROnPlateau):
                         self.scheduler.step(losses["val"])

--- a/train_args.py
+++ b/train_args.py
@@ -116,6 +116,14 @@ def parse_args():
     training_group.add_argument('--gns_max_batch', type=int, default=100)
     training_group.add_argument('--gns_batch_pct', type=float, default=0.2)
 
+    # Normalized Transformer (nGPT) options
+    training_group.add_argument(
+        '--use_ngpt',
+        default=False,
+        action=argparse.BooleanOptionalAction,
+        help='Enable nGPT-style per-step weight normalisation and related operations.'
+    )
+
 
     # Optimizer-specific arguments
     optimizer_variations = [

--- a/utils/ngpt_utils.py
+++ b/utils/ngpt_utils.py
@@ -1,0 +1,45 @@
+import torch
+import torch.nn as nn
+
+
+def unit_norm(x: torch.Tensor, dim: int = -1, eps: float = 1e-8) -> torch.Tensor:
+    """Return ``x`` rescaled to unit L2 norm along ``dim``.
+
+    This helper mirrors the ``Norm`` operation used throughout nGPT, where
+    vectors live on the surface of a hypersphere.  An ``eps`` is added for
+    numerical stability when a vector has near zero norm.
+    """
+    return x / (x.norm(dim=dim, keepdim=True) + eps)
+
+
+def normalize_module_weights(module: nn.Module, embedding_dim: int | None = None) -> None:
+    """In-place L2 normalisation of weight tensors within ``module``.
+
+    Any parameter tensor that contains a dimension equal to ``embedding_dim``
+    (typically ``config.n_embd``) will be projected onto the unit hypersphere
+    along that dimension. Bias terms (``ndim == 1``) are left untouched.
+
+    Parameters
+    ----------
+    module : nn.Module
+        Module whose parameters will be normalised.
+    embedding_dim : int, optional
+        The embedding dimension ``n_embd``. If ``None`` the function attempts to
+        read ``module.config.n_embd`` and falls back to raising ``ValueError`` if
+        unavailable.
+    """
+    if embedding_dim is None:
+        embedding_dim = getattr(getattr(module, "config", None), "n_embd", None)
+        if embedding_dim is None:
+            raise ValueError("embedding_dim must be provided or module.config.n_embd must exist")
+
+    with torch.no_grad():
+        for param in module.parameters():
+            if param.ndim <= 1:
+                continue
+            dims = [i for i, s in enumerate(param.shape) if s == embedding_dim]
+            for dim in dims:
+                param.data = unit_norm(param.data, dim=dim)
+
+
+__all__ = ["unit_norm", "normalize_module_weights"]

--- a/variations/norm_variations.py
+++ b/variations/norm_variations.py
@@ -203,6 +203,23 @@ class IdentityNorm(nn.Module):
         return self.identity(x)
 
 
+class UnitNorm(nn.Module):
+    """Simple L2 normalisation to unit length.
+
+    This layer is used by the normalized Transformer (nGPT) where all
+    activations and weight vectors live on the surface of the unit
+    hypersphere.  Unlike ``RMSNorm`` or ``LayerNorm`` no learnable scale or
+    bias is applied; the output merely has unit L2 norm along the last
+    dimension.
+    """
+
+    def __init__(self, config=None):  # pragma: no cover - config unused
+        super().__init__()
+
+    def forward(self, x):
+        return x / (x.norm(p=2, dim=-1, keepdim=True) + 1e-8)
+
+
 norm_dictionary = {
     "layernorm": LayerNorm,
     "rmsnorm": RMSNorm,
@@ -211,4 +228,5 @@ norm_dictionary = {
     "hyperspherenorm": HyperSphereNorm,
     "dact": DynamicActivation,
     "identity": IdentityNorm,
+    "unitnorm": UnitNorm,
 }


### PR DESCRIPTION
## Summary
- add generic unit-norm utilities for nGPT
- expose `--use_ngpt` flag and per-step weight normalisation in training
- provide UnitNorm layer option in norm variations
- normalise any parameter tensor along dimensions matching embedding size

## Testing
- `pip install jamo yakinori`
- `pytest` *(fails: Failed initializing MeCab. [ifs] no such file or directory: /usr/local/etc/mecabrc)*

------
https://chatgpt.com/codex/tasks/task_e_6895697b37588326b7b4d56a81656863