### PR TITLE
Enable JL transforms during training

### DIFF
--- a/explorations/jl_transform_comparison.yaml
+++ b/explorations/jl_transform_comparison.yaml
@@ -1,0 +1,30 @@
+# jl_transform_comparison.yaml
+---
+
+# base hyperparameters
+max_iters: [5000]
+eval_interval: [500]
+n_layer: [6]
+n_head: [6]
+n_embd: [384]
+block_size: [256]
+device: ["cuda"]
+dataset: ["minipile"]
+
+# position encodings
+use_rotary_embeddings: [true]
+use_abs_pos_embeddings: [false]
+
+# training precision and compilation
+dtype: ["bfloat16"]
+compile: [true]
+
+parameter_groups:
+  - {}  # default training
+  - jl_transform_interval_mult: [2]   # transform every 2 * eval_interval
+    jl_transform_out_dim: [256]        # initial projection dimension
+    jl_type: ["gaussian"]
+    jl_seed: [1337]
+    jl_out_dim_mult: [1.0]            # subsequent transforms keep dimension
+    jl_out_dim_add: [0.0]
+

--- a/train.py
+++ b/train.py
@@ -23,6 +23,7 @@ from train_variations.optimizer_variants import (
     ActRegularizedAdamW,
 )
 from train_variations.eta_variants import build_eta_estimator, ETAUpdate
+from train_variations.jl_transform_variants import jl_transform_model
 
 from utils.gpu_monitoring import get_gpu_memory_info
 from torch.cuda import reset_peak_memory_stats, max_memory_allocated
@@ -381,6 +382,11 @@ class Trainer:
 
         self.raw_model = self.model.module if self.ddp else self.model
 
+        # Track embedding dimension for JL transforms
+        self.jl_current_dim = self.raw_model.config.n_embd
+        # Optional first target dimension override
+        self._jl_first_target = self.args.jl_transform_out_dim
+
         timestamp_prefix = time.strftime("%Y%m%d-%H%M%S")
         if self.args.timestamp:
             timestamp_prefix = self.args.timestamp
@@ -442,6 +448,62 @@ class Trainer:
             return torch.optim.lr_scheduler.ReduceLROnPlateau(self.optimizer, mode=self.args.plateau_mode, factor=self.args.plateau_factor, patience=self.args.plateau_patience)
         else:
             raise ValueError(f"Unknown scheduler: {self.args.lr_scheduler}")
+
+    def next_jl_dim(self) -> int:
+        """Compute the embedding dimension for the next JL transform."""
+        if self._jl_first_target is not None:
+            dim = self._jl_first_target
+            self._jl_first_target = None
+        else:
+            dim = self.jl_current_dim
+            if self.args.jl_out_dim_mult is not None:
+                dim = round(dim * self.args.jl_out_dim_mult)
+            if self.args.jl_out_dim_add is not None:
+                dim = round(dim + self.args.jl_out_dim_add)
+
+        dim = max(1, int(dim))
+        self.jl_current_dim = dim
+        return dim
+
+    def jl_transform_and_rebuild(self):
+        """Apply a JL transform to the model and rebuild optimiser/scheduler."""
+        if self.ddp:
+            torch.distributed.barrier()
+            base_model = self.model.module
+        else:
+            base_model = self.model
+
+        out_dim = self.next_jl_dim()
+        new_model = jl_transform_model(
+            base_model,
+            out_dim,
+            jl_type=self.args.jl_type,
+            seed=self.args.jl_seed,
+            cproj_vertical=self.args.jl_cproj_vertical,
+        )
+        new_model.to(self.device)
+
+        if self.args.compile:
+            self.unoptimized_model = new_model
+            new_model = torch.compile(new_model)
+
+        if self.ddp:
+            new_model = DDP(new_model, device_ids=[self.ddp_local_rank])
+            self.raw_model = new_model.module
+        else:
+            self.raw_model = new_model
+
+        self.model = new_model
+
+        # update model args for logging/ckpts
+        self.model_args['n_embd'] = out_dim
+
+        self.model.num_param = self.raw_model.get_num_params(non_embedding=False)
+
+        # rebuild optimiser, scaler, and scheduler
+        self.optimizer = self.create_optimizer()
+        self.scaler = torch.amp.GradScaler(self.device_type, enabled=(self.args.dtype == 'float16'))
+        self.scheduler = self.create_scheduler()
 
     def load_tokenizer(self):
         if self.args.dataset_list is not None and self.args.multidataset_wte:
@@ -1505,6 +1567,18 @@ class Trainer:
                         break
                     if losses['val'] > self.best_val_loss:
                         num_steps_with_worse_loss += 1
+
+                if self.iter_num % self.args.eval_interval == 0:
+                    if (
+                        self.args.jl_transform_interval_mult is not None
+                        and (
+                            self.args.jl_transform_out_dim is not None
+                            or self.args.jl_out_dim_mult is not None
+                            or self.args.jl_out_dim_add is not None
+                        )
+                        and self.iter_num % (self.args.eval_interval * self.args.jl_transform_interval_mult) == 0
+                    ):
+                        self.jl_transform_and_rebuild()
 
                 if self.args.eval_only:
                     break

--- a/train_args.py
+++ b/train_args.py
@@ -46,6 +46,51 @@ def parse_args():
     training_group.add_argument('--eval_iters', default=200, type=int)
     training_group.add_argument('--eval_only', default=False, action=argparse.BooleanOptionalAction)
 
+    # JL transform options
+    training_group.add_argument(
+        '--jl_transform_interval_mult',
+        type=int,
+        default=None,
+        help='Apply a JL transform every N * eval_interval iterations.'
+    )
+    training_group.add_argument(
+        '--jl_transform_out_dim',
+        type=int,
+        default=None,
+        help='Embedding dimension after applying the JL transform.'
+    )
+    training_group.add_argument(
+        '--jl_type',
+        type=str,
+        default='gaussian',
+        choices=['sign', 'gaussian', 'sparse', 'srht', 'qr'],
+        help='Type of JL transform to apply during training.'
+    )
+    training_group.add_argument(
+        '--jl_seed',
+        type=int,
+        default=1337,
+        help='Random seed used when constructing JL projection matrices.'
+    )
+    training_group.add_argument(
+        '--jl_cproj_vertical',
+        default=False,
+        action=argparse.BooleanOptionalAction,
+        help='Project c_proj weights along the out_features dimension instead of the in_features dimension.'
+    )
+    training_group.add_argument(
+        '--jl_out_dim_mult',
+        type=float,
+        default=None,
+        help='Multiply embedding dimension by this factor at each JL transform (result rounded).'
+    )
+    training_group.add_argument(
+        '--jl_out_dim_add',
+        type=float,
+        default=None,
+        help='Add this amount to embedding dimension at each JL transform (result rounded).'
+    )
+
     # latency / ETA estimate options
     training_group.add_argument('--eta_variant', choices=['iteration', 'eval_cycle'], default='eval_cycle', help="iteration - estimates only based on training iterations -- use if doing one eval at the end; eval_cycle -- use if doing multiple evals, will use a single cycle for the estimation.")
     training_group.add_argument('--iteration_window', default=100, type=int)

--- a/train_variations/jl_transform_variants.py
+++ b/train_variations/jl_transform_variants.py
@@ -1,0 +1,146 @@
+# train_variations/jl_transform_variants.py
+"""Utilities to apply Johnson-Lindenstrauss (JL) transforms during training.
+
+This module mirrors the functionality of :mod:`initializations/jl_transform_ckpt.py`
+but operates directly on an in-memory model.  It allows projecting all model
+parameters to a new embedding dimension via several JL transform variants and
+returns a freshly initialised :class:`~model.GPT` instance that can resume
+training with the transformed weights.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import asdict
+
+import torch
+
+from model import GPT
+from gpt_conf import GPTConfig
+
+
+def sign_matrix(out_dim: int, in_dim: int, generator: torch.Generator, device) -> torch.Tensor:
+    """Create a sign-based JL projection matrix of shape (out_dim, in_dim)."""
+    mat = torch.randint(0, 2, (out_dim, in_dim), generator=generator, device=device, dtype=torch.float32)
+    mat = mat * 2 - 1
+    mat /= math.sqrt(out_dim)
+    return mat
+
+
+def jl_project_tensor(tensor: torch.Tensor, proj: torch.Tensor, vertical_only: bool = False) -> torch.Tensor:
+    """Project ``tensor`` using ``proj``.
+
+    Parameters
+    ----------
+    tensor        : Tensor to project.
+    proj          : Projection matrix of shape (out_dim, in_dim).
+    vertical_only : If True, apply projection only along the first dimension.
+    """
+    in_dim = proj.shape[1]
+
+    if tensor.ndim == 0:
+        return tensor
+
+    if vertical_only:
+        if tensor.ndim > 1 and tensor.shape[0] == in_dim:
+            return proj @ tensor
+        if tensor.ndim == 1 and tensor.shape[0] == in_dim:
+            return (proj @ tensor.unsqueeze(-1)).squeeze(-1)
+        return tensor
+
+    if tensor.ndim >= 1 and tensor.shape[-1] == in_dim:
+        tensor = tensor @ proj.t()
+
+    if tensor.ndim > 1 and tensor.shape[0] == in_dim:
+        tensor = proj @ tensor
+    elif tensor.ndim == 1 and tensor.shape[0] == in_dim:
+        tensor = (proj @ tensor.unsqueeze(-1)).squeeze(-1)
+
+    return tensor
+
+
+def hadamard(n: int) -> torch.Tensor:
+    """Return a Hadamard matrix of size ``n`` (``n`` must be a power of two)."""
+    H = torch.tensor([[1.0]])
+    size = 1
+    while size < n:
+        H = torch.cat([torch.cat([H, H], dim=1), torch.cat([H, -H], dim=1)], dim=0)
+        size *= 2
+    return H
+
+
+def build_projection(out_dim: int, in_dim: int, jl_type: str, g: torch.Generator, device) -> torch.Tensor:
+    """Construct a JL projection matrix according to ``jl_type``."""
+    if jl_type == "gaussian":
+        proj = torch.empty((out_dim, in_dim), device=device)
+        proj.normal_(mean=0.0, std=1.0, generator=g)
+        proj /= math.sqrt(out_dim)
+    elif jl_type == "sign":
+        proj = sign_matrix(out_dim, in_dim, g, device)
+    elif jl_type == "sparse":
+        rand = torch.rand(out_dim, in_dim, generator=g, device=device)
+        proj = torch.zeros_like(rand)
+        proj[rand < 1 / 6] = 1
+        proj[(rand >= 1 / 6) & (rand < 2 / 6)] = -1
+        proj *= math.sqrt(3.0 / out_dim)
+    elif jl_type == "srht":
+        if (in_dim & (in_dim - 1)) != 0:
+            raise ValueError("srht JL requires n_embd to be a power of two")
+        D = torch.randint(0, 2, (in_dim,), generator=g, device=device, dtype=torch.float32) * 2 - 1
+        H = hadamard(in_dim).to(device)
+        idx = torch.randperm(in_dim, generator=g, device=device)[:out_dim]
+        proj = H[idx] * D
+        proj /= math.sqrt(out_dim)
+    elif jl_type == "qr":
+        raw = torch.randn(out_dim, in_dim, generator=g, device=device)
+        q, _ = torch.linalg.qr(raw.T, mode="reduced")
+        proj = q.T
+        proj /= math.sqrt(out_dim)
+    else:
+        raise ValueError(f"Unknown jl_type: {jl_type}")
+    return proj
+
+
+def jl_transform_model(
+    model: GPT,
+    out_embd: int,
+    jl_type: str = "gaussian",
+    seed: int = 1337,
+    cproj_vertical: bool = False,
+) -> GPT:
+    """Return a new ``GPT`` model whose parameters were JL-projected.
+
+    The projection is applied even if ``out_embd`` equals the model's current
+    embedding dimension.
+
+    Parameters
+    ----------
+    model         : Existing GPT model to transform.
+    out_embd      : Desired embedding dimension after projection.
+    jl_type       : Variant of JL transform (gaussian, sign, sparse, srht, qr).
+    seed          : Random seed for projection matrix.
+    cproj_vertical: If True, project ``c_proj`` weights along the first dimension.
+    """
+    device = next(model.parameters()).device
+    g = torch.Generator(device=device)
+    g.manual_seed(seed)
+
+    old_embd = model.config.n_embd
+    proj = build_projection(out_embd, old_embd, jl_type, g, device)
+
+    state_dict = model.state_dict()
+    for key, tensor in list(state_dict.items()):
+        if not torch.is_floating_point(tensor):
+            continue
+        vertical = cproj_vertical and key.endswith("c_proj.weight")
+        state_dict[key] = jl_project_tensor(tensor, proj, vertical_only=vertical)
+
+    cfg_dict = asdict(model.config)
+    cfg_dict["n_embd"] = out_embd
+    if cfg_dict.get("n_embd_wte") == old_embd:
+        cfg_dict["n_embd_wte"] = out_embd
+
+    new_conf = GPTConfig(**cfg_dict)
+    new_model = GPT(new_conf)
+    new_model.load_state_dict(state_dict, strict=False)
+    return new_model


### PR DESCRIPTION
## Summary
- add `jl_transform_variants` utilities for projecting model weights to new embedding dimensions via Johnson-Lindenstrauss transforms
- expose JL transform scheduling and parameters in training arguments
- support on-the-fly JL projection in `train.py` after periodic evaluations
- allow multiplicative or additive changes to embedding dimension at each transform, with transforms applied even if dimension remains unchanged
- provide an exploration config contrasting baseline training against runs with JL transforms enabled using rotary embeddings

## Testing
- `python -m py_compile train_variations/jl_transform_variants.py train_args.py train.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'jamo', 'yakinori')*

------
https://chatgpt.com/codex/tasks/task_e_68a69794b4088326ab0350e916f0da2e