### PR TITLE
Add target-left probability metric to training and tools

### DIFF
--- a/explorations/focal_loss_confidence_vector_sweep.yaml
+++ b/explorations/focal_loss_confidence_vector_sweep.yaml
@@ -1,0 +1,63 @@
+# explorations/focal_loss_confidence_vector_sweep.yaml
+---
+parameter_groups:
+  # Cross Entropy
+  - use_attn_resid_scaling: [false]
+    use_mlp_resid_scaling: [false]
+    loss_fn: ["cross_entropy"]
+
+  # Focal Loss
+  - use_attn_resid_scaling: [false]
+    use_mlp_resid_scaling: [false]
+    loss_fn: ["focal"]
+    focal_gamma: [0.5, 1.0, 2.0, 5.0, 10.0]
+
+  # Learned Confidence with Cross Entropy
+  - use_attn_resid_scaling: [true]
+    use_mlp_resid_scaling: [true]
+    attn_confidence_variant: ["zeros"]
+    mlp_confidence_variant: ["zeros"]
+    use_attn_resid_const: [true]
+    use_mlp_resid_const: [true]
+    learn_attn_resid_const: [false]
+    learn_mlp_resid_const: [false]
+    attn_resid_const: [1]
+    mlp_resid_const: [1]
+    loss_fn: ["cross_entropy"]
+
+  # Learned Confidence with Focal Loss
+  - use_attn_resid_scaling: [true]
+    use_mlp_resid_scaling: [true]
+    attn_confidence_variant: ["zeros"]
+    mlp_confidence_variant: ["zeros"]
+    use_attn_resid_const: [true]
+    use_mlp_resid_const: [true]
+    learn_attn_resid_const: [false]
+    learn_mlp_resid_const: [false]
+    attn_resid_const: [1]
+    mlp_resid_const: [1]
+    loss_fn: ["focal"]
+    focal_gamma: [0.5, 1.0, 2.0, 5.0, 10.0]
+
+# base hyperparameters
+max_iters: [10000]
+n_layer: [6]
+n_head: [6]
+n_embd: [384]
+block_size: [256]
+dataset: ["minipile"]
+device: ["cuda"]
+dtype: ["float16"]
+
+use_qk_norm: [true]
+use_qk_norm_scale: [true]
+use_peri_ln: [true, false]
+
+# Position Encoding
+use_rotary_embeddings: [true]
+use_abs_pos_embeddings: [false]
+
+# Misc
+never_save_checkpoint: [true]
+compile: [true]
+

--- a/optimization_and_search/run_experiments.py
+++ b/optimization_and_search/run_experiments.py
@@ -27,6 +27,8 @@ METRIC_KEYS = [
     "avg_top1_correct",
     "avg_target_rank",
     "avg_target_left_prob",
+    "target_rank_95",
+    "left_prob_95",
 ]
 
 
@@ -157,7 +159,7 @@ def read_metrics(out_dir: str) -> dict:
     line = path.read_text().strip()
     parts = [p.strip() for p in line.split(',')]
 
-    casts = [float, int, int, float, float, float, float, float, float, float, float]
+    casts = [float, int, int, float, float, float, float, float, float, float, float, float, float]
     return {k: typ(v) for k, typ, v in zip(METRIC_KEYS, casts, parts)}
 
 

--- a/optimization_and_search/run_experiments.py
+++ b/optimization_and_search/run_experiments.py
@@ -27,6 +27,7 @@ METRIC_KEYS = [
     "avg_top1_correct",
     "avg_target_rank",
     "avg_target_left_prob",
+    "avg_target_prob",
     "target_rank_95",
     "left_prob_95",
 ]
@@ -159,7 +160,7 @@ def read_metrics(out_dir: str) -> dict:
     line = path.read_text().strip()
     parts = [p.strip() for p in line.split(',')]
 
-    casts = [float, int, int, float, float, float, float, float, float, float, float, float, float]
+    casts = [float, int, int, float, float, float, float, float, float, float, float, float, float, float]
     return {k: typ(v) for k, typ, v in zip(METRIC_KEYS, casts, parts)}
 
 

--- a/optimization_and_search/run_experiments.py
+++ b/optimization_and_search/run_experiments.py
@@ -26,6 +26,7 @@ METRIC_KEYS = [
     "avg_top1_prob",
     "avg_top1_correct",
     "avg_target_rank",
+    "avg_target_left_prob",
 ]
 
 
@@ -156,7 +157,7 @@ def read_metrics(out_dir: str) -> dict:
     line = path.read_text().strip()
     parts = [p.strip() for p in line.split(',')]
 
-    casts = [float, int, int, float, float, float, float, float, float, float]
+    casts = [float, int, int, float, float, float, float, float, float, float, float]
     return {k: typ(v) for k, typ, v in zip(METRIC_KEYS, casts, parts)}
 
 

--- a/run_exploration_monitor.py
+++ b/run_exploration_monitor.py
@@ -176,6 +176,8 @@ class MonitorApp(App):
             "avg_top1_correct",
             "avg_target_rank",
             "avg_target_left_prob",
+            "target_rank_95",
+            "left_prob_95",
         ] + self.param_keys
         self.all_columns = base_cols.copy()
         self.columns = base_cols.copy()
@@ -227,6 +229,8 @@ class MonitorApp(App):
             "avg_top1_correct",
             "avg_target_rank",
             "avg_target_left_prob",
+            "target_rank_95",
+            "left_prob_95",
         ):
             return entry.get(col_name)
         return entry.get("config", {}).get(col_name)

--- a/run_exploration_monitor.py
+++ b/run_exploration_monitor.py
@@ -176,6 +176,7 @@ class MonitorApp(App):
             "avg_top1_correct",
             "avg_target_rank",
             "avg_target_left_prob",
+            "avg_target_prob",
             "target_rank_95",
             "left_prob_95",
         ] + self.param_keys
@@ -229,6 +230,7 @@ class MonitorApp(App):
             "avg_top1_correct",
             "avg_target_rank",
             "avg_target_left_prob",
+            "avg_target_prob",
             "target_rank_95",
             "left_prob_95",
         ):

--- a/run_exploration_monitor.py
+++ b/run_exploration_monitor.py
@@ -175,6 +175,7 @@ class MonitorApp(App):
             "avg_top1_prob",
             "avg_top1_correct",
             "avg_target_rank",
+            "avg_target_left_prob",
         ] + self.param_keys
         self.all_columns = base_cols.copy()
         self.columns = base_cols.copy()
@@ -225,6 +226,7 @@ class MonitorApp(App):
             "avg_top1_prob",
             "avg_top1_correct",
             "avg_target_rank",
+            "avg_target_left_prob",
         ):
             return entry.get(col_name)
         return entry.get("config", {}).get(col_name)

--- a/train.py
+++ b/train.py
@@ -909,9 +909,9 @@ class Trainer:
                             target_logits = logits.gather(-1, Y.unsqueeze(-1)).squeeze(-1)
                             ranks = (logits > target_logits.unsqueeze(-1)).sum(dim=-1) + 1
                             target_ranks.append(ranks.float())
-                            target_prob = probs.gather(-1, Y.unsqueeze(-1)).squeeze(-1)
+                            target_prob = probs.gather(-1, Y.unsqueeze(-1)).squeeze(-1).float()
                             target_probs.append(target_prob)
-                            left_prob = (probs * (probs > target_prob.unsqueeze(-1))).sum(dim=-1)
+                            left_prob = (probs * (probs > target_prob.unsqueeze(-1))).sum(dim=-1).float()
                             target_left_probs.append(left_prob)
                             left_inclusive_probs.append(left_prob + target_prob)
                 out['datasets'][dataset] = {
@@ -1005,9 +1005,9 @@ class Trainer:
                         target_logits = logits.gather(-1, Y.unsqueeze(-1)).squeeze(-1)
                         ranks = (logits > target_logits.unsqueeze(-1)).sum(dim=-1) + 1
                         target_ranks.append(ranks.float())
-                        target_prob = probs.gather(-1, Y.unsqueeze(-1)).squeeze(-1)
+                        target_prob = probs.gather(-1, Y.unsqueeze(-1)).squeeze(-1).float()
                         target_probs.append(target_prob)
-                        left_prob = (probs * (probs > target_prob.unsqueeze(-1))).sum(dim=-1)
+                        left_prob = (probs * (probs > target_prob.unsqueeze(-1))).sum(dim=-1).float()
                         target_left_probs.append(left_prob)
                         left_inclusive_probs.append(left_prob + target_prob)
                 out[split] = losses.mean()

--- a/train.py
+++ b/train.py
@@ -925,7 +925,7 @@ class Trainer:
                         'target_left_prob': torch.cat(target_left_probs).mean() if target_left_probs else torch.tensor(float('nan')),
                         'target_prob': torch.cat(target_probs).mean() if target_probs else torch.tensor(float('nan')),
                         'target_rank_95': torch.quantile(torch.cat(target_ranks), 0.95) if target_ranks else torch.tensor(float('nan')),
-                        'left_prob_95': torch.quantile(torch.cat(left_inclusive_probs), 0.95) if left_inclusive_probs else torch.tensor(float('nan')),
+                        'left_prob_95': torch.quantile(torch.cat(left_inclusive_probs).float(), 0.95) if left_inclusive_probs else torch.tensor(float('nan')),
                         }
             out['val'] = out['datasets'][self.args.dataset]['val']
             out['val_std'] = out['datasets'][self.args.dataset]['val_std']
@@ -1019,7 +1019,7 @@ class Trainer:
                     out['target_left_prob'] = torch.cat(target_left_probs).mean() if target_left_probs else torch.tensor(float('nan'))
                     out['target_prob'] = torch.cat(target_probs).mean() if target_probs else torch.tensor(float('nan'))
                     out['target_rank_95'] = torch.quantile(torch.cat(target_ranks), 0.95) if target_ranks else torch.tensor(float('nan'))
-                    out['left_prob_95'] = torch.quantile(torch.cat(left_inclusive_probs), 0.95) if left_inclusive_probs else torch.tensor(float('nan'))
+                    out['left_prob_95'] = torch.quantile(torch.cat(left_inclusive_probs).float(), 0.95) if left_inclusive_probs else torch.tensor(float('nan'))
 
         # compute statistics from a single validation batch
         if self.compute_model_stats:

--- a/train.py
+++ b/train.py
@@ -113,6 +113,8 @@ class Trainer:
         self.latest_top1_correct = float('nan')
         self.latest_target_rank = float('nan')
         self.latest_target_left_prob = float('nan')
+        self.latest_rank_95 = float('nan')
+        self.latest_left_prob_95 = float('nan')
 
         # store overall statistics for weights and activations
         self.latest_overall_weight_stats = {
@@ -884,7 +886,7 @@ class Trainer:
             for dataset in self.args.dataset_list:
                 print(f"Calculating loss for dataset: {dataset}")
                 dataset_losses = {'train': torch.zeros(self.args.eval_iters), 'val': torch.zeros(self.args.eval_iters)}
-                top1_probs, top1_corrects, target_ranks, target_left_probs = [], [], [], []
+                top1_probs, top1_corrects, target_ranks, target_left_probs, left_inclusive_probs = [], [], [], [], []
                 for split in ['train', 'val']:
                     for k in range(self.args.eval_iters):
                         X, Y, test_dataset = self.get_batch(split, target_dataset=dataset)
@@ -909,6 +911,7 @@ class Trainer:
                             target_prob = probs.gather(-1, Y.unsqueeze(-1)).squeeze(-1)
                             left_prob = (probs * (probs > target_prob.unsqueeze(-1))).sum(dim=-1)
                             target_left_probs.append(left_prob)
+                            left_inclusive_probs.append(left_prob + target_prob)
                 out['datasets'][dataset] = {
                         'train': dataset_losses['train'].mean(),
                         'train_std': dataset_losses['train'].std(),
@@ -918,6 +921,8 @@ class Trainer:
                         'top1_correct': torch.cat(top1_corrects).mean() if top1_corrects else torch.tensor(float('nan')),
                         'target_rank': torch.cat(target_ranks).mean() if target_ranks else torch.tensor(float('nan')),
                         'target_left_prob': torch.cat(target_left_probs).mean() if target_left_probs else torch.tensor(float('nan')),
+                        'target_rank_95': torch.quantile(torch.cat(target_ranks), 0.95) if target_ranks else torch.tensor(float('nan')),
+                        'left_prob_95': torch.quantile(torch.cat(left_inclusive_probs), 0.95) if left_inclusive_probs else torch.tensor(float('nan')),
                         }
             out['val'] = out['datasets'][self.args.dataset]['val']
             out['val_std'] = out['datasets'][self.args.dataset]['val_std']
@@ -927,6 +932,8 @@ class Trainer:
             out['top1_correct'] = out['datasets'][self.args.dataset]['top1_correct']
             out['target_rank'] = out['datasets'][self.args.dataset]['target_rank']
             out['target_left_prob'] = out['datasets'][self.args.dataset]['target_left_prob']
+            out['target_rank_95'] = out['datasets'][self.args.dataset]['target_rank_95']
+            out['left_prob_95'] = out['datasets'][self.args.dataset]['left_prob_95']
         elif self.args.training_mode == "multicontext":
             for i, dataset in enumerate(self.args.multicontext_datasets):
                 out['datasets'][dataset] = {}
@@ -974,7 +981,7 @@ class Trainer:
             # Default behavior for a single dataset
             for split in ['train', 'val']:
                 losses = torch.zeros(self.args.eval_iters)
-                top1_probs, top1_corrects, target_ranks, target_left_probs = [], [], [], []
+                top1_probs, top1_corrects, target_ranks, target_left_probs, left_inclusive_probs = [], [], [], [], []
                 for k in range(self.args.eval_iters):
                     X, Y, _ = self.get_batch(split)
                     with self.ctx:
@@ -997,6 +1004,7 @@ class Trainer:
                         target_prob = probs.gather(-1, Y.unsqueeze(-1)).squeeze(-1)
                         left_prob = (probs * (probs > target_prob.unsqueeze(-1))).sum(dim=-1)
                         target_left_probs.append(left_prob)
+                        left_inclusive_probs.append(left_prob + target_prob)
                 out[split] = losses.mean()
                 out[split + "_std"] = losses.std()
                 if split == 'val':
@@ -1004,6 +1012,8 @@ class Trainer:
                     out['top1_correct'] = torch.cat(top1_corrects).mean() if top1_corrects else torch.tensor(float('nan'))
                     out['target_rank'] = torch.cat(target_ranks).mean() if target_ranks else torch.tensor(float('nan'))
                     out['target_left_prob'] = torch.cat(target_left_probs).mean() if target_left_probs else torch.tensor(float('nan'))
+                    out['target_rank_95'] = torch.quantile(torch.cat(target_ranks), 0.95) if target_ranks else torch.tensor(float('nan'))
+                    out['left_prob_95'] = torch.quantile(torch.cat(left_inclusive_probs), 0.95) if left_inclusive_probs else torch.tensor(float('nan'))
 
         # compute statistics from a single validation batch
         if self.compute_model_stats:
@@ -1192,6 +1202,8 @@ class Trainer:
                 self.writer.add_scalar(f"{target_dataset}/avg_top1_correct", losses['top1_correct'], self.iter_num)
                 self.writer.add_scalar(f"{target_dataset}/avg_target_rank", losses['target_rank'], self.iter_num)
                 self.writer.add_scalar(f"{target_dataset}/avg_target_left_prob", losses['target_left_prob'], self.iter_num)
+                self.writer.add_scalar(f"{target_dataset}/target_rank_95", losses['target_rank_95'], self.iter_num)
+                self.writer.add_scalar(f"{target_dataset}/left_prob_95", losses['left_prob_95'], self.iter_num)
 
             if self.args.gns_type is not None:
                 self.writer.add_scalar(f"{target_dataset}/gns_iters", self.gns, self.iter_num)
@@ -1390,6 +1402,8 @@ class Trainer:
                 TextColumn("[bold dark_cyan]T1C:[/bold dark_cyan]{task.fields[t1c]}"),
                 TextColumn("-- [bold dark_magenta]TR:[/bold dark_magenta]{task.fields[tr]}"),
                 TextColumn("[bold dark_magenta]TLP:[/bold dark_magenta]{task.fields[tlp]}"),
+                TextColumn("[bold dark_magenta]R95:[/bold dark_magenta]{task.fields[r95]}"),
+                TextColumn("[bold dark_magenta]P95:[/bold dark_magenta]{task.fields[p95]}"),
                 console=self.console
                 )
 
@@ -1410,6 +1424,8 @@ class Trainer:
                     t1c=f"{self.latest_top1_correct:.6f}",
                     tr=f"{self.latest_target_rank:.2f}",
                     tlp=f"{self.latest_target_left_prob:.6f}",
+                    r95=f"{self.latest_rank_95:.2f}",
+                    p95=f"{self.latest_left_prob_95:.6f}",
                     )
 
             while True:
@@ -1426,6 +1442,8 @@ class Trainer:
                     self.latest_top1_correct = losses.get('top1_correct', float('nan'))
                     self.latest_target_rank = losses.get('target_rank', float('nan'))
                     self.latest_target_left_prob = losses.get('target_left_prob', float('nan'))
+                    self.latest_rank_95 = losses.get('target_rank_95', float('nan'))
+                    self.latest_left_prob_95 = losses.get('left_prob_95', float('nan'))
 
                     if self.args.gns_type is not None:
                         self.gns = self.gns_ema.get_gns()
@@ -1528,6 +1546,8 @@ class Trainer:
                                         f"{losses.get('top1_correct', float('nan')):.6f}",
                                         f"{losses.get('target_rank', float('nan')):.2f}",
                                         f"{losses.get('target_left_prob', float('nan')):.6f}",
+                                        f"{losses.get('target_rank_95', float('nan')):.2f}",
+                                        f"{losses.get('left_prob_95', float('nan')):.6f}",
                                         f"{self.latest_overall_weight_stats['stdev']:.6f}",
                                         f"{self.latest_overall_weight_stats['kurtosis']:.6f}",
                                         f"{self.latest_overall_weight_stats['max']:.6f}",
@@ -1781,6 +1801,8 @@ class Trainer:
                         t1c=f"{self.latest_top1_correct:.6f}",
                         tr=f"{self.latest_target_rank:.2f}",
                         tlp=f"{self.latest_target_left_prob:.6f}",
+                        r95=f"{self.latest_rank_95:.2f}",
+                        p95=f"{self.latest_left_prob_95:.6f}",
                         )
                 live.update(Group(progress.get_renderable(), cli_text))
 


### PR DESCRIPTION
## Summary
- Track probability mass of tokens ranked above the target during evaluation
- Log and persist the new `avg_target_left_prob` metric in training outputs
- Display and parse the metric in experiment utilities and exploration monitor

## Testing
- `pytest` *(fails: RuntimeError: Failed initializing MeCab; no such file or directory: /usr/local/etc/mecabrc)*


------
https://chatgpt.com/codex/tasks/task_e_68b227c63b808326a00ed328093b484e