### PR TITLE
Add optional learnable offsets to ReLUMax and ReLU2Max

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -260,9 +260,13 @@ class GPTConfig:
 
     ## ReLUMax options
     relumax_divisor: float = 256.0
+    relumax_offset: float = 0.0
+    relumax_use_learned_offset: bool = False
 
-    ## ReLUMax options
+    ## ReLU2Max options
     relu2max_divisor: float = 256.0
+    relu2max_offset: float = 0.0
+    relu2max_use_learned_offset: bool = False
 
     ## SigmoidMax options
     sigmoidmax_divisor: float = 256.0

--- a/train_args.py
+++ b/train_args.py
@@ -845,9 +845,13 @@ def parse_args():
 
     ### ReLUMax Options
     model_group.add_argument("--relumax_divisor", type=float, default=256.0)
+    model_group.add_argument("--relumax_offset", type=float, default=0.0)
+    model_group.add_argument('--relumax_use_learned_offset', default=False, action=argparse.BooleanOptionalAction)
 
     ### ReLU2Max Options
     model_group.add_argument("--relu2max_divisor", type=float, default=256.0)
+    model_group.add_argument("--relu2max_offset", type=float, default=0.0)
+    model_group.add_argument('--relu2max_use_learned_offset', default=False, action=argparse.BooleanOptionalAction)
 
     ### SimgoidMax Options
     model_group.add_argument("--sigmoidmax_divisor", type=float, default=256.0)

--- a/variations/softmax_variations.py
+++ b/variations/softmax_variations.py
@@ -546,10 +546,15 @@ class ReLUMax(nn.Module):
         self.relumax = nn.ReLU()
         self.relumax_divisor = config.relumax_divisor
         self.div_by_seq_len = config.div_by_seq_len
+        offset_val = torch.tensor(config.relumax_offset)
+        if getattr(config, "relumax_use_learned_offset", False):
+            self.offset = nn.Parameter(offset_val)
+        else:
+            self.register_buffer("offset", offset_val)
 
     def forward(self, x):
 
-        result = self.relumax(x) / self.relumax_divisor
+        result = self.relumax(x + self.offset) / self.relumax_divisor
 
         # divide by sequence length
         if self.div_by_seq_len:
@@ -564,10 +569,15 @@ class ReLU2Max(nn.Module):
         self.dim = dim
         self.relu2max_divisor = config.relu2max_divisor
         self.div_by_seq_len = config.div_by_seq_len
+        offset_val = torch.tensor(config.relu2max_offset)
+        if getattr(config, "relu2max_use_learned_offset", False):
+            self.offset = nn.Parameter(offset_val)
+        else:
+            self.register_buffer("offset", offset_val)
 
     def forward(self, x):
 
-        result = torch.relu(x) ** 2 / self.relu2max_divisor
+        result = torch.relu(x + self.offset) ** 2 / self.relu2max_divisor
 
         # divide by sequence length
         if self.div_by_seq_len:


### PR DESCRIPTION
## Summary
- allow ReLUMax and ReLU2Max to apply a configurable offset before activation
- expose offset defaults and learnable flags in GPT config and CLI

## Testing
- `python -m pytest` (fails: [ifs] no such file or directory: /usr/local/etc/mecabrc)
- `bash tests/test_finetuning_cpu.sh` (fails: ModuleNotFoundError: No module named 'sentencepiece')
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68b13f7b83d4832696e10d1f925c099d