### PR TITLE
Add top-k table view to colorize_dataset

### DIFF
--- a/colorize_dataset.py
+++ b/colorize_dataset.py
@@ -116,6 +116,8 @@ def parse_args():
     p.add_argument("--rank_red", type=int, default=100, help="Rank value treated as fully red in heatmap")
     p.add_argument("--target_style", default="cyan",
                    help="Color to highlight the target token or 'underline' to underline it")
+    p.add_argument("--bold_target", action=argparse.BooleanOptionalAction, default=True,
+                   help="Bold the target token when highlighting")
     p.add_argument("--escape_whitespace", action=argparse.BooleanOptionalAction, default=True,
                    help="Show newline and tab characters as escape sequences")
     p.add_argument("--plot_metrics", action="store_true", help="Generate Plotly graphs for prediction metrics")
@@ -238,12 +240,16 @@ def main():
             words: List[Text] = []
             for idx, v in zip(topi.tolist(), norm.tolist()):
                 r = int((1 - v) * 255); g = int(v * 255)
-                style = f"bold #{r:02x}{g:02x}00"
+                style = f"#{r:02x}{g:02x}00"
                 if idx == tgt_token:
                     if args.target_style == "underline":
+                        if args.bold_target:
+                            style += " bold"
                         style += " underline"
                     else:
-                        style = f"bold {args.target_style}"
+                        style = args.target_style
+                        if args.bold_target:
+                            style = f"bold {style}"
                 token = decode([idx])
                 if args.max_token_chars >= 0:
                     token = token[: args.max_token_chars]
@@ -268,7 +274,12 @@ def main():
                 target_word = target_word[: args.max_token_chars]
             if args.escape_whitespace:
                 target_word = _escape_ws(target_word)
-            target_style = f"bold {args.target_style}" if args.target_style != "underline" else "bold underline"
+            if args.target_style == "underline":
+                target_style = "underline"
+            else:
+                target_style = args.target_style
+            if args.bold_target:
+                target_style = f"bold {target_style}" if target_style else "bold"
 
             row = [Text(target_word, style=target_style), f"{ce:.4f}", rank_text, p_tgt_text, p_left_text] + words
             table.add_row(*row)

--- a/colorize_dataset.py
+++ b/colorize_dataset.py
@@ -114,6 +114,8 @@ def parse_args():
     p.add_argument("--topk", type=int, default=10, help="Number of top predictions to display when using topk display")
     p.add_argument("--max_token_chars", type=int, default=20, help="Maximum characters for top-k token columns (-1 to disable clipping)")
     p.add_argument("--rank_red", type=int, default=100, help="Rank value treated as fully red in heatmap")
+    p.add_argument("--target_style", choices=["orange", "underline"], default="orange",
+                   help="How to highlight the target token in top-k display")
     p.add_argument("--escape_whitespace", action=argparse.BooleanOptionalAction, default=True,
                    help="Show newline and tab characters as escape sequences")
     p.add_argument("--plot_metrics", action="store_true", help="Generate Plotly graphs for prediction metrics")
@@ -238,7 +240,10 @@ def main():
                 r = int((1 - v) * 255); g = int(v * 255)
                 style = f"bold #{r:02x}{g:02x}00"
                 if idx == tgt_token:
-                    style += " underline"
+                    if args.target_style == "underline":
+                        style += " underline"
+                    else:
+                        style = "bold #ff8800"
                 token = decode([idx])
                 if args.max_token_chars >= 0:
                     token = token[: args.max_token_chars]
@@ -263,8 +268,9 @@ def main():
                 target_word = target_word[: args.max_token_chars]
             if args.escape_whitespace:
                 target_word = _escape_ws(target_word)
+            target_style = "bold #ff8800" if args.target_style == "orange" else "bold underline"
 
-            row = [Text(target_word), f"{ce:.4f}", rank_text, p_tgt_text, p_left_text] + words
+            row = [Text(target_word, style=target_style), f"{ce:.4f}", rank_text, p_tgt_text, p_left_text] + words
             table.add_row(*row)
 
         # advance

--- a/colorize_dataset.py
+++ b/colorize_dataset.py
@@ -165,6 +165,13 @@ def main():
     if args.display == "token":
         ids: List[int] = []
         scalars: List[float] = []
+    else:
+        table = Table(show_header=False, box=None, pad_edge=False)
+        table.add_column("rank", justify="right", no_wrap=True)
+        table.add_column("p_tgt", justify="right", no_wrap=True)
+        table.add_column("p_left", justify="right", no_wrap=True)
+        for _ in range(args.topk):
+            table.add_column(justify="center", no_wrap=True)
 
     while tokens_left > 0:
         # Build window
@@ -203,16 +210,8 @@ def main():
                     style += " underline"
                 words.append(Text(decode([idx]), style=style))
 
-            table = Table(show_header=False, box=None, pad_edge=False)
-            table.add_column("rank")
-            table.add_column("p_tgt")
-            table.add_column("p_left")
-            for _ in range(args.topk):
-                table.add_column(justify="center")
             row = [str(rank), f"{tgt_prob:.4f}", f"{prob_left:.4f}"] + words
             table.add_row(*row)
-            console.print(table)
-            lines.append(_ansi(table))
 
         # advance
         step = 1 if args.window == "rolling" else ctx_len
@@ -223,6 +222,9 @@ def main():
         coloured = _colour(ids, scalars, decode)
         console.print(coloured)
         lines.append(_ansi(coloured))
+    else:
+        console.print(table)
+        lines.append(_ansi(table))
 
     if args.output_file:
         Path(args.output_file).write_text("".join(lines), "utf-8", errors="replace")

--- a/colorize_dataset.py
+++ b/colorize_dataset.py
@@ -114,8 +114,8 @@ def parse_args():
     p.add_argument("--topk", type=int, default=10, help="Number of top predictions to display when using topk display")
     p.add_argument("--max_token_chars", type=int, default=20, help="Maximum characters for top-k token columns (-1 to disable clipping)")
     p.add_argument("--rank_red", type=int, default=100, help="Rank value treated as fully red in heatmap")
-    p.add_argument("--target_style", choices=["orange", "underline"], default="orange",
-                   help="How to highlight the target token in top-k display")
+    p.add_argument("--target_style", default="cyan",
+                   help="Color to highlight the target token or 'underline' to underline it")
     p.add_argument("--escape_whitespace", action=argparse.BooleanOptionalAction, default=True,
                    help="Show newline and tab characters as escape sequences")
     p.add_argument("--plot_metrics", action="store_true", help="Generate Plotly graphs for prediction metrics")
@@ -243,7 +243,7 @@ def main():
                     if args.target_style == "underline":
                         style += " underline"
                     else:
-                        style = "bold #ff8800"
+                        style = f"bold {args.target_style}"
                 token = decode([idx])
                 if args.max_token_chars >= 0:
                     token = token[: args.max_token_chars]
@@ -268,7 +268,7 @@ def main():
                 target_word = target_word[: args.max_token_chars]
             if args.escape_whitespace:
                 target_word = _escape_ws(target_word)
-            target_style = "bold #ff8800" if args.target_style == "orange" else "bold underline"
+            target_style = f"bold {args.target_style}" if args.target_style != "underline" else "bold underline"
 
             row = [Text(target_word, style=target_style), f"{ce:.4f}", rank_text, p_tgt_text, p_left_text] + words
             table.add_row(*row)


### PR DESCRIPTION
## Summary
- add `--display topk` mode with `--topk` depth control
- show per-token top-k logits in colored table, underlining the target when present
- generalize ANSI helper to support arbitrary rich renderables

## Testing
- `python -m py_compile colorize_dataset.py`
- `python colorize_dataset.py --help` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b5ed1e8ef48326ab3d8a743ce3dd36