### PR TITLE
Add SoftShrink softmax variation

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -267,6 +267,10 @@ class GPTConfig:
     ## SigmoidMax options
     sigmoidmax_divisor: float = 256.0
 
+    ## SoftShrink options
+    softshrink_attn_lambda: float = 0.5
+    softshrink_attn_divisor: float = 64.0
+
     ## Squareplus options
     squareplus_divisor: float = 256.0
 

--- a/tests/test_all_softmax_variations_cpu.sh
+++ b/tests/test_all_softmax_variations_cpu.sh
@@ -16,7 +16,7 @@ softmax_variation=( \
   "exppolymax" \
   "saturatingconsmax" \
   "strongermax" \
-  "softshrink")
+  )
 
 n_layer="2"
 n_head="2"

--- a/tests/test_all_softmax_variations_cpu.sh
+++ b/tests/test_all_softmax_variations_cpu.sh
@@ -15,7 +15,8 @@ softmax_variation=( \
   "sigsoftmax" \
   "exppolymax" \
   "saturatingconsmax" \
-  "strongermax")
+  "strongermax" \
+  "softshrink")
 
 n_layer="2"
 n_head="2"

--- a/train_args.py
+++ b/train_args.py
@@ -811,6 +811,7 @@ def parse_args():
         "softmax",
         "softplus",
         "squareplus",
+        "softshrink",
         "exppolymax",
         "pfla_softmax",
         ]
@@ -892,6 +893,9 @@ def parse_args():
     model_group.add_argument('--softplus_divisor', type=float,default=100.0)
     ### SquarePlus Options
     model_group.add_argument('--squareplus_divisor', type=float,default=100.0)
+    ### SoftShrink Options
+    model_group.add_argument('--softshrink_attn_lambda', type=float, default=0.5)
+    model_group.add_argument('--softshrink_attn_divisor', type=float, default=64.0)
 
     ### Sequence Length Division https://arxiv.org/abs/2309.
     model_group.add_argument('--div_by_seq_len', default=False, action=argparse.BooleanOptionalAction)

--- a/train_args.py
+++ b/train_args.py
@@ -812,6 +812,7 @@ def parse_args():
         "softplus",
         "squareplus",
         "softshrink",
+        "gelumax",
         "exppolymax",
         "pfla_softmax",
         ]

--- a/variations/mlp_variations.py
+++ b/variations/mlp_variations.py
@@ -388,9 +388,11 @@ class KanMLP(nn.Module):
 
 class MLP_Identity(nn.Module):
     def __init__(self, config):
-        super(Identity, self).__init__()
+        super().__init__()
+        self.activation = nn.Identity()
 
     def forward(self, x, iter_num=None):
+        x = self.activation(x)
         return x
 
 mlp_dictionary = {

--- a/variations/softmax_variations.py
+++ b/variations/softmax_variations.py
@@ -576,6 +576,24 @@ class ReLU2Max(nn.Module):
 
         return result
 
+class Softshrink(nn.Module):
+    def __init__(self, config, dim=-1):
+        super().__init__()
+        self.dim = dim
+        self.softshrink = nn.Softshrink(lambd=config.softshrink_attn_lambda)
+        self.softshrink_attn_divisor = config.softshrink_attn_divisor
+        self.div_by_seq_len = config.div_by_seq_len
+
+    def forward(self, x):
+        result = self.softshrink(x) / self.softshrink_attn_divisor
+
+        # divide by sequence length
+        if self.div_by_seq_len:
+            seq_len = x.shape[self.dim]
+            result = result / seq_len
+
+        return result
+
 class Softplus(nn.Module):
     """ Softmax variant based on arxiv 1805.10829 with added handles for base """
     def __init__(self, config, dim=-1):
@@ -776,6 +794,7 @@ softmax_dictionary = {
     "relumax": ReLUMax,
     "relu2max": ReLU2Max,
     "sigmoidmax": SigmoidMax,
+    "softshrink": Softshrink,
     "softplus": Softplus,
     "squareplus": Squareplus,
     "pfla_softmax": PFLASoftmax,

--- a/variations/softmax_variations.py
+++ b/variations/softmax_variations.py
@@ -576,6 +576,26 @@ class ReLU2Max(nn.Module):
 
         return result
 
+
+class Gelumax(nn.Module):
+    def __init__(self, config, dim=-1):
+        super().__init__()
+        self.dim = dim
+        self.softshrink = nn.GELU()
+        self.softshrink_attn_divisor = config.softshrink_attn_divisor
+        self.div_by_seq_len = config.div_by_seq_len
+
+    def forward(self, x):
+        result = self.softshrink(x) / self.softshrink_attn_divisor
+
+        # divide by sequence length
+        if self.div_by_seq_len:
+            seq_len = x.shape[self.dim]
+            result = result / seq_len
+
+        return result
+
+
 class Softshrink(nn.Module):
     def __init__(self, config, dim=-1):
         super().__init__()
@@ -795,6 +815,7 @@ softmax_dictionary = {
     "relu2max": ReLU2Max,
     "sigmoidmax": SigmoidMax,
     "softshrink": Softshrink,
+    "gelumax": Gelumax,
     "softplus": Softplus,
     "squareplus": Squareplus,
     "pfla_softmax": PFLASoftmax,


### PR DESCRIPTION
## Summary
- add SoftShrink attention softmax variation
- expose softshrink_attn_lambda and softshrink_attn_divisor in config and CLI
- cover new variation in softmax tests

## Testing
- `bash test_all_softmax_variations_cpu.sh` *(fails: ModuleNotFoundError: No module named 'lm_eval')*


------
https://chatgpt.com/codex/tasks/task_e_68b1348050a08326be82f156854f8f4d