### PR TITLE
Add softshrink squared activation variant

### DIFF
--- a/tests/test_all_activation_variations_cpu.sh
+++ b/tests/test_all_activation_variations_cpu.sh
@@ -20,6 +20,8 @@ activation_variation=("celu"
             "silu"
             "softplus"
             "softsign"
+            "softshrink"
+            "softshrink_squared"
             "squared_relu"
             "tanh")
 

--- a/train_args.py
+++ b/train_args.py
@@ -610,6 +610,7 @@ def parse_args():
             "softplus",
             "softsign",
             "softshrink",
+            "softshrink_squared",
             "squared_relu",
             "tanh",
             "identity",

--- a/variations/activation_variations.py
+++ b/variations/activation_variations.py
@@ -310,6 +310,16 @@ class Softshrink_Config(nn.Module):
     def forward(self, x):
         return self.activation(x)
 
+class SoftshrinkSquared_Config(nn.Module):
+    def __init__(self, config=None):
+        super().__init__()
+        lambd = getattr(config, "softshrink_lambda", 0.5) if config is not None else 0.5
+        self.activation = nn.Softshrink(lambd=lambd)
+
+    def forward(self, x):
+        out = self.activation(x)
+        return out * out
+
 class Tanh_Config(ActivationWrapper):
     def __init__(self, config=None):
         super().__init__(nn.Tanh, config)
@@ -341,6 +351,7 @@ activation_dictionary = {
     "softplus": Softplus_Config,
     "softsign": Softsign_Config,
     "softshrink": Softshrink_Config,
+    "softshrink_squared": SoftshrinkSquared_Config,
     "squared_relu": SquaredReLU,
     "tanh": Tanh_Config,
     "identity": Identity_Config,


### PR DESCRIPTION
## Summary
- add SoftshrinkSquared activation implementation and register it
- expose `softshrink_squared` in training arguments and activation tests

## Testing
- `python train.py --max_iters 1 --n_layer 1 --n_head 1 --n_kv_group 1 --n_embd 32 --eval_iters 1 --eval_interval 1 --log_interval 1 --device cpu --dataset shakespeare_char --activation_variant softshrink_squared --block_size 32 --out_dir /tmp/softshrink_sq_test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jamo'; ModuleNotFoundError: No module named 'yakinori')*

------
https://chatgpt.com/codex/tasks/task_e_68b37a64a884832689f16b1391e93e6b