### PR TITLE
Add FireMLP variation

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -4,11 +4,14 @@ from typing import List
 import json
 import math
 
+
 @dataclass
 class GPTConfig:
     attention_list: List[str] = field(default_factory=lambda: [])
     block_size: int = 1024
-    vocab_size: int = 50304 # GPT-2 vocab_size of 50257, padded up to nearest multiple of 64 for efficiency
+    vocab_size: int = (
+        50304  # GPT-2 vocab_size of 50257, padded up to nearest multiple of 64 for efficiency
+    )
     n_layer: int = 12
     n_head: int = 12
     n_kv_group: int = 12
@@ -25,7 +28,7 @@ class GPTConfig:
     multicontext: bool = False
     # Use separate embeddings/LM heads per dataset in multidataset mode
     multidataset_wte: bool = False
-    vocab_sizes: List[int] = field(default_factory=lambda: []) # Used in place of vocab
+    vocab_sizes: List[int] = field(default_factory=lambda: [])  # Used in place of vocab
 
     # MLP bias configuration
     mlp_up_bias: bool | None = None  # If None, uses global bias setting
@@ -38,11 +41,11 @@ class GPTConfig:
     learn_mlp_y_offset: bool = False
 
     ## MLA Variations
-    mla_latent_dim: int | None = None   # d_c  (proj dimension of the shared latent)
-    mla_rotary_dim: int       = 32      # d_r  (# rotary channels per head)
+    mla_latent_dim: int | None = None  # d_c  (proj dimension of the shared latent)
+    mla_rotary_dim: int = 32  # d_r  (# rotary channels per head)
 
-    use_mla_lobo: bool = False          # turns the feature on/off
-    mla_lobo_init: float = 0.0          # log-space initial value (like flash_lobo_log_const)
+    use_mla_lobo: bool = False  # turns the feature on/off
+    mla_lobo_init: float = 0.0  # log-space initial value (like flash_lobo_log_const)
 
     ## CO4 attention variation
     n_latent: int = None
@@ -111,7 +114,7 @@ class GPTConfig:
 
     # weight tying
     n_embd_wte_scale_tying: bool = True
-    wte_weight_tying: bool = True # Non-factorized wte weight tying
+    wte_weight_tying: bool = True  # Non-factorized wte weight tying
 
     # wte import/export
     import_wte_freeze: bool = False
@@ -169,6 +172,7 @@ class GPTConfig:
     mlp_variant: str = "mlp"
     mlp_expansion_factor: int = 4
     mlp_size: int = None
+    fire_mlp_hidden: int | None = None  # Hidden size of the shared per-element MLP
 
     ## KAN Option
     kan_poly_order: int = 3
@@ -186,31 +190,36 @@ class GPTConfig:
     shared_attn_seq: int = 1
 
     # Softmax Alternatives and Options
-    softmax_variant_attn: str = "softmax" # Choices: "softmax" "softermax" "sigsoftmax" "polymax" "strongermax" "consmax"
-    softmax_variant_output: str = "softmax" # Choices: "softmax" "softermax" "sigsoftmax" "polymax" "strongermax" "consmax"
-
+    softmax_variant_attn: str = (
+        "softmax"  # Choices: "softmax" "softermax" "sigsoftmax" "polymax" "strongermax" "consmax"
+    )
+    softmax_variant_output: str = (
+        "softmax"  # Choices: "softmax" "softermax" "sigsoftmax" "polymax" "strongermax" "consmax"
+    )
 
     ## General Options
-    div_by_seq_len: bool = False # for supported functions will divide by seq length
+    div_by_seq_len: bool = False  # for supported functions will divide by seq length
 
     ## ConSmax Options
-    consmax_initial_beta: float = 2.0 # beta adjustment
-    consmax_initial_gamma: float = 100.0 # denominator adjustment
-    consmax_base: float = 2.0 # base to utilize for ConSmax
-    consmax_use_euler_base: bool = True # use 'e' as base for ConSmax, default
+    consmax_initial_beta: float = 2.0  # beta adjustment
+    consmax_initial_gamma: float = 100.0  # denominator adjustment
+    consmax_base: float = 2.0  # base to utilize for ConSmax
+    consmax_use_euler_base: bool = True  # use 'e' as base for ConSmax, default
 
     ## ConSmaxV2 Special Options
-    consmax_per_head: bool = True # different beta gamma per head
+    consmax_per_head: bool = True  # different beta gamma per head
     consmax_v2_clamping: bool = True
     consmax_v2_clamp_value: float = 80.0
 
     ## SaturatingConSmax Special options (otherwise same as ConSmax)
-    consmax_saturation: float = 11.0 # for SaturatingConSmax saturation point
+    consmax_saturation: float = 11.0  # for SaturatingConSmax saturation point
     consmax_learnable_beta: bool = True
     consmax_learnable_gamma: bool = True
 
     ## Softermax options
-    softermax_use_xmax: bool = True # Softermax Option active is softermax selected - True: uses (x - x_max) normalization; False: removes normalization (potential overflow)
+    softermax_use_xmax: bool = (
+        True  # Softermax Option active is softermax selected - True: uses (x - x_max) normalization; False: removes normalization (potential overflow)
+    )
 
     ## Polymax options
     polymax_x_intercept: float = -100.0
@@ -219,8 +228,8 @@ class GPTConfig:
     polymax_divisor: float = 1000.0
 
     ## SigSoftmaxBase
-    sigsoftmax_use_euler_base: bool = True # use 'e' as base for Constantmax
-    sigsoftmax_base: float = 2.0 # denominator to utilize for Constantmax
+    sigsoftmax_use_euler_base: bool = True  # use 'e' as base for Constantmax
+    sigsoftmax_base: float = 2.0  # denominator to utilize for Constantmax
 
     ## Strongermax options
     strongermax_strength: float = math.e
@@ -267,38 +276,40 @@ class GPTConfig:
 
     # ──────────────────────────────────────────────────────────────────────
     ## PFLA‑Softmax configuration
-    pfla_softmax_num_points: int  = 30      # # inner control points
-    pfla_softmax_left_bound: float  = -10.0 # x‑range start
+    pfla_softmax_num_points: int = 30  # # inner control points
+    pfla_softmax_left_bound: float = -10.0  # x‑range start
     pfla_softmax_right_bound: float = 10.0  # x‑range end
-    pfla_softmax_learn_x: bool  = False     # learn knot x‑positions?
-    pfla_softmax_learn_y: bool  = True      # learn √y values?
-    pfla_softmax_init_activation: str = "gelu"   # reference curve for init
-    pfla_softmax_density: str = "linear"    # linear | quad | exp
+    pfla_softmax_learn_x: bool = False  # learn knot x‑positions?
+    pfla_softmax_learn_y: bool = True  # learn √y values?
+    pfla_softmax_init_activation: str = "gelu"  # reference curve for init
+    pfla_softmax_density: str = "linear"  # linear | quad | exp
 
     ### normalisation extras
     pfla_softmax_use_learned_divisor: bool = False
-    pfla_softmax_gamma_init: float  = 1.0   # γ initial value iff learned
+    pfla_softmax_gamma_init: float = 1.0  # γ initial value iff learned
 
-    pfla_softmax_use_obo: bool = False # enables obo feature
-    pfla_softmax_use_learned_obo: bool = False # we require "use_obo" before use_learned_obo
-    pfla_softmax_obo: float = 0.0           # fixed or initial OBO (+1) addend
+    pfla_softmax_use_obo: bool = False  # enables obo feature
+    pfla_softmax_use_learned_obo: bool = (
+        False  # we require "use_obo" before use_learned_obo
+    )
+    pfla_softmax_obo: float = 0.0  # fixed or initial OBO (+1) addend
 
     ### interpolation mode
-    pfla_softmax_mode: str = "linear"       # "linear" | "quadratic"
+    pfla_softmax_mode: str = "linear"  # "linear" | "quadratic"
     # ──────────────────────────────────────────────────────────────────────
 
     # Positional Embeddings Variations
-    use_abs_pos_embeddings: bool = True # Note: one can use this AND rotary embeddings
+    use_abs_pos_embeddings: bool = True  # Note: one can use this AND rotary embeddings
     use_fire_embeddings: bool = False
     shared_fire_embeddings: bool = False
     use_rotary_embeddings: bool = False
     sym_rot_num_angles: int = 512
-    rope_variant: str = "rope" # options: "shortrope", "rope"
-    rope_length: int = 8 # number of embeddings to use in shortrope
+    rope_variant: str = "rope"  # options: "shortrope", "rope"
+    rope_length: int = 8  # number of embeddings to use in shortrope
 
     ## Embedding Intialization Options
-    embedding_mean_init: float= 0.0
-    embedding_std_init: float= 0.02
+    embedding_mean_init: float = 0.0
+    embedding_std_init: float = 0.02
 
     ## FIRE Options (Functional Interpolation for Relative Positional Encoding)
     fire_log_bias: float = 1.0
@@ -316,19 +327,21 @@ class GPTConfig:
     # Layernorm Alternatives and Options
     norm_variant_attn: str = "rmsnorm"
     norm_variant_output: str = "rmsnorm"
-    bias: bool = False # True: bias in Linears and LayerNorms, like GPT-2. False: a bit better and faster
+    bias: bool = (
+        False  # True: bias in Linears and LayerNorms, like GPT-2. False: a bit better and faster
+    )
     prmsnorm_pct: float = 0.0625
     krmsnorm_num: float = 10
-    krmsnorm_quantize_type: str = 'int8'
+    krmsnorm_quantize_type: str = "int8"
     krmsnorm_enable_gain: bool = True
-    krmsnorm_selection_type: str = 'last'
+    krmsnorm_selection_type: str = "last"
     krmsnorm_recompute_percentage: float = 0.05
     hsnorm_gain: bool = False
     hsnorm_radius: float = 1.0
     hsnorm_radius_learning: bool = False
 
     dact_alpha_init: float = 1.0
-    dact_activation: str = 'tanh'
+    dact_activation: str = "tanh"
     dact_use_gamma: bool = True
     dact_use_beta: bool = True
     dact_use_alpha: bool = True
@@ -355,7 +368,6 @@ class GPTConfig:
     ## LearnedSplineActivation - lsa
     lsa_num_knots: int = 30
 
-
     # Linear Alternatives
     linear_variant_attn: str = "linear"
     linear_variant_mlp: str = "linear"
@@ -367,8 +379,8 @@ class GPTConfig:
     linear_variant_mlp_down: str = None
 
     ## Linear Initialization Options
-    linear_mean_init: float= 0.0
-    linear_std_init: float= 0.02
+    linear_mean_init: float = 0.0
+    linear_std_init: float = 0.02
 
     ## Embedding initialization options
     init_variant: str = "gaussian"
@@ -376,7 +388,7 @@ class GPTConfig:
     init_wte_npy: str = "wte.npy"
     init_radius: float = 1.0
     gaussian_min_norm: float = 0.0
-    gaussian_max_norm: float = float('inf')
+    gaussian_max_norm: float = float("inf")
 
     # Quantizations
     start_quant_level: float = 0
@@ -445,7 +457,7 @@ class GPTConfig:
     @classmethod
     def from_json(cls, filename: str):
         try:
-            with open(filename, 'r') as json_file:
+            with open(filename, "r") as json_file:
                 config_dict = json.load(json_file)
 
             # Get all field names of the dataclass
@@ -476,6 +488,5 @@ class GPTConfig:
         """
         conf_dict = asdict(self)
 
-        with open(filename, 'w') as json_file:
+        with open(filename, "w") as json_file:
             json.dump(conf_dict, json_file)
-

--- a/variations/mlp_variations.py
+++ b/variations/mlp_variations.py
@@ -8,6 +8,7 @@ from variations.linear_variations import linear_dictionary
 from quantization.quantize import fake_quantize_act
 from quantization.quant_utils import set_variant, create_activation_buffers
 
+
 class OriginalMLP(nn.Module):
     def __init__(self, config):
         super().__init__()
@@ -21,40 +22,76 @@ class OriginalMLP(nn.Module):
         self.quant_scheduler = config.quant_scheduler
 
         # Select activation variant
-        self.activation_variant = activation_dictionary[config.activation_variant](config=config)
+        self.activation_variant = activation_dictionary[config.activation_variant](
+            config=config
+        )
 
         # Add learnable or fixed offsets for the activation function
         if config.learn_mlp_x_offset:
             self.activation_x_offset = nn.Parameter(torch.tensor(config.mlp_x_offset))
         else:
-            self.register_buffer("activation_x_offset", torch.tensor(config.mlp_x_offset))
+            self.register_buffer(
+                "activation_x_offset", torch.tensor(config.mlp_x_offset)
+            )
 
         if config.learn_mlp_y_offset:
             self.activation_y_offset = nn.Parameter(torch.tensor(config.mlp_y_offset))
         else:
-            self.register_buffer("activation_y_offset", torch.tensor(config.mlp_y_offset))
+            self.register_buffer(
+                "activation_y_offset", torch.tensor(config.mlp_y_offset)
+            )
 
         # Sets the class of linear for MLP
-        self.linear_variant_mlp_up = linear_dictionary[set_variant(config.linear_variant_mlp_up, config.linear_variant_mlp)]
-        self.linear_variant_mlp_down = linear_dictionary[set_variant(config.linear_variant_mlp_down, config.linear_variant_mlp)]
+        self.linear_variant_mlp_up = linear_dictionary[
+            set_variant(config.linear_variant_mlp_up, config.linear_variant_mlp)
+        ]
+        self.linear_variant_mlp_down = linear_dictionary[
+            set_variant(config.linear_variant_mlp_down, config.linear_variant_mlp)
+        ]
 
         self.quantization_mlp_dict = {}
-        self.quantization_mlp_dict["activations_quant_method"] = config.activations_quant_method
+        self.quantization_mlp_dict["activations_quant_method"] = (
+            config.activations_quant_method
+        )
 
         # Set quantization parameters for MLP
         for arg, val in vars(config).items():
             # Set MLP Activation precision and quantization method
-            if arg.startswith("quantize_") and "mlp_act" in arg and arg.endswith("_bits"):
-                self.quantization_mlp_dict[arg] = set_variant(val, config.quantize_mlp_act_bits)
+            if (
+                arg.startswith("quantize_")
+                and "mlp_act" in arg
+                and arg.endswith("_bits")
+            ):
+                self.quantization_mlp_dict[arg] = set_variant(
+                    val, config.quantize_mlp_act_bits
+                )
             elif arg.startswith("quantize_") and "mlp_act" in arg:
-                self.quantization_mlp_dict[arg] = set_variant(val, config.quantize_mlp_act)
-                if config.store_activations and arg != "quantize_mlp_act" and self.quantization_mlp_dict[arg]:
+                self.quantization_mlp_dict[arg] = set_variant(
+                    val, config.quantize_mlp_act
+                )
+                if (
+                    config.store_activations
+                    and arg != "quantize_mlp_act"
+                    and self.quantization_mlp_dict[arg]
+                ):
                     create_activation_buffers(self, arg)
             # Set MLP Linear Weight precision and quantization method
-            elif arg.startswith("quantize_") and "linear_mlp" in arg and arg.endswith("_bits"):
-                self.quantization_mlp_dict[arg] = set_variant(val, config.quantize_linear_bits)
-            elif arg.startswith("quantize_") and "linear_mlp" in arg and arg.endswith("_method"):
-                self.quantization_mlp_dict[arg] = set_variant(val, config.quantize_linear_method)
+            elif (
+                arg.startswith("quantize_")
+                and "linear_mlp" in arg
+                and arg.endswith("_bits")
+            ):
+                self.quantization_mlp_dict[arg] = set_variant(
+                    val, config.quantize_linear_bits
+                )
+            elif (
+                arg.startswith("quantize_")
+                and "linear_mlp" in arg
+                and arg.endswith("_method")
+            ):
+                self.quantization_mlp_dict[arg] = set_variant(
+                    val, config.quantize_linear_method
+                )
 
         mlp_expansion_size = None
         if config.mlp_size is not None:
@@ -63,8 +100,12 @@ class OriginalMLP(nn.Module):
             mlp_expansion_size = config.mlp_expansion_factor * config.n_embd
 
         # Determine bias settings - use specific up/down if set, otherwise use global bias
-        use_up_bias = config.mlp_up_bias if config.mlp_up_bias is not None else config.bias
-        use_down_bias = config.mlp_down_bias if config.mlp_down_bias is not None else config.bias
+        use_up_bias = (
+            config.mlp_up_bias if config.mlp_up_bias is not None else config.bias
+        )
+        use_down_bias = (
+            config.mlp_down_bias if config.mlp_down_bias is not None else config.bias
+        )
 
         # Instantiate Linear Layers with configurable bias
         self.c_fc = self.linear_variant_mlp_up(
@@ -73,7 +114,7 @@ class OriginalMLP(nn.Module):
             config,
             self.quantization_mlp_dict["quantize_linear_mlp_up_method"],
             self.quantization_mlp_dict["quantize_linear_mlp_up_bits"],
-            bias=use_up_bias
+            bias=use_up_bias,
         )
 
         # Fused down projection
@@ -93,23 +134,35 @@ class OriginalMLP(nn.Module):
         if self.quantization_mlp_dict["quantize_mlp_act_input"]:
             num_bits = self.quantization_mlp_dict["quantize_mlp_act_input_bits"]
             quant_method = self.quantization_mlp_dict["activations_quant_method"]
-            x = fake_quantize_act(self, "mlp_act_input", x, num_bits, quant_method, iter_num)
+            x = fake_quantize_act(
+                self, "mlp_act_input", x, num_bits, quant_method, iter_num
+            )
 
         x = self.c_fc(x)
 
         if self.quantization_mlp_dict["quantize_mlp_act_activation_input"]:
-            num_bits = self.quantization_mlp_dict["quantize_mlp_act_activation_input_bits"]
+            num_bits = self.quantization_mlp_dict[
+                "quantize_mlp_act_activation_input_bits"
+            ]
             quant_method = self.quantization_mlp_dict["activations_quant_method"]
-            x = fake_quantize_act(self, "mlp_act_activation_input", x, num_bits, quant_method, iter_num)
+            x = fake_quantize_act(
+                self, "mlp_act_activation_input", x, num_bits, quant_method, iter_num
+            )
 
         # Apply offsets to the activation function
-        x = self.activation_variant(x - self.activation_x_offset) - self.activation_y_offset
+        x = (
+            self.activation_variant(x - self.activation_x_offset)
+            - self.activation_y_offset
+        )
 
         if self.quantization_mlp_dict["quantize_mlp_act_activation_output"]:
-            num_bits = self.quantization_mlp_dict["quantize_mlp_act_activation_output_bits"]
+            num_bits = self.quantization_mlp_dict[
+                "quantize_mlp_act_activation_output_bits"
+            ]
             quant_method = self.quantization_mlp_dict["activations_quant_method"]
-            x = fake_quantize_act(self, "mlp_act_activation_output", x, num_bits, quant_method, iter_num)
-
+            x = fake_quantize_act(
+                self, "mlp_act_activation_output", x, num_bits, quant_method, iter_num
+            )
 
         # Apply fused down projection and sum the outputs
         x = self.c_proj(x)
@@ -123,8 +176,11 @@ class OriginalMLP(nn.Module):
         if self.quantization_mlp_dict["quantize_mlp_act_output"]:
             num_bits = self.quantization_mlp_dict["quantize_mlp_act_output_bits"]
             quant_method = self.quantization_mlp_dict["activations_quant_method"]
-            x = fake_quantize_act(self, "mlp_act_output", x, num_bits, quant_method, iter_num)
+            x = fake_quantize_act(
+                self, "mlp_act_output", x, num_bits, quant_method, iter_num
+            )
         return x
+
 
 class DualPathMLP(nn.Module):
     def __init__(self, config):
@@ -134,40 +190,76 @@ class DualPathMLP(nn.Module):
         self.eval_interval = config.eval_interval
 
         # Select activation variant
-        self.activation_variant = activation_dictionary[config.activation_variant](config=config)
+        self.activation_variant = activation_dictionary[config.activation_variant](
+            config=config
+        )
 
         # Dual path specific parameters
         if config.learn_mlp_x_offset:
             self.activation_x_offset = nn.Parameter(torch.tensor(config.mlp_x_offset))
         else:
-            self.register_buffer("activation_x_offset", torch.tensor(config.mlp_x_offset))
+            self.register_buffer(
+                "activation_x_offset", torch.tensor(config.mlp_x_offset)
+            )
 
         if config.learn_mlp_y_offset:
             self.activation_y_offset = nn.Parameter(torch.tensor(config.mlp_y_offset))
         else:
-            self.register_buffer("activation_y_offset", torch.tensor(config.mlp_y_offset))
+            self.register_buffer(
+                "activation_y_offset", torch.tensor(config.mlp_y_offset)
+            )
 
         # Sets the class of linear for MLP
-        self.linear_variant_mlp_up = linear_dictionary[set_variant(config.linear_variant_mlp_up, config.linear_variant_mlp)]
-        self.linear_variant_mlp_down = linear_dictionary[set_variant(config.linear_variant_mlp_down, config.linear_variant_mlp)]
+        self.linear_variant_mlp_up = linear_dictionary[
+            set_variant(config.linear_variant_mlp_up, config.linear_variant_mlp)
+        ]
+        self.linear_variant_mlp_down = linear_dictionary[
+            set_variant(config.linear_variant_mlp_down, config.linear_variant_mlp)
+        ]
 
         self.quantization_mlp_dict = {}
-        self.quantization_mlp_dict["activations_quant_method"] = config.activations_quant_method
+        self.quantization_mlp_dict["activations_quant_method"] = (
+            config.activations_quant_method
+        )
 
         # Set quantization parameters for MLP
         for arg, val in vars(config).items():
             # Set MLP Activation precision and quantization method
-            if arg.startswith("quantize_") and "mlp_act" in arg and arg.endswith("_bits"):
-                self.quantization_mlp_dict[arg] = set_variant(val, config.quantize_mlp_act_bits)
+            if (
+                arg.startswith("quantize_")
+                and "mlp_act" in arg
+                and arg.endswith("_bits")
+            ):
+                self.quantization_mlp_dict[arg] = set_variant(
+                    val, config.quantize_mlp_act_bits
+                )
             elif arg.startswith("quantize_") and "mlp_act" in arg:
-                self.quantization_mlp_dict[arg] = set_variant(val, config.quantize_mlp_act)
-                if config.store_activations and arg != "quantize_mlp_act" and self.quantization_mlp_dict[arg]:
+                self.quantization_mlp_dict[arg] = set_variant(
+                    val, config.quantize_mlp_act
+                )
+                if (
+                    config.store_activations
+                    and arg != "quantize_mlp_act"
+                    and self.quantization_mlp_dict[arg]
+                ):
                     create_activation_buffers(self, arg)
             # Set MLP Linear Weight precision and quantization method
-            elif arg.startswith("quantize_") and "linear_mlp" in arg and arg.endswith("_bits"):
-                self.quantization_mlp_dict[arg] = set_variant(val, config.quantize_linear_bits)
-            elif arg.startswith("quantize_") and "linear_mlp" in arg and arg.endswith("_method"):
-                self.quantization_mlp_dict[arg] = set_variant(val, config.quantize_linear_method)
+            elif (
+                arg.startswith("quantize_")
+                and "linear_mlp" in arg
+                and arg.endswith("_bits")
+            ):
+                self.quantization_mlp_dict[arg] = set_variant(
+                    val, config.quantize_linear_bits
+                )
+            elif (
+                arg.startswith("quantize_")
+                and "linear_mlp" in arg
+                and arg.endswith("_method")
+            ):
+                self.quantization_mlp_dict[arg] = set_variant(
+                    val, config.quantize_linear_method
+                )
 
         mlp_expansion_size = None
         if config.mlp_size is not None:
@@ -182,7 +274,7 @@ class DualPathMLP(nn.Module):
             config,
             self.quantization_mlp_dict["quantize_linear_mlp_up_method"],
             self.quantization_mlp_dict["quantize_linear_mlp_up_bits"],
-            bias=config.mlp_up_bias
+            bias=config.mlp_up_bias,
         )
 
         # Two separate projection layers for each activation path
@@ -192,7 +284,7 @@ class DualPathMLP(nn.Module):
             config,
             self.quantization_mlp_dict["quantize_linear_mlp_down_method"],
             self.quantization_mlp_dict["quantize_linear_mlp_down_bits"],
-            bias=config.mlp_down_bias
+            bias=config.mlp_down_bias,
         )
 
         self.c_proj2 = self.linear_variant_mlp_down(
@@ -201,7 +293,7 @@ class DualPathMLP(nn.Module):
             config,
             self.quantization_mlp_dict["quantize_linear_mlp_down_method"],
             self.quantization_mlp_dict["quantize_linear_mlp_down_bits"],
-            bias=config.mlp_down_bias
+            bias=config.mlp_down_bias,
         )
 
         self.dropout = nn.Dropout(config.dropout)
@@ -210,40 +302,59 @@ class DualPathMLP(nn.Module):
         if self.quantization_mlp_dict["quantize_mlp_act_input"]:
             num_bits = self.quantization_mlp_dict["quantize_mlp_act_input_bits"]
             quant_method = self.quantization_mlp_dict["activations_quant_method"]
-            x = fake_quantize_act(self, "mlp_act_input", x, num_bits, quant_method, iter_num)
+            x = fake_quantize_act(
+                self, "mlp_act_input", x, num_bits, quant_method, iter_num
+            )
 
         # Common upscale projection
         x = self.c_fc(x)
 
         if self.quantization_mlp_dict["quantize_mlp_act_activation_input"]:
-            num_bits = self.quantization_mlp_dict["quantize_mlp_act_activation_input_bits"]
+            num_bits = self.quantization_mlp_dict[
+                "quantize_mlp_act_activation_input_bits"
+            ]
             quant_method = self.quantization_mlp_dict["activations_quant_method"]
-            x = fake_quantize_act(self, "mlp_act_activation_input", x, num_bits, quant_method, iter_num)
+            x = fake_quantize_act(
+                self, "mlp_act_activation_input", x, num_bits, quant_method, iter_num
+            )
 
         # First activation path - shifted right
-        x1 = self.activation_variant(x - self.activation_x_offset) - self.activation_y_offset
+        x1 = (
+            self.activation_variant(x - self.activation_x_offset)
+            - self.activation_y_offset
+        )
         x1 = self.c_proj1(x1)
 
         # Second activation path - shifted left and negated input
-        x2 = -self.activation_variant(-(x + self.activation_x_offset)) - self.activation_y_offset
+        x2 = (
+            -self.activation_variant(-(x + self.activation_x_offset))
+            - self.activation_y_offset
+        )
         x2 = self.c_proj2(x2)
 
         # Combine paths
         x = x1 + x2
 
         if self.quantization_mlp_dict["quantize_mlp_act_activation_output"]:
-            num_bits = self.quantization_mlp_dict["quantize_mlp_act_activation_output_bits"]
+            num_bits = self.quantization_mlp_dict[
+                "quantize_mlp_act_activation_output_bits"
+            ]
             quant_method = self.quantization_mlp_dict["activations_quant_method"]
-            x = fake_quantize_act(self, "mlp_act_activation_output", x, num_bits, quant_method, iter_num)
+            x = fake_quantize_act(
+                self, "mlp_act_activation_output", x, num_bits, quant_method, iter_num
+            )
 
         x = self.dropout(x)
 
         if self.quantization_mlp_dict["quantize_mlp_act_output"]:
             num_bits = self.quantization_mlp_dict["quantize_mlp_act_output_bits"]
             quant_method = self.quantization_mlp_dict["activations_quant_method"]
-            x = fake_quantize_act(self, "mlp_act_output", x, num_bits, quant_method, iter_num)
+            x = fake_quantize_act(
+                self, "mlp_act_output", x, num_bits, quant_method, iter_num
+            )
 
         return x
+
 
 class Swiglu(nn.Module):
     def __init__(self, config):
@@ -257,40 +368,76 @@ class Swiglu(nn.Module):
         self.mlp_down_projs = config.mlp_down_projs
 
         # Select activation variant
-        self.activation_variant = activation_dictionary[config.activation_variant](config=config)
+        self.activation_variant = activation_dictionary[config.activation_variant](
+            config=config
+        )
 
         # Add learnable or fixed offsets for the activation function
         if config.learn_mlp_x_offset:
             self.activation_x_offset = nn.Parameter(torch.tensor(config.mlp_x_offset))
         else:
-            self.register_buffer("activation_x_offset", torch.tensor(config.mlp_x_offset))
+            self.register_buffer(
+                "activation_x_offset", torch.tensor(config.mlp_x_offset)
+            )
 
         if config.learn_mlp_y_offset:
             self.activation_y_offset = nn.Parameter(torch.tensor(config.mlp_y_offset))
         else:
-            self.register_buffer("activation_y_offset", torch.tensor(config.mlp_y_offset))
+            self.register_buffer(
+                "activation_y_offset", torch.tensor(config.mlp_y_offset)
+            )
 
         # Sets the class of linear for MLP
-        self.linear_variant_mlp_up = linear_dictionary[set_variant(config.linear_variant_mlp_up, config.linear_variant_mlp)]
-        self.linear_variant_mlp_down = linear_dictionary[set_variant(config.linear_variant_mlp_down, config.linear_variant_mlp)]
+        self.linear_variant_mlp_up = linear_dictionary[
+            set_variant(config.linear_variant_mlp_up, config.linear_variant_mlp)
+        ]
+        self.linear_variant_mlp_down = linear_dictionary[
+            set_variant(config.linear_variant_mlp_down, config.linear_variant_mlp)
+        ]
 
         self.quantization_mlp_dict = {}
-        self.quantization_mlp_dict["activations_quant_method"] = config.activations_quant_method
+        self.quantization_mlp_dict["activations_quant_method"] = (
+            config.activations_quant_method
+        )
 
         # Set quantization parameters for MLP
         for arg, val in vars(config).items():
             # Set MLP Activation precision and quantization method
-            if arg.startswith("quantize_") and "mlp_act" in arg and arg.endswith("_bits"):
-                self.quantization_mlp_dict[arg] = set_variant(val, config.quantize_mlp_act_bits)
+            if (
+                arg.startswith("quantize_")
+                and "mlp_act" in arg
+                and arg.endswith("_bits")
+            ):
+                self.quantization_mlp_dict[arg] = set_variant(
+                    val, config.quantize_mlp_act_bits
+                )
             elif arg.startswith("quantize_") and "mlp_act" in arg:
-                self.quantization_mlp_dict[arg] = set_variant(val, config.quantize_mlp_act)
-                if config.store_activations and arg != "quantize_mlp_act" and self.quantization_mlp_dict[arg]:
+                self.quantization_mlp_dict[arg] = set_variant(
+                    val, config.quantize_mlp_act
+                )
+                if (
+                    config.store_activations
+                    and arg != "quantize_mlp_act"
+                    and self.quantization_mlp_dict[arg]
+                ):
                     create_activation_buffers(self, arg)
             # Set MLP Linear Weight precision and quantization method
-            elif arg.startswith("quantize_") and "linear_mlp" in arg and arg.endswith("_bits"):
-                self.quantization_mlp_dict[arg] = set_variant(val, config.quantize_linear_bits)
-            elif arg.startswith("quantize_") and "linear_mlp" in arg and arg.endswith("_method"):
-                self.quantization_mlp_dict[arg] = set_variant(val, config.quantize_linear_method)
+            elif (
+                arg.startswith("quantize_")
+                and "linear_mlp" in arg
+                and arg.endswith("_bits")
+            ):
+                self.quantization_mlp_dict[arg] = set_variant(
+                    val, config.quantize_linear_bits
+                )
+            elif (
+                arg.startswith("quantize_")
+                and "linear_mlp" in arg
+                and arg.endswith("_method")
+            ):
+                self.quantization_mlp_dict[arg] = set_variant(
+                    val, config.quantize_linear_method
+                )
 
         mlp_expansion_size = None
         if config.mlp_size is not None:
@@ -299,8 +446,12 @@ class Swiglu(nn.Module):
             mlp_expansion_size = config.mlp_expansion_factor * config.n_embd
 
         # Determine bias settings - use specific up/down if set, otherwise use global bias
-        use_up_bias = config.mlp_up_bias if config.mlp_up_bias is not None else config.bias
-        use_down_bias = config.mlp_down_bias if config.mlp_down_bias is not None else config.bias
+        use_up_bias = (
+            config.mlp_up_bias if config.mlp_up_bias is not None else config.bias
+        )
+        use_down_bias = (
+            config.mlp_down_bias if config.mlp_down_bias is not None else config.bias
+        )
 
         # Instantiate Linear Layers with configurable bias
         self.c_fc_in1 = self.linear_variant_mlp_up(
@@ -309,7 +460,7 @@ class Swiglu(nn.Module):
             config,
             self.quantization_mlp_dict["quantize_linear_mlp_up_method"],
             self.quantization_mlp_dict["quantize_linear_mlp_up_bits"],
-            bias=use_up_bias
+            bias=use_up_bias,
         )
 
         self.c_fc_in2 = self.linear_variant_mlp_up(
@@ -318,7 +469,7 @@ class Swiglu(nn.Module):
             config,
             self.quantization_mlp_dict["quantize_linear_mlp_up_method"],
             self.quantization_mlp_dict["quantize_linear_mlp_up_bits"],
-            bias=use_up_bias
+            bias=use_up_bias,
         )
 
         # Fused down projection
@@ -338,21 +489,44 @@ class Swiglu(nn.Module):
         if self.quantization_mlp_dict["quantize_mlp_act_input"]:
             num_bits = self.quantization_mlp_dict["quantize_mlp_act_input_bits"]
             quant_method = self.quantization_mlp_dict["activations_quant_method"]
-            x = fake_quantize_act(self, "mlp_act_input", x, num_bits, quant_method, iter_num)
+            x = fake_quantize_act(
+                self, "mlp_act_input", x, num_bits, quant_method, iter_num
+            )
 
         x_in1 = self.c_fc_in1(x)
 
         if self.quantization_mlp_dict["quantize_mlp_act_activation_input"]:
-            num_bits = self.quantization_mlp_dict["quantize_mlp_act_activation_input_bits"]
+            num_bits = self.quantization_mlp_dict[
+                "quantize_mlp_act_activation_input_bits"
+            ]
             quant_method = self.quantization_mlp_dict["activations_quant_method"]
-            x_in1 = fake_quantize_act(self, "mlp_act_activation_input", x_in1, num_bits, quant_method, iter_num)
+            x_in1 = fake_quantize_act(
+                self,
+                "mlp_act_activation_input",
+                x_in1,
+                num_bits,
+                quant_method,
+                iter_num,
+            )
 
-        x_in1 = self.activation_variant(x_in1 - self.activation_x_offset) - self.activation_y_offset
+        x_in1 = (
+            self.activation_variant(x_in1 - self.activation_x_offset)
+            - self.activation_y_offset
+        )
 
         if self.quantization_mlp_dict["quantize_mlp_act_activation_output"]:
-            num_bits = self.quantization_mlp_dict["quantize_mlp_act_activation_output_bits"]
+            num_bits = self.quantization_mlp_dict[
+                "quantize_mlp_act_activation_output_bits"
+            ]
             quant_method = self.quantization_mlp_dict["activations_quant_method"]
-            x_in1 = fake_quantize_act(self, "mlp_act_activation_output", x_in1, num_bits, quant_method, iter_num)
+            x_in1 = fake_quantize_act(
+                self,
+                "mlp_act_activation_output",
+                x_in1,
+                num_bits,
+                quant_method,
+                iter_num,
+            )
 
         x_in2 = self.c_fc_in2(x)
         x_out = x_in1 * x_in2
@@ -369,8 +543,142 @@ class Swiglu(nn.Module):
         if self.quantization_mlp_dict["quantize_mlp_act_output"]:
             num_bits = self.quantization_mlp_dict["quantize_mlp_act_output_bits"]
             quant_method = self.quantization_mlp_dict["activations_quant_method"]
-            x = fake_quantize_act(self, "mlp_act_output", x, num_bits, quant_method, iter_num)
+            x = fake_quantize_act(
+                self, "mlp_act_output", x, num_bits, quant_method, iter_num
+            )
         return x
+
+
+class FireMLP(nn.Module):
+    """An MLP variation that replaces the standard activation and down projection
+    with a shared, element-wise feed-forward network. After the initial
+    projection, each element is independently expanded by a small MLP. The
+    outputs of these per-element networks are summed to form the final vector.
+    """
+
+    def __init__(self, config):
+        super().__init__()
+
+        self.full_quant_iteration = config.full_quant_iteration
+        self.eval_interval = config.eval_interval
+
+        # Select activation variant for the inner "fire" MLP
+        self.activation_variant = activation_dictionary[config.activation_variant](
+            config=config
+        )
+
+        # Sets the class of linear for the initial projection
+        self.linear_variant_mlp_up = linear_dictionary[
+            set_variant(config.linear_variant_mlp_up, config.linear_variant_mlp)
+        ]
+
+        self.quantization_mlp_dict = {}
+        self.quantization_mlp_dict["activations_quant_method"] = (
+            config.activations_quant_method
+        )
+
+        for arg, val in vars(config).items():
+            if (
+                arg.startswith("quantize_")
+                and "mlp_act" in arg
+                and arg.endswith("_bits")
+            ):
+                self.quantization_mlp_dict[arg] = set_variant(
+                    val, config.quantize_mlp_act_bits
+                )
+            elif arg.startswith("quantize_") and "mlp_act" in arg:
+                self.quantization_mlp_dict[arg] = set_variant(
+                    val, config.quantize_mlp_act
+                )
+                if (
+                    config.store_activations
+                    and arg != "quantize_mlp_act"
+                    and self.quantization_mlp_dict[arg]
+                ):
+                    create_activation_buffers(self, arg)
+            elif (
+                arg.startswith("quantize_")
+                and "linear_mlp" in arg
+                and arg.endswith("_bits")
+            ):
+                self.quantization_mlp_dict[arg] = set_variant(
+                    val, config.quantize_linear_bits
+                )
+            elif (
+                arg.startswith("quantize_")
+                and "linear_mlp" in arg
+                and arg.endswith("_method")
+            ):
+                self.quantization_mlp_dict[arg] = set_variant(
+                    val, config.quantize_linear_method
+                )
+
+        mlp_expansion_size = (
+            config.mlp_size
+            if config.mlp_size is not None
+            else config.mlp_expansion_factor * config.n_embd
+        )
+
+        use_up_bias = (
+            config.mlp_up_bias if config.mlp_up_bias is not None else config.bias
+        )
+        self.c_fc = self.linear_variant_mlp_up(
+            config.n_embd,
+            mlp_expansion_size,
+            config,
+            self.quantization_mlp_dict["quantize_linear_mlp_up_method"],
+            self.quantization_mlp_dict["quantize_linear_mlp_up_bits"],
+            bias=use_up_bias,
+        )
+
+        # Shared small MLP applied to every element of the expanded vector
+        self.fire_hidden_size = (
+            config.fire_mlp_hidden
+            if config.fire_mlp_hidden is not None
+            else config.n_embd
+        )
+        self.fire_expand = nn.Linear(1, self.fire_hidden_size)
+        self.fire_project = nn.Linear(self.fire_hidden_size, config.n_embd)
+
+        self.dropout = nn.Dropout(config.dropout)
+
+    def forward(self, x, iter_num=None):
+        if self.quantization_mlp_dict["quantize_mlp_act_input"]:
+            num_bits = self.quantization_mlp_dict["quantize_mlp_act_input_bits"]
+            quant_method = self.quantization_mlp_dict["activations_quant_method"]
+            x = fake_quantize_act(
+                self, "mlp_act_input", x, num_bits, quant_method, iter_num
+            )
+
+        x = self.c_fc(x)
+
+        if self.quantization_mlp_dict["quantize_mlp_act_activation_input"]:
+            num_bits = self.quantization_mlp_dict[
+                "quantize_mlp_act_activation_input_bits"
+            ]
+            quant_method = self.quantization_mlp_dict["activations_quant_method"]
+            x = fake_quantize_act(
+                self, "mlp_act_activation_input", x, num_bits, quant_method, iter_num
+            )
+
+        # Apply the shared per-element fire MLP
+        x = x.unsqueeze(-1)  # (B, T, M, 1)
+        x = self.fire_expand(x)
+        x = self.activation_variant(x)
+        x = self.fire_project(x)
+        x = x.sum(dim=2)
+
+        x = self.dropout(x)
+
+        if self.quantization_mlp_dict["quantize_mlp_act_output"]:
+            num_bits = self.quantization_mlp_dict["quantize_mlp_act_output_bits"]
+            quant_method = self.quantization_mlp_dict["activations_quant_method"]
+            x = fake_quantize_act(
+                self, "mlp_act_output", x, num_bits, quant_method, iter_num
+            )
+
+        return x
+
 
 class KanMLP(nn.Module):
     def __init__(self, config):
@@ -386,6 +694,7 @@ class KanMLP(nn.Module):
 
         return x
 
+
 class MLP_Identity(nn.Module):
     def __init__(self, config):
         super(Identity, self).__init__()
@@ -393,13 +702,16 @@ class MLP_Identity(nn.Module):
     def forward(self, x, iter_num=None):
         return x
 
+
 mlp_dictionary = {
     "mlp": OriginalMLP,
     "swiglu": Swiglu,
+    "fire": FireMLP,
     "identity": MLP_Identity,
     "kan": KanMLP,
-    "dual_path": DualPathMLP
-    }
+    "dual_path": DualPathMLP,
+}
+
 
 def get_mlp_instance(config):
     mlp_type = config.mlp_variant
@@ -407,4 +719,3 @@ def get_mlp_instance(config):
     if mlp_class is None:
         raise ValueError(f"Unsupported MLP variant: {mlp_type}")
     return mlp_class(config)
-


### PR DESCRIPTION
## Summary
- add `FireMLP` variation that expands each intermediate element through a shared MLP and sums the results
- expose `fire_mlp_hidden` option in `GPTConfig`

## Testing
- `python -m black variations/mlp_variations.py gpt_conf.py`
- `pytest` *(fails: No module named 'jamo'; No module named 'yakinori')*


------
https://chatgpt.com/codex/tasks/task_e_689a01c338e883269786c291af0716b2