### PR TITLE
Add Softshrink activation variant and exploration config

### DIFF
--- a/explorations/softshrink_vs_gelu.yaml
+++ b/explorations/softshrink_vs_gelu.yaml
@@ -1,0 +1,14 @@
+# softshrink_vs_gelu.yaml
+---
+parameter_groups:
+  - activation_variant: ["gelu"]
+  - activation_variant: ["softshrink"]
+
+mlp_variant: ["mlp"]
+compile: [true]
+
+use_rotary_embeddings: [true]
+use_abs_pos_embeddings: [false]
+
+dataset: ["minipile"]
+softshrink_lambda: [0.5]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -359,6 +359,9 @@ class GPTConfig:
     shifted_gelu_learnable_shift: bool = True
     shifted_gelu_initial_shift: float = 0.0
 
+    ## Softshrink
+    softshrink_lambda: float = 0.5
+
     ## PiecewiseLearnableActivation - pla
     pla_num_points: int = 7
     pla_left_bound: float = -2.0

--- a/train_args.py
+++ b/train_args.py
@@ -518,6 +518,7 @@ def parse_args():
             "silu",
             "softplus",
             "softsign",
+            "softshrink",
             "squared_relu",
             "tanh",
             "identity",
@@ -539,6 +540,9 @@ def parse_args():
     ## Shifted Gelu
     model_group.add_argument("--shifted_gelu_learnable_shift",  type=bool, default=True, action=argparse.BooleanOptionalAction)
     model_group.add_argument("--shifted_gelu_initial_shift", type=float, default=0.0)
+
+    ## Softshrink
+    model_group.add_argument("--softshrink_lambda", type=float, default=0.5)
 
     ## PiecewiseLearnableActivation - pla
     model_group.add_argument("--pla_num_points", type=int, default=7)

--- a/variations/activation_variations.py
+++ b/variations/activation_variations.py
@@ -301,6 +301,15 @@ class Softsign_Config(ActivationWrapper):
     def __init__(self, config=None):
         super().__init__(nn.Softsign, config)
 
+class Softshrink_Config(nn.Module):
+    def __init__(self, config=None):
+        super().__init__()
+        lambd = getattr(config, "softshrink_lambda", 0.5) if config is not None else 0.5
+        self.activation = nn.Softshrink(lambd=lambd)
+
+    def forward(self, x):
+        return self.activation(x)
+
 class Tanh_Config(ActivationWrapper):
     def __init__(self, config=None):
         super().__init__(nn.Tanh, config)
@@ -331,6 +340,7 @@ activation_dictionary = {
     "silu": SiLU_Config,
     "softplus": Softplus_Config,
     "softsign": Softsign_Config,
+    "softshrink": Softshrink_Config,
     "squared_relu": SquaredReLU,
     "tanh": Tanh_Config,
     "identity": Identity_Config,


### PR DESCRIPTION
## Summary
- add Softshrink activation wrapper with configurable threshold
- expose `softshrink_lambda` hyperparameter via CLI and config
- provide exploration YAML comparing Softshrink and GELU on minipile with rotary embeddings

## Testing
- `python - <<'PY'
import torch
from gpt_conf import GPTConfig
from variations.activation_variations import activation_dictionary
config = GPTConfig()
act = activation_dictionary['softshrink'](config)
print(act(torch.tensor([-1.0, 0.0, 1.0])))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ab7789effc83269c2305f5c9591d6b