### PR TITLE
Add sequential KV cache sharing

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -185,6 +185,15 @@ class GPTConfig:
     shared_attn_sym: bool = False
     shared_attn_seq: int = 1
 
+    # KV-cache sharing options
+    # None    -> each layer has its own cache (default)
+    # "group"   -> share cache every `kv_cache_group_size` sequential layers
+    # "cycle"   -> cycle through `kv_cache_num_slots` caches (e.g. a b c a b c)
+    # "symmetric" -> up-then-down pattern (e.g. a a b b a a)
+    kv_cache_sharing: str | None = None
+    kv_cache_group_size: int = 1
+    kv_cache_num_slots: int = 1
+
     # Softmax Alternatives and Options
     softmax_variant_attn: str = "softmax" # Choices: "softmax" "softermax" "sigsoftmax" "polymax" "strongermax" "consmax"
     softmax_variant_output: str = "softmax" # Choices: "softmax" "softermax" "sigsoftmax" "polymax" "strongermax" "consmax"


### PR DESCRIPTION
## Summary
- allow configuring KV-cache sharing patterns (group, cycle, symmetric)
- wire GPT and Block to route shared KV caches across layers

## Testing
- `bash tests/test_gradient_checkpointing_cpu.sh` *(fails: bash: data/shakespeare_char/get_dataset.sh: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689ff53438cc8326a1621acce4ab7bd7