### PR TITLE
Add character tokenizer with byte fallback

### DIFF
--- a/data/template/prepare.py
+++ b/data/template/prepare.py
@@ -8,6 +8,7 @@ from tokenizers import (
     TiktokenTokenizer,
     CustomTokenizer,
     CharTokenizer,
+    CharTokenizerWithByteFallback,
     CustomCharTokenizerWithByteFallback,
     JsonByteTokenizerWithByteFallback,
 )
@@ -26,7 +27,7 @@ def parse_arguments():
 
     # Tokenizer selection and configuration
     parser.add_argument("--method", type=str,
-                       choices=["sentencepiece", "tiktoken", "char", "custom", "custom_char_byte_fallback", "json_byte_fallback"],
+                       choices=["sentencepiece", "tiktoken", "char", "char_byte_fallback", "custom", "custom_char_byte_fallback", "json_byte_fallback"],
                        default="tiktoken", help="Tokenization method")
 
     # SentencePiece arguments
@@ -44,6 +45,14 @@ def parse_arguments():
 
     # Char tokenizer arguments
     parser.add_argument("--reuse_chars", action="store_true", help="Reuse character list from meta.pkl")
+    parser.add_argument("--char_vocab_limit", type=int, default=None,
+                       help="Maximum number of non-byte characters to keep for char_byte_fallback tokenizer")
+    parser.add_argument("--char_coverage", type=float, default=None,
+                       help="Target fraction of data to cover with char vocab before falling back to bytes")
+    parser.add_argument("--char_freq_cache", type=str, default="char_freqs.json",
+                       help="Path to cache file for character frequencies")
+    parser.add_argument("--char_hist_file", type=str, default="char_freq_hist.png",
+                       help="Path to save histogram of character frequencies")
 
     # Custom tokenizer arguments
     parser.add_argument("--tokens_file", type=str, default=None, help="Path to the file containing newline-separated tokens for tokenization")
@@ -92,6 +101,8 @@ def main():
         tokenizer = CustomTokenizer(args)
     elif args.method == "char":
         tokenizer = CharTokenizer(args, train_data, val_data)
+    elif args.method == "char_byte_fallback":
+        tokenizer = CharTokenizerWithByteFallback(args, train_data, val_data)
     elif args.method == "custom_char_byte_fallback":
         tokenizer = CustomCharTokenizerWithByteFallback(args)
     elif args.method == "json_byte_fallback":

--- a/data/template/tests.py
+++ b/data/template/tests.py
@@ -11,6 +11,7 @@ from tokenizers import (
     TiktokenTokenizer,
     CustomTokenizer,
     CharTokenizer,
+    CharTokenizerWithByteFallback,
     CustomCharTokenizerWithByteFallback,
     JsonByteTokenizerWithByteFallback,
 )
@@ -107,6 +108,10 @@ class TestTokenizers(unittest.TestCase):
             os.remove("meta.pkl")
         if os.path.exists("remaining.txt"):
             os.remove("remaining.txt")
+        if os.path.exists("char_freqs.json"):
+            os.remove("char_freqs.json")
+        if os.path.exists("char_freq_hist.png"):
+            os.remove("char_freq_hist.png")
 
     # --------------------------------------------------------------------------
     # Helper Method to Print Token Count Histogram
@@ -194,6 +199,25 @@ class TestTokenizers(unittest.TestCase):
     def test_char_tokenizer(self):
         args = Namespace(reuse_chars=False)
         tokenizer = CharTokenizer(args, self.sample_text, None)
+        ids = tokenizer.tokenize(self.sample_text)
+        detokenized = tokenizer.detokenize(ids)
+
+        console.print("[input]Input:[/input]")
+        console.print(self.sample_text, style="input")
+        console.print("[output]Detokenized Output:[/output]")
+        console.print(detokenized, style="output")
+
+        self.assertEqual(self.sample_text, detokenized)
+
+    def test_char_tokenizer_with_byte_fallback(self):
+        args = Namespace(
+            reuse_chars=False,
+            char_vocab_limit=5,
+            char_coverage=0.8,
+            char_freq_cache="char_freqs.json",
+            char_hist_file="char_freq_hist.png",
+        )
+        tokenizer = CharTokenizerWithByteFallback(args, self.sample_text, None)
         ids = tokenizer.tokenize(self.sample_text)
         detokenized = tokenizer.detokenize(ids)
 


### PR DESCRIPTION
## Summary
- refine char-byte tokenizer to sort by frequency, select by vocab limit or coverage, and cache character stats
- expose new `--char_coverage`, `--char_freq_cache`, and `--char_hist_file` options in `prepare.py`
- integrate char-byte fallback support into `sample.py`
- update tests for the revised tokenizer options

## Testing
- `python data/template/tests.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'jamo', 'yakinori')*

------
https://chatgpt.com/codex/tasks/task_e_68a16d9b67848326b1b9f367a972bdcc