### PR TITLE
Add progress tracking and nested parameter group support

### DIFF
--- a/optimization_and_search/run_experiments.py
+++ b/optimization_and_search/run_experiments.py
@@ -5,11 +5,13 @@ from datetime import datetime
 from itertools import product
 import argparse
 import os
+from typing import Optional
 
 import yaml
 from rich import print
 from rich.console import Console
 from rich.table import Table
+from rich.progress import Progress, BarColumn, TextColumn, TimeRemainingColumn
 
 # Constants
 LOG_DIR = Path("exploration_logs")
@@ -53,6 +55,14 @@ def parse_args() -> argparse.Namespace:
         '--use_timestamp', action='store_true',
         help="Prepend timestamp to run names and out_dir."
     )
+    parser.add_argument(
+        '--progress', action='store_true',
+        help="Display a rich progress bar while running experiments.",
+    )
+    parser.add_argument(
+        '--simple_log_count', action='store_true',
+        help=("Assume the exploration config has not changed and estimate the number of completed configs by counting entries in the log file."),
+    )
     return parser.parse_args()
 
 
@@ -94,26 +104,34 @@ def expand_range(val):
     return val
 
 
-def generate_combinations(config: dict) -> dict:
-    """
-    Yield all valid parameter combinations for a single config dict.
-
-    Returns:
-        Iterator of parameter-combination dicts.
-    """
-    groups = config.pop('parameter_groups', [{}])
-    base = {
-        k: (expand_range(v) if isinstance(v, dict) and 'range' in v else v)
-        for k, v in config.items()
-        if not (isinstance(v, dict) and 'conditions' in v)
-    }
-    base = {k: (v if isinstance(v, list) else [v]) for k, v in base.items()}
-    conditionals = {k: v for k, v in config.items() if isinstance(v, dict) and 'conditions' in v}
-
+def _expand_parameter_groups(cfg: dict) -> list[dict]:
+    """Recursively expand any nested ``parameter_groups`` entries."""
+    groups = cfg.get('parameter_groups')
+    base = {k: v for k, v in cfg.items() if k != 'parameter_groups'}
+    if not groups:
+        return [base]
+    expanded = []
     for grp in groups:
         merged = {**base, **grp}
-        keys = list(merged)
-        for combo in product(*(merged[k] for k in keys)):
+        expanded.extend(_expand_parameter_groups(merged))
+    return expanded
+
+
+def generate_combinations(config: dict) -> dict:
+    """Yield all valid parameter combinations for a single config dict."""
+    for cfg in _expand_parameter_groups(config):
+        base = {
+            k: (expand_range(v) if isinstance(v, dict) and 'range' in v else v)
+            for k, v in cfg.items()
+            if not (isinstance(v, dict) and 'conditions' in v)
+        }
+        base = {k: (v if isinstance(v, list) else [v]) for k, v in base.items()}
+        conditionals = {
+            k: v for k, v in cfg.items() if isinstance(v, dict) and 'conditions' in v
+        }
+
+        keys = list(base)
+        for combo in product(*(base[k] for k in keys)):
             combo_dict = dict(zip(keys, combo))
             valid = [combo_dict]
             for param, spec in conditionals.items():
@@ -199,16 +217,18 @@ def build_command(combo: dict) -> list[str]:
 def run_experiment(
     combo: dict,
     base: str,
-    args: argparse.Namespace
-) -> None:
-    """
-    Execute one experiment combo: skip if done, run train.py, record metrics.
-    """
+    args: argparse.Namespace,
+    completed: set[str],
+    log_file: Path,
+    console: Optional[Console] = None,
+) -> bool:
+    """Execute one experiment combo.
+
+    Returns True if a new experiment was run, False if it was skipped."""
     run_name = format_run_name(combo, base, args.prefix)
-    log_file = LOG_DIR / f"{base}.yaml"
-    if run_name in completed_runs(log_file):
+    if run_name in completed:
         print(f"[yellow]Skipping already-run:[/] {run_name}")
-        return
+        return False
 
     # Prepare output directory
     timestamp = datetime.now().strftime('%Y%m%d_%H%M%S') if args.use_timestamp else None
@@ -219,19 +239,23 @@ def run_experiment(
     combo['tensorboard_run_name'] = run_name
 
     # Show parameters
-    console = Console()
+    display = console or Console()
     table = Table("Parameters", show_header=False)
     for k, v in combo.items():
         table.add_row(k, str(v))
-    console.print(table)
+    display.print(table)
 
     # Build and run
     cmd = build_command(combo)
-    print(f"Running: {' '.join(cmd)}")
+    display.print(f"Running: {' '.join(cmd)}")
+    env = os.environ.copy()
+    if console:
+        # Pass the console file descriptor so train.py can share the progress display
+        env["NANOGPT_PROGRESS_FD"] = str(console.file.fileno())
     try:
-        subprocess.run(cmd, check=True)
+        subprocess.run(cmd, check=True, env=env)
     except subprocess.CalledProcessError:
-        print(f"[red]Process exited with error for run:[/] {run_name}")
+        display.print(f"[red]Process exited with error for run:[/] {run_name}")
 
     # Read metrics (use existing or nan on failure)
     try:
@@ -240,16 +264,48 @@ def run_experiment(
         metrics = {k: float("nan") for k in METRIC_KEYS}
 
     append_log(log_file, run_name, combo, metrics)
+    completed.add(run_name)
+    return True
 
 
 def main():
     args = parse_args()
     base = Path(args.config).stem
     configs = load_configurations(args.config, args.config_format)
+    log_file = LOG_DIR / f"{base}.yaml"
+    completed = completed_runs(log_file)
 
-    for cfg in configs:
-        for combo in generate_combinations(cfg):
-            run_experiment(combo, base, args)
+    if args.progress:
+        all_runs = []
+        for cfg in configs:
+            for combo in generate_combinations(cfg):
+                run_name = format_run_name(combo, base, args.prefix)
+                all_runs.append((combo, run_name))
+
+        total = len(all_runs)
+        if args.simple_log_count:
+            initial_completed = min(len(completed), total)
+        else:
+            initial_completed = sum(1 for _, name in all_runs if name in completed)
+
+        progress = Progress(
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TextColumn("{task.completed}/{task.total}"),
+            TimeRemainingColumn(),
+        )
+        with progress:
+            task = progress.add_task("configs", total=total, completed=initial_completed)
+            for combo, _ in all_runs:
+                ran = run_experiment(
+                    combo, base, args, completed, log_file, console=progress.console
+                )
+                if ran:
+                    progress.advance(task)
+    else:
+        for cfg in configs:
+            for combo in generate_combinations(cfg):
+                run_experiment(combo, base, args, completed, log_file)
 
 
 if __name__ == '__main__':

--- a/tests/run_optimization_tests/test_nested_param_groups.yaml
+++ b/tests/run_optimization_tests/test_nested_param_groups.yaml
@@ -1,0 +1,19 @@
+---
+parameter_groups:
+  - parameter_groups:
+      - use_rotary_embeddings: [true]
+        tensorboard_run_name: ["nested_rotary"]
+      - use_rotary_embeddings: [false]
+        tensorboard_run_name: ["nested_no_rotary"]
+    use_abs_pos_embeddings: [true]
+  - use_rotary_embeddings: [false]
+    use_abs_pos_embeddings: [false]
+    tensorboard_run_name: ["simple_group"]
+max_iters: [1]
+n_layer: [1]
+n_head: [1]
+n_embd: [8]
+block_size: [8]
+device: ["cpu"]
+dtype: ["bfloat16"]
+dataset: ["shakespeare_char"]

--- a/tests/test_run_experiments.sh
+++ b/tests/test_run_experiments.sh
@@ -7,4 +7,5 @@ python3 optimization_and_search/run_experiments.py -c tests/run_optimization_tes
 python3 optimization_and_search/run_experiments.py -c tests/run_optimization_tests/test_booleans.yaml      --config_format yaml
 python3 optimization_and_search/run_experiments.py -c tests/run_optimization_tests/test_param_groups.yaml  --config_format yaml
 python3 optimization_and_search/run_experiments.py -c tests/run_optimization_tests/test_conditionals.yaml  --config_format yaml
+python3 optimization_and_search/run_experiments.py -c tests/run_optimization_tests/test_nested_param_groups.yaml --config_format yaml --progress --simple_log_count
 popd

--- a/train.py
+++ b/train.py
@@ -4,6 +4,7 @@ import csv
 import json
 import math
 import os
+import io
 import random
 import pickle
 import shutil
@@ -1317,7 +1318,18 @@ class Trainer:
 
         cli_settings = " ".join(sys.argv)
         cli_text = Text(f"CLI: {cli_settings}", style="chartreuse1")
-        self.console = Console()
+        fd = os.environ.get("NANOGPT_PROGRESS_FD")
+        if fd is not None:
+            # Use the parent progress console so both bars render together
+            try:
+                shared_stream = io.TextIOWrapper(
+                    os.fdopen(int(fd), "wb"), encoding="utf-8", write_through=True
+                )
+                self.console = Console(file=shared_stream)
+            except Exception:
+                self.console = Console()
+        else:
+            self.console = Console()
         # Create progress bar with ETA and remaining time display
         progress = Progress(
                 TextColumn("[bold white]{task.description}"),


### PR DESCRIPTION
## Summary
- allow nested `parameter_groups` in experiment configs
- add optional rich progress bar with ETA and log-count mode
- share console between experiment runner and `train.py` so both progress bars render

## Testing
- `bash tests/test_run_experiments.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b1be4f39c883269986bdc0abf21a1e