### PR TITLE
feat: add option to disable checkpoint saving

### DIFF
--- a/train.py
+++ b/train.py
@@ -1279,6 +1279,8 @@ class Trainer:
         return abbr
 
     def save_checkpoint(self, filename):
+        if self.args.never_save_checkpoint:
+            return
         checkpoint = {
                 'model': self.raw_model.state_dict(),
                 'optimizer': self.optimizer.state_dict() if self.optimizer else None,
@@ -1425,7 +1427,8 @@ class Trainer:
                             print("Exiting with nan")
                             file.write(str(self.iter_num))
 
-                    if self.args.save_major_ckpt_interval is not None:
+                    if (not self.args.never_save_checkpoint and 
+                        self.args.save_major_ckpt_interval is not None):
                         if self.iter_num % self.args.save_major_ckpt_interval == 0:
                             major_ckpt_name = str(self.iter_num) +'.pt'
                             # Save major checkpoint
@@ -1461,7 +1464,7 @@ class Trainer:
                                         )
                             # Reset early exit counter
                             num_steps_with_worse_loss = 0
-                        if self.iter_num > 0:
+                        if self.iter_num > 0 and not self.args.never_save_checkpoint:
                             print(f"saving checkpoint to {self.args.out_dir}")
                             # Save checkpoint
                             self.save_checkpoint('ckpt.pt')
@@ -1682,9 +1685,9 @@ class Trainer:
                 if self.iter_num > self.args.max_iters:
                     print(self.best_val_loss, self.best_iter)
                     if self.args.only_save_checkpoint_at_end:
-
-                        self.save_checkpoint('ckpt.pt')
-                        print(f"Saved checkpoint to {self.args.out_dir}")
+                        if not self.args.never_save_checkpoint:
+                            self.save_checkpoint('ckpt.pt')
+                            print(f"Saved checkpoint to {self.args.out_dir}")
 
                         # Sample if set
                         if self.args.max_sample_tokens:

--- a/train_args.py
+++ b/train_args.py
@@ -66,6 +66,7 @@ def parse_args():
     training_group.add_argument('--save_major_ckpt_interval', default=None, type=int, help="Interval for saving major checkpoints.")
     training_group.add_argument('--only_save_checkpoint_at_end', default=False, action=argparse.BooleanOptionalAction)
     training_group.add_argument('--always_save_checkpoint', default=False, action=argparse.BooleanOptionalAction)
+    training_group.add_argument('--never_save_checkpoint', default=False, action=argparse.BooleanOptionalAction, help="If set, disables saving of all checkpoints.")
     training_group.add_argument('--patience', default=None, type=int, help="if set, will stop training if the number of evaluations since val loss was seen to decrease exceeds 'patience' setting.")
     training_group.add_argument('--init_from', default='scratch', choices=['scratch', 'prev_run', 'resume', 'gpt2'], type=str)
     training_group.add_argument('--gpt2_type', default='gpt2', type=str)


### PR DESCRIPTION
## Summary
- add CLI flag `--never_save_checkpoint` to allow training without writing checkpoints
- skip checkpoint writes in training loop when flag is set

## Testing
- `pytest` *(fails: IndexError in yakinori_test.py)*

------
https://chatgpt.com/codex/tasks/task_e_6897ae14e8b48326b84c7edb8bcf0292