### PR TITLE
Add cproj scaling options to MLP

### DIFF
--- a/explorations/mlp_cproj_comparison.yaml
+++ b/explorations/mlp_cproj_comparison.yaml
@@ -1,0 +1,29 @@
+# mlp_cproj_comparison.yaml
+---
+parameter_groups:
+  # Baseline: default down projection
+  - mlp_cproj_scale: [1.0]
+    mlp_cproj_row_norm: [false]
+  # Divide down projection by 2
+  - mlp_cproj_scale: [2.0]
+    mlp_cproj_row_norm: [false]
+  # Normalize down projection vectors
+  - mlp_cproj_scale: [1.0]
+    mlp_cproj_row_norm: [true]
+
+mlp_variant: ["mlp"]
+activation_variant: ["relu"]
+compile: [true]
+use_rotary_embeddings: [true]
+use_abs_pos_embeddings: [false]
+
+max_iters: [10000]
+lr_decay_iters: [10000]
+eval_interval: [10000]
+eta_variant: ["iteration"]
+warmup_iters: [1000]
+decay_lr: [true]
+
+dataset: ["minipile"]
+
+dtype: ["float16", "bfloat16"]

--- a/explorations/mlp_cproj_comparison.yaml
+++ b/explorations/mlp_cproj_comparison.yaml
@@ -10,6 +10,10 @@ parameter_groups:
   # Normalize down projection vectors
   - mlp_cproj_scale: [1.0]
     mlp_cproj_row_norm: [true]
+  # L2 normalize activation vectors
+  - mlp_cproj_scale: [1.0]
+    mlp_cproj_row_norm: [false]
+    mlp_post_act_l2_norm: [true]
 
 mlp_variant: ["mlp"]
 activation_variant: ["relu"]

--- a/explorations/mlp_cproj_comparison.yaml
+++ b/explorations/mlp_cproj_comparison.yaml
@@ -3,31 +3,41 @@
 parameter_groups:
   # Baseline: default down projection
   - mlp_cproj_scale: [1.0]
-    mlp_cproj_row_norm: [false]
-  # Divide down projection by 2
-  - mlp_cproj_scale: [2.0]
-    mlp_cproj_row_norm: [false]
-  # Normalize down projection vectors
-  - mlp_cproj_scale: [1.0]
-    mlp_cproj_row_norm: [true]
+    tensorboard_run_name: ["default_settings"]
   # L2 normalize activation vectors
   - mlp_cproj_scale: [1.0]
-    mlp_cproj_row_norm: [false]
     mlp_post_act_l2_norm: [true]
+    tensorboard_run_name: ["only_post_activation_norm"]
+  # L2 normalize activation vectors and cproj_scale
+  - mlp_cproj_scale: [1536]
+    mlp_post_act_l2_norm: [true]
+    tensorboard_run_name: ["c-proj-scale_and_post-act-norm"]
+  # only cproj scale
+  - mlp_cproj_scale: [1536]
+    mlp_post_act_l2_norm: [false]
+    tensorboard_run_name: ["only_cproj_scale"]
 
-mlp_variant: ["mlp"]
-activation_variant: ["relu"]
+mlp_variant: ["mlp", "swiglu"]
+activation_variant: ["relu", "squared_relu", "gelu", "silu"]
 compile: [true]
 use_rotary_embeddings: [true]
 use_abs_pos_embeddings: [false]
+use_peri_ln: [true]
 
-max_iters: [10000]
-lr_decay_iters: [10000]
-eval_interval: [10000]
-eta_variant: ["iteration"]
-warmup_iters: [1000]
-decay_lr: [true]
+warmup_iters: [500]
+max_iters: [5000]
+eval_interval: [500]
+
+n_layer: [5]
+n_embd: [320]
+n_head: [5]
+
+block_size: [256]
+batch_size: [32]
+
+compile: [true]
+compute_model_stats: [true]
 
 dataset: ["minipile"]
 
-dtype: ["float16", "bfloat16"]
+dtype: ["float16"]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -175,7 +175,6 @@ class GPTConfig:
     mlp_expansion_factor: int = 4
     mlp_size: int = None
     mlp_cproj_scale: float = 1.0
-    mlp_cproj_row_norm: bool = False
     mlp_post_act_l2_norm: bool = False
 
     ## KAN Option

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -176,6 +176,7 @@ class GPTConfig:
     mlp_size: int = None
     mlp_cproj_scale: float = 1.0
     mlp_cproj_row_norm: bool = False
+    mlp_post_act_l2_norm: bool = False
 
     ## KAN Option
     kan_poly_order: int = 3

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -174,6 +174,8 @@ class GPTConfig:
     mlp_variant: str = "mlp"
     mlp_expansion_factor: int = 4
     mlp_size: int = None
+    mlp_cproj_scale: float = 1.0
+    mlp_cproj_row_norm: bool = False
 
     ## KAN Option
     kan_poly_order: int = 3

--- a/logging/start_tensorboard.sh
+++ b/logging/start_tensorboard.sh
@@ -4,6 +4,7 @@
 # Default Port
 PORT=6006
 ULIMIT=8192
+LOG_DIRECTORY=logs
 
 # Check if user provided a specific port
 if [ ! -z "$1" ]; then
@@ -15,8 +16,13 @@ if [ ! -z "$2" ]; then
   ULIMIT="$2"
 fi
 
+# Check if user provided a specific port
+if [ ! -z "$3" ]; then
+  LOG_DIRECTORY="$3"
+fi
+
 ulimit -n "$ULIMIT"
 
 echo "ULIMIT=${ULIMIT}; PORT=${PORT}"
 
-tensorboard --logdir=./logs --port="$PORT" --bind_all --load_fast=false || python3 -m tensorboard.main --logdir=./logs --port="$PORT" --bind_all --load_fast=false
+tensorboard --logdir="$LOG_DIRECTORY" --port="$PORT" --bind_all --load_fast=false || python3 -m tensorboard.main --logdir="$LOG_DIRECTORY" --port="$PORT" --bind_all --load_fast=false

--- a/logging/start_tensorboard.sh
+++ b/logging/start_tensorboard.sh
@@ -16,7 +16,7 @@ if [ ! -z "$2" ]; then
   ULIMIT="$2"
 fi
 
-# Check if user provided a specific port
+# Check if user provided a specific log directory
 if [ ! -z "$3" ]; then
   LOG_DIRECTORY="$3"
 fi

--- a/train_args.py
+++ b/train_args.py
@@ -428,7 +428,6 @@ def parse_args():
     model_group.add_argument("--mlp_expansion_factor", type=int, default=4, help="If MLP like variant is used, set the expansion factor for the linear transformations, default is 4.")
     model_group.add_argument("--mlp_size", type=int, default=None, help="If not None, is used instead of mlp_expansion_factor")
     model_group.add_argument('--mlp_cproj_scale', default=1.0, type=float, help="Divide MLP down projection outputs by this value")
-    model_group.add_argument('--mlp_cproj_row_norm', default=False, action=argparse.BooleanOptionalAction, help="L2 normalize rows of MLP down projection weights at init")
     model_group.add_argument('--mlp_post_act_l2_norm', default=False, action=argparse.BooleanOptionalAction, help="L2 normalize MLP activation vectors before down projection")
 
     ## KAN Options

--- a/train_args.py
+++ b/train_args.py
@@ -429,6 +429,7 @@ def parse_args():
     model_group.add_argument("--mlp_size", type=int, default=None, help="If not None, is used instead of mlp_expansion_factor")
     model_group.add_argument('--mlp_cproj_scale', default=1.0, type=float, help="Divide MLP down projection outputs by this value")
     model_group.add_argument('--mlp_cproj_row_norm', default=False, action=argparse.BooleanOptionalAction, help="L2 normalize rows of MLP down projection weights at init")
+    model_group.add_argument('--mlp_post_act_l2_norm', default=False, action=argparse.BooleanOptionalAction, help="L2 normalize MLP activation vectors before down projection")
 
     ## KAN Options
     model_group.add_argument("--kan_poly_order", type=int, default=3, help="Order of KAN non-linearity")

--- a/train_args.py
+++ b/train_args.py
@@ -427,6 +427,8 @@ def parse_args():
     model_group.add_argument("--mlp_variant", type=str, default="mlp", choices=mlp_variants, help="MLP variation type")
     model_group.add_argument("--mlp_expansion_factor", type=int, default=4, help="If MLP like variant is used, set the expansion factor for the linear transformations, default is 4.")
     model_group.add_argument("--mlp_size", type=int, default=None, help="If not None, is used instead of mlp_expansion_factor")
+    model_group.add_argument('--mlp_cproj_scale', default=1.0, type=float, help="Divide MLP down projection outputs by this value")
+    model_group.add_argument('--mlp_cproj_row_norm', default=False, action=argparse.BooleanOptionalAction, help="L2 normalize rows of MLP down projection weights at init")
 
     ## KAN Options
     model_group.add_argument("--kan_poly_order", type=int, default=3, help="Order of KAN non-linearity")

--- a/variations/mlp_variations.py
+++ b/variations/mlp_variations.py
@@ -390,7 +390,7 @@ class Swiglu(nn.Module):
         x_out = x_in1 * x_in2
 
         if self.cproj_scale is not None and self.cproj_scale != 1.0:
-            x = x / self.cproj_scale
+            x_out = x_out / self.cproj_scale
 
         # Apply fused down projection and sum the outputs
         x = self.c_fc_out(x_out)

--- a/variations/mlp_variations.py
+++ b/variations/mlp_variations.py
@@ -239,7 +239,7 @@ class DualPathMLP(nn.Module):
             x1 = x1 / x1.norm(dim=-1, keepdim=True).clamp_min(1e-6)
 
         if self.cproj_scale is not None and self.cproj_scale != 1.0:
-            x1 = x1/ self.cproj_scale
+            x1 = x1 / self.cproj_scale
 
         x1 = self.c_proj1(x1)
 

--- a/variations/mlp_variations.py
+++ b/variations/mlp_variations.py
@@ -250,7 +250,7 @@ class DualPathMLP(nn.Module):
             x2 = x2 / x2.norm(dim=-1, keepdim=True).clamp_min(1e-6)
 
         if self.cproj_scale is not None and self.cproj_scale != 1.0:
-            x2 = x2/ self.cproj_scale
+            x2 = x2 / self.cproj_scale
 
         x2 = self.c_proj2(x2)
 

--- a/variations/mlp_variations.py
+++ b/variations/mlp_variations.py
@@ -86,6 +86,14 @@ class OriginalMLP(nn.Module):
             bias=use_down_bias,
         )
 
+        self.cproj_scale = config.mlp_cproj_scale
+        self.cproj_row_norm = config.mlp_cproj_row_norm
+        if self.cproj_row_norm:
+            with torch.no_grad():
+                w = self.c_proj.weight.data
+                w_norm = w.norm(dim=1, keepdim=True).clamp_min(1e-6)
+                self.c_proj.weight.data = w / w_norm
+
         self.dropout = nn.Dropout(config.dropout)
 
     def forward(self, x, iter_num=None):
@@ -117,6 +125,9 @@ class OriginalMLP(nn.Module):
             batch_size, seq_len, _ = x.shape
             x = x.view(batch_size, seq_len, self.mlp_down_projs, -1)
             x = x.sum(dim=2)
+
+        if self.cproj_scale is not None and self.cproj_scale != 1.0:
+            x = x / self.cproj_scale
 
         x = self.dropout(x)
 
@@ -204,6 +215,15 @@ class DualPathMLP(nn.Module):
             bias=config.mlp_down_bias
         )
 
+        self.cproj_scale = config.mlp_cproj_scale
+        self.cproj_row_norm = config.mlp_cproj_row_norm
+        if self.cproj_row_norm:
+            with torch.no_grad():
+                for proj in (self.c_proj1, self.c_proj2):
+                    w = proj.weight.data
+                    w_norm = w.norm(dim=1, keepdim=True).clamp_min(1e-6)
+                    proj.weight.data = w / w_norm
+
         self.dropout = nn.Dropout(config.dropout)
 
     def forward(self, x, iter_num=None):
@@ -230,6 +250,9 @@ class DualPathMLP(nn.Module):
 
         # Combine paths
         x = x1 + x2
+
+        if self.cproj_scale is not None and self.cproj_scale != 1.0:
+            x = x / self.cproj_scale
 
         if self.quantization_mlp_dict["quantize_mlp_act_activation_output"]:
             num_bits = self.quantization_mlp_dict["quantize_mlp_act_activation_output_bits"]
@@ -331,6 +354,14 @@ class Swiglu(nn.Module):
             bias=use_down_bias,
         )
 
+        self.cproj_scale = config.mlp_cproj_scale
+        self.cproj_row_norm = config.mlp_cproj_row_norm
+        if self.cproj_row_norm:
+            with torch.no_grad():
+                w = self.c_fc_out.weight.data
+                w_norm = w.norm(dim=1, keepdim=True).clamp_min(1e-6)
+                self.c_fc_out.weight.data = w / w_norm
+
         self.dropout = nn.Dropout(config.dropout)
 
     def forward(self, x, iter_num=None):
@@ -363,6 +394,9 @@ class Swiglu(nn.Module):
             batch_size, seq_len, _ = x.shape
             x = x.view(batch_size, seq_len, self.mlp_down_projs, -1)
             x = x.sum(dim=2)
+
+        if self.cproj_scale is not None and self.cproj_scale != 1.0:
+            x = x / self.cproj_scale
 
         x = self.dropout(x)
 


### PR DESCRIPTION
## Summary
- allow optional scaling and row-wise normalization of MLP c_proj weights
- expose new flags in configuration and CLI
- add exploration config comparing default vs scaled/normalized c_proj

## Testing
- `pytest` (fails: Failed initializing MeCab)
- `pytest tests` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68aa0e7360848326854df91605b3f4a1