### PR TITLE
Add relu2max vs softmax exploration with qk norm toggle

### DIFF
--- a/explorations/relu2max_softmax_qk_norm.yaml
+++ b/explorations/relu2max_softmax_qk_norm.yaml
@@ -1,0 +1,46 @@
+# relu2max_softmax_qk_norm.yaml
+---
+
+# parameter groups: toggle qk norm
+parameter_groups:
+  - use_qk_norm: true
+    use_qk_norm_scale: true
+  - use_qk_norm: false
+    use_qk_norm_scale: false
+
+# base hyperparameters (GPT-2 style)
+n_layer: [12]
+n_head: [12]
+n_embd: [768]
+block_size: [1024]
+device: ["cuda"]
+dtype: ["bfloat16"]
+dataset: ["minipile"]
+batch_size: [32]
+max_iters: [20000]
+lr_decay_iters: [20000]
+warmup_iters: [2000]
+beta1: [0.9]
+beta2: [0.95]
+learning_rate: [6e-4]
+min_lr: [6e-5]
+decay_lr: [true]
+eval_interval: [20000]
+never_save_checkpoint: [true]
+
+# positional embeddings
+use_rotary_embeddings: [true]
+use_abs_pos_embeddings: [false]
+
+# normalization
+norm_variant_attn: ["rmsnorm"]
+norm_variant_output: ["rmsnorm"]
+
+# attention softmax variants
+softmax_variant_attn: ["softmax", "relu2max"]
+relu2max_divisor: [64.0, 256.0, 1024.0]
+
+compile: [true]
+
+# tensorboard run name
+tensorboard_run_name: ["relu2max_softmax_qk_norm"]


### PR DESCRIPTION
## Summary
- explore relu2max attention softmax variation against regular softmax
- sweep qk norm on and off with rotary embeddings and RMSNorm on minipile
- train for 20k steps with warmup, betas, and multiple relu2max divisors while avoiding checkpoint saves

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'jamo'; ModuleNotFoundError: No module named 'yakinori')*

------
https://chatgpt.com/codex/tasks/task_e_68ab7452e0588326aa6081b91a68c597