### PR TITLE
add gradient-noise-scale feedback controllers

### DIFF
--- a/train.py
+++ b/train.py
@@ -63,8 +63,14 @@ from rich.progress import (
 
 # GNS Related
 import utils.gns_monitoring.gns_utils as gns_utils
-from utils.gns_monitoring.hook import (add_hooks_to_model, add_sogns_hooks,
-                   add_exact_hooks,  gather_hook_results)
+from utils.gns_monitoring.hook import (
+    add_hooks_to_model,
+    add_sogns_hooks,
+    add_exact_hooks,
+    gather_hook_results,
+)
+
+from train_variations.gns_variants import gns_feedback_dictionary
 
 import numpy as np
 
@@ -356,11 +362,12 @@ class Trainer:
             add_hooks_to_model(self.model, get_gns_fn[self.args.gns_type])
             ema_beta = self.args.gns_ema_beta
             self.gns_ema = gns_utils.EMA(beta=ema_beta)
-
             # Initialize GNS for later
             self.gns = None
 
-
+        
+        # controller for GNS-driven batch-size feedback
+        self.gns_controller = gns_feedback_dictionary[self.args.gns_variant](self.args)
         # Get Model Size
         self.model.num_param = self.model.get_num_params(non_embedding=False)
 
@@ -805,12 +812,7 @@ class Trainer:
             data = self.train_data if split == 'train' else self.val_data
 
         # Adaptive GNS settings
-        if (self.gns is not None) and (self.args.gns_target is not None):
-            if self.gns < self.args.gns_target:
-                if self.args.batch_size < self.args.gns_max_batch:
-                    self.args.batch_size = math.ceil(self.args.batch_size * (1.0 + self.args.gns_batch_pct))
-            if self.gns > self.args.gns_target:
-                self.args.batch_size = math.ceil(self.args.batch_size * (1.0 - self.args.gns_batch_pct))
+        self.gns_controller.update(self)
 
         # Generate random indices for the batch
         ix = torch.randint(len(data) - self.args.block_size, (self.args.batch_size,))

--- a/train_args.py
+++ b/train_args.py
@@ -3,6 +3,8 @@ import argparse
 import math
 import re
 
+from train_variations.gns_variants import gns_feedback_dictionary
+
 def clean_dataset_path(dataset_name):
     """Removes leading './data/' or 'data/' from dataset paths."""
     return re.sub(r'^(?:\./)?data/', '', dataset_name)
@@ -118,6 +120,11 @@ def parse_args():
     training_group.add_argument('--gns_target', type=float, default=None)
     training_group.add_argument('--gns_max_batch', type=int, default=100)
     training_group.add_argument('--gns_batch_pct', type=float, default=0.2)
+    training_group.add_argument('--gns_variant', type=str, default='none', choices=list(gns_feedback_dictionary.keys()),
+                                help='Strategy for adjusting batch size using gradient noise scale feedback')
+    training_group.add_argument('--gns_pid_kp', type=float, default=0.1, help='PID proportional gain')
+    training_group.add_argument('--gns_pid_ki', type=float, default=0.0, help='PID integral gain')
+    training_group.add_argument('--gns_pid_kd', type=float, default=0.0, help='PID derivative gain')
 
 
     # Optimizer-specific arguments

--- a/train_variations/gns_variants.py
+++ b/train_variations/gns_variants.py
@@ -1,0 +1,145 @@
+"""train_variations/gns_variants.py
+
+Controllers that adjust training behavior based on the measured
+Gradient Noise Scale (GNS).  The design mirrors the optimizer
+variant helpers and exposes a dictionary so that different feedback
+strategies can be selected from the command line.
+
+Each controller is initialized with the full ``args`` namespace and
+provides an ``update(trainer)`` method.  The trainer instance carries
+state such as the current GNS estimate, batch size and learning rate.
+The controller is free to manipulate ``trainer.args`` to implement a
+particular feedback rule.
+
+The variants below are inspired by the analysis in
+"An Empirical Model of Large-Batch Training" (McCandlish et al. 2018)
+and "Efficient and Approximate Per-Example Gradient Norms for Gradient
+Noise Scale" (Gray et al. 2023).  They demonstrate a spectrum of
+schemes for keeping the GNS near a desired target and for coupling the
+batch size with the learning rate to maintain a stable training
+"temperature".
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+@dataclass
+class _BaseController:
+    args: any
+
+    def update(self, trainer) -> None:  # pragma: no cover - interface
+        """Adjust training hyper-parameters based on trainer.gns."""
+        raise NotImplementedError
+
+
+@dataclass
+class _NullController(_BaseController):
+    """No-op controller – leaves the batch size untouched."""
+
+    def update(self, trainer) -> None:  # pragma: no cover - trivial
+        return
+
+
+@dataclass
+class _ProportionalController(_BaseController):
+    """Simple proportional controller.
+
+    Replicates the previous heuristic: if the measured GNS falls below
+    the target, increase the batch size by ``gns_batch_pct`` (capped by
+    ``gns_max_batch``); if it rises above the target, decrease it by the
+    same percentage.
+    """
+
+    def update(self, trainer) -> None:
+        gns = trainer.gns
+        target = self.args.gns_target
+        if gns is None or target is None:
+            return
+        pct = self.args.gns_batch_pct
+        max_batch = self.args.gns_max_batch
+        if gns < target and trainer.args.batch_size < max_batch:
+            trainer.args.batch_size = math.ceil(trainer.args.batch_size * (1.0 + pct))
+        elif gns > target:
+            trainer.args.batch_size = max(1, math.ceil(trainer.args.batch_size * (1.0 - pct)))
+
+
+@dataclass
+class _DoublingController(_BaseController):
+    """Binary doubling/halving strategy.
+
+    When GNS is below the target, double the batch size until
+    ``gns_max_batch`` is reached.  When it is above the target, halve
+    the batch size.  This mirrors the coarse adjustment procedure used
+    in a number of large batch-size studies.
+    """
+
+    def update(self, trainer) -> None:
+        gns = trainer.gns
+        target = self.args.gns_target
+        if gns is None or target is None:
+            return
+        if gns < target and trainer.args.batch_size < self.args.gns_max_batch:
+            trainer.args.batch_size = min(self.args.gns_max_batch, trainer.args.batch_size * 2)
+        elif gns > target and trainer.args.batch_size > 1:
+            trainer.args.batch_size = max(1, trainer.args.batch_size // 2)
+
+
+@dataclass
+class _PIDController(_BaseController):
+    """PID style controller for smoother convergence to the target GNS."""
+
+    kp: float = 0.1
+    ki: float = 0.0
+    kd: float = 0.0
+    _integral: float = 0.0
+    _prev_error: float | None = None
+
+    def update(self, trainer) -> None:
+        gns = trainer.gns
+        target = self.args.gns_target
+        if gns is None or target is None:
+            return
+        error = target - gns
+        self._integral += error
+        derivative = 0.0 if self._prev_error is None else error - self._prev_error
+        self._prev_error = error
+        adj = self.kp * error + self.ki * self._integral + self.kd * derivative
+        if adj == 0:
+            return
+        new_batch = trainer.args.batch_size * (1.0 + adj)
+        new_batch = int(max(1, min(self.args.gns_max_batch, new_batch)))
+        trainer.args.batch_size = new_batch
+
+
+@dataclass
+class _TemperatureController(_ProportionalController):
+    """Proportional rule that also rescales the learning rate.
+
+    The learning-rate to batch-size ratio acts as a proxy for the
+    training *temperature* described in the GNS literature.  Keeping the
+    ratio constant while changing the batch size helps to maintain a
+    similar optimisation dynamics when parallelising across more
+    hardware.
+    """
+
+    def update(self, trainer) -> None:
+        old_batch = trainer.args.batch_size
+        super().update(trainer)
+        if trainer.args.batch_size != old_batch:
+            scale = trainer.args.batch_size / float(old_batch)
+            trainer.args.learning_rate *= scale
+
+
+# Public dictionary -----------------------------------------------------------
+
+gns_feedback_dictionary = {
+    "none": lambda args: _NullController(args),
+    "proportional": lambda args: _ProportionalController(args),
+    "doubling": lambda args: _DoublingController(args),
+    "pid": lambda args: _PIDController(args, kp=args.gns_pid_kp, ki=args.gns_pid_ki, kd=args.gns_pid_kd),
+    "temperature": lambda args: _TemperatureController(args),
+}
+


### PR DESCRIPTION
## Summary
- add `train_variations/gns_variants.py` with multiple GNS feedback controllers
- expose `--gns_variant` and PID gains via `train_args.py`
- integrate GNS controllers into training loop to adapt batch size and optionally learning rate

## Testing
- `python train.py --help` *(fails: ModuleNotFoundError: No module named 'seaborn')*

------
https://chatgpt.com/codex/tasks/task_e_68a6894506308326b23d394db5125f06