### PR TITLE
Skip data scripts without optional deps

### DIFF
--- a/data/korean-parallel-corpora/korean_jamo_conversion_test.py
+++ b/data/korean-parallel-corpora/korean_jamo_conversion_test.py
@@ -1,3 +1,6 @@
+import pytest
+
+pytest.importorskip("jamo")
 from jamo import h2j, j2hcj, j2h, is_jamo
 
 def korean_to_phonetic(text):

--- a/data/opus-100/yakinori_test.py
+++ b/data/opus-100/yakinori_test.py
@@ -1,3 +1,6 @@
+import pytest
+
+pytest.importorskip("yakinori")
 from yakinori import Yakinori
 yakinori = Yakinori()
 sentence = "幽遊白書は最高の漫画です"


### PR DESCRIPTION
## Summary
- skip `korean_jamo_conversion_test` when `jamo` isn't installed
- skip `yakinori_test` when `yakinori` isn't installed

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897b318df6083269cdd9c98655c9d98