### PR TITLE
Add value vector normalization option

### DIFF
--- a/explorations/v_norm_vs_qk_norm.yaml
+++ b/explorations/v_norm_vs_qk_norm.yaml
@@ -1,0 +1,23 @@
+# v_norm_vs_qk_norm.yaml
+---
+# parameter_groups: define sets of overrides to compare normalization strategies
+parameter_groups:
+  - use_qk_norm: [false]
+    use_v_norm: [false]
+  - use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+    use_v_norm: [false]
+  - use_qk_norm: [false]
+    use_v_norm: [true]
+
+# base hyperparameters
+max_iters: [5000]
+n_layer: [6]
+n_head: [6]
+n_embd: [384]
+block_size: [256]
+device: ["cuda"]
+dtype: ["float16"]
+dataset: ["shakespeare_char"]
+
+compile: [true]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -167,6 +167,7 @@ class GPTConfig:
     # QK Norm Options
     use_qk_norm: bool = False
     use_qk_norm_scale: bool = False
+    use_v_norm: bool = False
 
     ## SSM - Attention Varient (same as Hymba)
     ssm_mamba_expand: int = 2

--- a/train_args.py
+++ b/train_args.py
@@ -719,6 +719,7 @@ def parse_args():
     ## qk_norm variations
     model_group.add_argument("--use_qk_norm",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="applies the norm to q and k before attn")
     model_group.add_argument("--use_qk_norm_scale",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="applies norm scale, preloads scale for flash attn, post qk multiplication in manual attn")
+    model_group.add_argument("--use_v_norm",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="applies the norm to v before attn output")
 
     ## Flash Lobo
     model_group.add_argument("--use_flash_lobo",   type=bool, default=False, action=argparse.BooleanOptionalAction)

--- a/variations/attention_variations.py
+++ b/variations/attention_variations.py
@@ -108,9 +108,10 @@ class CausalSelfAttention(nn.Module):
         self.window_size = config.window_size
         print(f"sliding window size: {self.window_size}")
 
-        # qk_norm
+        # qk_norm and v_norm
         self.use_qk_norm = config.use_qk_norm
         self.use_qk_norm_scale = config.use_qk_norm_scale
+        self.use_v_norm = config.use_v_norm
 
         # Flash Lobo
         self.use_flash_lobo = config.use_flash_lobo
@@ -287,6 +288,9 @@ class CausalSelfAttention(nn.Module):
         if self.use_qk_norm:
             q = q / (q.norm(dim=-1, keepdim=True) + 1e-6)
             k = k / (k.norm(dim=-1, keepdim=True) + 1e-6)
+
+        if self.use_v_norm:
+            v = v / (v.norm(dim=-1, keepdim=True) + 1e-6)
 
         # causal self-attention; Self-attend: (B, nh, T, hs) x (B, nh, hs, T) -> (B, nh, T, T)
         if self.flash:
@@ -660,6 +664,7 @@ class InfiniteHeadAttention(nn.Module):
         # QK Norm
         self.use_qk_norm        = config.use_qk_norm
         self.use_qk_norm_scale  = config.use_qk_norm_scale
+        self.use_v_norm         = config.use_v_norm
 
         # Flash Lobo
         self.use_flash_lobo          = config.use_flash_lobo
@@ -768,6 +773,9 @@ class InfiniteHeadAttention(nn.Module):
         if self.use_qk_norm:
             q = q / (q.norm(dim=-1, keepdim=True) + 1e-6)
             k = k / (k.norm(dim=-1, keepdim=True) + 1e-6)
+
+        if self.use_v_norm:
+            v = v / (v.norm(dim=-1, keepdim=True) + 1e-6)
 
         y = None
         att = None


### PR DESCRIPTION
## Summary
- add `use_v_norm` config and CLI flag to normalize attention value vectors
- apply value-vector normalization in attention modules
- add exploration config to compare default, qk norm, and v norm settings

## Testing
- `pytest` *(fails: Failed initializing MeCab. Please see the README for possible solutions: [ifs] no such file or directory: /usr/local/etc/mecabrc)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f6834f448326812d44bd5068b69b