### PR TITLE
Include default special tokens in Tiktoken tokenizer

### DIFF
--- a/data/template/tokenizers.py
+++ b/data/template/tokenizers.py
@@ -129,20 +129,22 @@ class TiktokenTokenizer(Tokenizer):
         # Get base encoding
         base_enc = tiktoken.get_encoding(self.tiktoken_encoding)
 
+        # Always include base special tokens such as the end-of-text token
+        base_special_tokens = dict(base_enc._special_tokens)
+
         if self.additional_tokens:
             # Create custom encoding with additional tokens
+            self.special_tokens = {**base_special_tokens, **self.additional_tokens}
             self.enc = tiktoken.Encoding(
                 name=f"{self.tiktoken_encoding}_custom",
                 pat_str=base_enc._pat_str,
                 mergeable_ranks=base_enc._mergeable_ranks,
-                special_tokens={**base_enc._special_tokens,
-                                **self.additional_tokens},
+                special_tokens=self.special_tokens,
                 disallowed_special=(),
             )
-            self.special_tokens = self.additional_tokens
         else:
             self.enc = base_enc
-            self.special_tokens = {}
+            self.special_tokens = base_special_tokens
 
     def tokenize(self, data):
         """Tokenize the input data using tiktoken with support for special tokens."""
@@ -185,7 +187,7 @@ class TiktokenTokenizer(Tokenizer):
 
         # Save metadata
         meta = {
-            "vocab_size": len(self.enc._mergeable_ranks) + len(self.special_tokens),
+            "vocab_size": self.enc.n_vocab,
             "tokenizer": "tiktoken",
             "tiktoken_encoding": self.tiktoken_encoding,
             "has_additional_tokens": bool(self.additional_tokens),


### PR DESCRIPTION
## Summary
- ensure Tiktoken tokenizer registers base special tokens like `<|endoftext|>`
- derive tokenizer vocab size from encoding's `n_vocab` to include special tokens

## Testing
- `python data/template/tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68a72e5e77608326aa4b8b175767442c