### PR TITLE
Add early exit routers for optional layer skipping

### DIFF
--- a/explorations/early_exit_router.yaml
+++ b/explorations/early_exit_router.yaml
@@ -1,0 +1,26 @@
+# early_exit_router.yaml
+---
+# base hyperparameters
+max_iters: [20000]
+n_layer: [6]
+n_head: [6]
+n_embd: [384]
+eval_interval: [500]
+block_size: [256]
+device: ["cuda"]
+dataset: ["minipile"]
+dtype: ["float16"]
+compile: [true]
+
+# parameter groups comparing conventional model vs early exit routers
+parameter_groups:
+  - use_early_exit: [false]
+  - use_early_exit: [true]
+    early_exit_router_variant: ["random"]
+    early_exit_prob: [0.1]
+  - use_early_exit: [true]
+    early_exit_router_variant: ["linear"]
+    early_exit_threshold: [0.5]
+  - use_early_exit: [true]
+    early_exit_router_variant: ["norm"]
+    early_exit_norm_threshold: [10.0]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -136,6 +136,13 @@ class GPTConfig:
     moe_top_k: int = 2
     moe_router_scheme: str = "softmax"
 
+    # Early exit routing
+    use_early_exit: bool = False
+    early_exit_router_variant: str = "random"
+    early_exit_threshold: float = 0.5
+    early_exit_prob: float = 0.0
+    early_exit_norm_threshold: float = 1e9
+
     # Logging options
     softmax_io_logging: bool = False
     consmax_beta_gamma_logging: bool = False

--- a/train_args.py
+++ b/train_args.py
@@ -371,6 +371,18 @@ def parse_args():
     model_group.add_argument('--n_experts', default=8, type=int, help="set number of experts per MoE layer")
     model_group.add_argument('--moe_top_k', default=2, type=int)
     model_group.add_argument('--moe_router_scheme', default="softmax", type=str, help="option to set routing scheme for MoE layer, defaults to softmax")
+
+    # Early exit routing
+    model_group.add_argument('--use_early_exit', default=False, action=argparse.BooleanOptionalAction,
+                             help='Enable early exit after each transformer block')
+    model_group.add_argument('--early_exit_router_variant', default='random', type=str,
+                             help='Router variant for early exit decisions')
+    model_group.add_argument('--early_exit_threshold', default=0.5, type=float,
+                             help='Threshold for linear early exit router')
+    model_group.add_argument('--early_exit_prob', default=0.0, type=float,
+                             help='Exit probability for random early exit router')
+    model_group.add_argument('--early_exit_norm_threshold', default=1e9, type=float,
+                             help='Norm threshold for norm-based early exit router')
     model_group.add_argument('--use_flex_attn', default=None,  action=argparse.BooleanOptionalAction, help="option for using flex attention for sliding windows")
     model_group.add_argument('--attn_logit_softcapping', default=None, action=argparse.BooleanOptionalAction, help="option for softcapping attention (before masking)")
     model_group.add_argument('--final_logit_softcapping', default=None, action=argparse.BooleanOptionalAction, help="option for softcapping final logits")

--- a/variations/early_exit_router_variants.py
+++ b/variations/early_exit_router_variants.py
@@ -1,0 +1,44 @@
+# variations/early_exit_router_variants.py
+import torch
+import torch.nn as nn
+
+
+class RandomRouter(nn.Module):
+    """Router that exits with a fixed probability."""
+    def __init__(self, config):
+        super().__init__()
+        self.exit_prob = getattr(config, 'early_exit_prob', 0.0)
+
+    def forward(self, x: torch.Tensor) -> bool:
+        return torch.rand(1, device=x.device).item() < self.exit_prob
+
+
+class LinearRouter(nn.Module):
+    """Learns a score and exits if it exceeds a threshold."""
+    def __init__(self, config):
+        super().__init__()
+        self.linear = nn.Linear(config.n_embd, 1)
+        self.threshold = getattr(config, 'early_exit_threshold', 0.5)
+
+    def forward(self, x: torch.Tensor) -> bool:
+        score = self.linear(x.mean(dim=1))
+        prob = torch.sigmoid(score)
+        return prob.mean().item() > self.threshold
+
+
+class NormRouter(nn.Module):
+    """Exits when the mean L2 norm of activations exceeds a threshold."""
+    def __init__(self, config):
+        super().__init__()
+        self.threshold = getattr(config, 'early_exit_norm_threshold', 1e9)
+
+    def forward(self, x: torch.Tensor) -> bool:
+        norm = x.norm(dim=-1).mean()
+        return norm.item() > self.threshold
+
+
+early_exit_router_dictionary = {
+    'random': RandomRouter,
+    'linear': LinearRouter,
+    'norm': NormRouter,
+}


### PR DESCRIPTION
## Summary
- add norm-based early exit router alongside random and linear variants
- expose norm threshold arg and config for norm router
- include exploration config comparing early exit routers against baseline on minipile

## Testing
- `python -m py_compile model.py variations/early_exit_router_variants.py gpt_conf.py train_args.py`
- `MECABRC=/etc/mecabrc pytest -q` *(fails: ModuleNotFoundError: No module named 'jamo', 'yakinori')*

------
https://chatgpt.com/codex/tasks/task_e_68a2766e5ab883268c06c12ca4dfa641