### PR TITLE
Add progress tracking and nested parameter group support

### DIFF
--- a/optimization_and_search/run_experiments.py
+++ b/optimization_and_search/run_experiments.py
@@ -5,11 +5,13 @@ from datetime import datetime
 from itertools import product
 import argparse
 import os
+from typing import Optional
 
 import yaml
 from rich import print
 from rich.console import Console
 from rich.table import Table
+from rich.progress import Progress, BarColumn, TextColumn, TimeRemainingColumn
 
 # Constants
 LOG_DIR = Path("exploration_logs")
@@ -53,6 +55,14 @@ def parse_args() -> argparse.Namespace:
         '--use_timestamp', action='store_true',
         help="Prepend timestamp to run names and out_dir."
     )
+    parser.add_argument(
+        '--progress', action='store_true',
+        help="Display a rich progress bar while running experiments.",
+    )
+    parser.add_argument(
+        '--simple_log_count', action='store_true',
+        help=("Assume the exploration config has not changed and estimate the number of completed configs by counting entries in the log file."),
+    )
     return parser.parse_args()
 
 
@@ -94,26 +104,34 @@ def expand_range(val):
     return val
 
 
-def generate_combinations(config: dict) -> dict:
-    """
-    Yield all valid parameter combinations for a single config dict.
-
-    Returns:
-        Iterator of parameter-combination dicts.
-    """
-    groups = config.pop('parameter_groups', [{}])
-    base = {
-        k: (expand_range(v) if isinstance(v, dict) and 'range' in v else v)
-        for k, v in config.items()
-        if not (isinstance(v, dict) and 'conditions' in v)
-    }
-    base = {k: (v if isinstance(v, list) else [v]) for k, v in base.items()}
-    conditionals = {k: v for k, v in config.items() if isinstance(v, dict) and 'conditions' in v}
-
+def _expand_parameter_groups(cfg: dict) -> list[dict]:
+    """Recursively expand any nested ``parameter_groups`` entries."""
+    groups = cfg.get('parameter_groups')
+    base = {k: v for k, v in cfg.items() if k != 'parameter_groups'}
+    if not groups:
+        return [base]
+    expanded = []
     for grp in groups:
         merged = {**base, **grp}
-        keys = list(merged)
-        for combo in product(*(merged[k] for k in keys)):
+        expanded.extend(_expand_parameter_groups(merged))
+    return expanded
+
+
+def generate_combinations(config: dict) -> dict:
+    """Yield all valid parameter combinations for a single config dict."""
+    for cfg in _expand_parameter_groups(config):
+        base = {
+            k: (expand_range(v) if isinstance(v, dict) and 'range' in v else v)
+            for k, v in cfg.items()
+            if not (isinstance(v, dict) and 'conditions' in v)
+        }
+        base = {k: (v if isinstance(v, list) else [v]) for k, v in base.items()}
+        conditionals = {
+            k: v for k, v in cfg.items() if isinstance(v, dict) and 'conditions' in v
+        }
+
+        keys = list(base)
+        for combo in product(*(base[k] for k in keys)):
             combo_dict = dict(zip(keys, combo))
             valid = [combo_dict]
             for param, spec in conditionals.items():
@@ -199,16 +217,18 @@ def build_command(combo: dict) -> list[str]:
 def run_experiment(
     combo: dict,
     base: str,
-    args: argparse.Namespace
-) -> None:
-    """
-    Execute one experiment combo: skip if done, run train.py, record metrics.
-    """
+    args: argparse.Namespace,
+    completed: set[str],
+    log_file: Path,
+    console: Optional[Console] = None,
+) -> bool:
+    """Execute one experiment combo.
+
+    Returns True if a new experiment was run, False if it was skipped."""
     run_name = format_run_name(combo, base, args.prefix)
-    log_file = LOG_DIR / f"{base}.yaml"
-    if run_name in completed_runs(log_file):
+    if run_name in completed:
         print(f"[yellow]Skipping already-run:[/] {run_name}")
-        return
+        return False
 
     # Prepare output directory
     timestamp = datetime.now().strftime('%Y%m%d_%H%M%S') if args.use_timestamp else None
@@ -219,19 +239,26 @@ def run_experiment(
     combo['tensorboard_run_name'] = run_name
 
     # Show parameters
-    console = Console()
+    display = console or Console()
     table = Table("Parameters", show_header=False)
     for k, v in combo.items():
         table.add_row(k, str(v))
-    console.print(table)
+    display.print(table)
 
     # Build and run
     cmd = build_command(combo)
-    print(f"Running: {' '.join(cmd)}")
-    try:
-        subprocess.run(cmd, check=True)
-    except subprocess.CalledProcessError:
-        print(f"[red]Process exited with error for run:[/] {run_name}")
+    display.print(f"Running: {' '.join(cmd)}")
+    if console:
+        try:
+            import train
+            train.main(cmd[2:], console=display)
+        except Exception:
+            display.print(f"[red]Process exited with error for run:[/] {run_name}")
+    else:
+        try:
+            subprocess.run(cmd, check=True)
+        except subprocess.CalledProcessError:
+            display.print(f"[red]Process exited with error for run:[/] {run_name}")
 
     # Read metrics (use existing or nan on failure)
     try:
@@ -240,16 +267,48 @@ def run_experiment(
         metrics = {k: float("nan") for k in METRIC_KEYS}
 
     append_log(log_file, run_name, combo, metrics)
+    completed.add(run_name)
+    return True
 
 
 def main():
     args = parse_args()
     base = Path(args.config).stem
     configs = load_configurations(args.config, args.config_format)
+    log_file = LOG_DIR / f"{base}.yaml"
+    completed = completed_runs(log_file)
 
-    for cfg in configs:
-        for combo in generate_combinations(cfg):
-            run_experiment(combo, base, args)
+    if args.progress:
+        all_runs = []
+        for cfg in configs:
+            for combo in generate_combinations(cfg):
+                run_name = format_run_name(combo, base, args.prefix)
+                all_runs.append((combo, run_name))
+
+        total = len(all_runs)
+        if args.simple_log_count:
+            initial_completed = min(len(completed), total)
+        else:
+            initial_completed = sum(1 for _, name in all_runs if name in completed)
+
+        progress = Progress(
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TextColumn("{task.completed}/{task.total}"),
+            TimeRemainingColumn(),
+        )
+        with progress:
+            task = progress.add_task("configs", total=total, completed=initial_completed)
+            for combo, _ in all_runs:
+                ran = run_experiment(
+                    combo, base, args, completed, log_file, console=progress.console
+                )
+                if ran:
+                    progress.advance(task)
+    else:
+        for cfg in configs:
+            for combo in generate_combinations(cfg):
+                run_experiment(combo, base, args, completed, log_file)
 
 
 if __name__ == '__main__':

--- a/tests/run_optimization_tests/test_nested_param_groups.yaml
+++ b/tests/run_optimization_tests/test_nested_param_groups.yaml
@@ -1,0 +1,19 @@
+---
+parameter_groups:
+  - parameter_groups:
+      - use_rotary_embeddings: [true]
+        tensorboard_run_name: ["nested_rotary"]
+      - use_rotary_embeddings: [false]
+        tensorboard_run_name: ["nested_no_rotary"]
+    use_abs_pos_embeddings: [true]
+  - use_rotary_embeddings: [false]
+    use_abs_pos_embeddings: [false]
+    tensorboard_run_name: ["simple_group"]
+max_iters: [1]
+n_layer: [1]
+n_head: [1]
+n_embd: [8]
+block_size: [8]
+device: ["cpu"]
+dtype: ["bfloat16"]
+dataset: ["shakespeare_char"]

--- a/tests/test_run_experiments.sh
+++ b/tests/test_run_experiments.sh
@@ -7,4 +7,5 @@ python3 optimization_and_search/run_experiments.py -c tests/run_optimization_tes
 python3 optimization_and_search/run_experiments.py -c tests/run_optimization_tests/test_booleans.yaml      --config_format yaml
 python3 optimization_and_search/run_experiments.py -c tests/run_optimization_tests/test_param_groups.yaml  --config_format yaml
 python3 optimization_and_search/run_experiments.py -c tests/run_optimization_tests/test_conditionals.yaml  --config_format yaml
+python3 optimization_and_search/run_experiments.py -c tests/run_optimization_tests/test_nested_param_groups.yaml --config_format yaml --progress --simple_log_count
 popd

--- a/train.py
+++ b/train.py
@@ -1293,7 +1293,7 @@ class Trainer:
                 }
         torch.save(checkpoint, os.path.join(self.args.out_dir, filename))
 
-    def train(self):
+    def train(self, console=None):
         if self.args.training_mode == 'multicontext':
             self.X_dict, self.Y_dict, dataset_list = self.get_batch('train')
             current_dataset = dataset_list[0]
@@ -1317,7 +1317,7 @@ class Trainer:
 
         cli_settings = " ".join(sys.argv)
         cli_text = Text(f"CLI: {cli_settings}", style="chartreuse1")
-        self.console = Console()
+        self.console = console or Console()
         # Create progress bar with ETA and remaining time display
         progress = Progress(
                 TextColumn("[bold white]{task.description}"),
@@ -1714,12 +1714,14 @@ class Trainer:
                 wandb.log({"finished": True})
                 wandb.finish()
 
-def main():
-    args, model_group, training_group, logging_group = parse_args()
+def main(cli_args=None, console=None):
+    if cli_args is not None:
+        sys.argv = ['train.py', *cli_args]
+    args, model_group, training_group, logging_group = parse_args(cli_args)
     trainer = Trainer(args, model_group, training_group, logging_group)
 
     if not args.sample_only:
-        trainer.train()
+        trainer.train(console=console)
 
     if trainer.ddp:
         destroy_process_group()

--- a/train_args.py
+++ b/train_args.py
@@ -7,7 +7,7 @@ def clean_dataset_path(dataset_name):
     """Removes leading './data/' or 'data/' from dataset paths."""
     return re.sub(r'^(?:\./)?data/', '', dataset_name)
 
-def parse_args():
+def parse_args(args_list=None):
 
     parser = argparse.ArgumentParser()
 
@@ -1075,7 +1075,7 @@ def parse_args():
     # Model Parameter Distribution
     logging_group.add_argument('--print_model_info', default=True, action=argparse.BooleanOptionalAction)
 
-    args = parser.parse_args()
+    args = parser.parse_args(args_list)
 
     if args.log_all_metrics:
         args.log_btc_train = True


### PR DESCRIPTION
## Summary
- allow nested `parameter_groups` in experiment configs
- add optional rich progress bar with ETA and log-count mode
- stream training output through shared console so training progress remains visible
- pass console object into training run so both progress bars render simultaneously

## Testing
- `bash tests/test_run_experiments.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b1be4f39c883269986bdc0abf21a1e