### PR TITLE
Add target token column, metrics plotting, whitespace escaping, bold target option and top-k display to colorize_dataset

### DIFF
--- a/colorize_dataset.py
+++ b/colorize_dataset.py
@@ -30,13 +30,14 @@ python colorize_dataset.py \
 """
 from __future__ import annotations
 
-import argparse, io, pickle
+import argparse, io, pickle, math
 from pathlib import Path
 from typing import Callable, List, Sequence
 
 import numpy as np
 import torch, torch.nn.functional as F
 from rich.console import Console
+from rich.table import Table
 from rich.text import Text
 import tiktoken  # type: ignore
 
@@ -46,18 +47,25 @@ from model import GPT, GPTConfig
 # helpers
 ################################################################################
 
-def _ansi(text: Text) -> str:
-    buf = io.StringIO(); Console(file=buf, force_terminal=True, color_system="truecolor").print(text)
+def _ansi(renderable) -> str:
+    buf = io.StringIO()
+    Console(file=buf, force_terminal=True, color_system="truecolor").print(renderable)
     return buf.getvalue()
 
 
-def _colour(ids: List[int], scalars: List[float], decode: Callable[[Sequence[int]], str]) -> Text:
+def _escape_ws(text: str) -> str:
+    return text.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+
+def _colour(ids: List[int], scalars: List[float], decode: Callable[[Sequence[int]], str], escape_ws: bool = True) -> Text:
     vals = torch.tensor(scalars, dtype=torch.float32)
     norm = (vals - vals.min()) / (vals.max() - vals.min() + 1e-6)
     out = Text()
     for tid, v in zip(ids, norm):
         r = int((1 - v.item()) * 255); g = int(v.item() * 255)
-        out.append(decode([tid]), style=f"bold #{r:02x}{g:02x}00")
+        token = decode([tid])
+        if escape_ws:
+            token = _escape_ws(token)
+        out.append(token, style=f"bold #{r:02x}{g:02x}00")
     return out
 
 # byte-fallback helpers -------------------------------------------------------
@@ -102,6 +110,19 @@ def parse_args():
     p.add_argument("--window", choices=["block", "rolling"], default="block", help="Context window strategy")
     p.add_argument("--offset", type=int, default=0, help="Starting token index within the binary dataset file")
     p.add_argument("--output_file", default="dataset_color.txt")
+    p.add_argument("--display", choices=["token", "topk"], default="token", help="Output format")
+    p.add_argument("--topk", type=int, default=10, help="Number of top predictions to display when using topk display")
+    p.add_argument("--max_token_chars", type=int, default=20, help="Maximum characters for top-k token columns (-1 to disable clipping)")
+    p.add_argument("--rank_red", type=int, default=100, help="Rank value treated as fully red in heatmap")
+    p.add_argument("--target_style", default="cyan",
+                   help="Color to highlight the target token or 'underline' to underline it")
+    p.add_argument("--bold_target", action=argparse.BooleanOptionalAction, default=True,
+                   help="Bold the target token when highlighting")
+    p.add_argument("--escape_whitespace", action=argparse.BooleanOptionalAction, default=True,
+                   help="Show newline and tab characters as escape sequences")
+    p.add_argument("--plot_metrics", action="store_true", help="Generate Plotly graphs for prediction metrics")
+    p.add_argument("--plot_file", default="metrics.html", help="Output HTML file for Plotly metrics")
+    p.add_argument("--focal_gamma", type=float, default=2.0, help="Focal loss gamma for metrics plotting")
     return p.parse_args()
 
 
@@ -156,13 +177,34 @@ def main():
     pos = args.offset
     tokens_left = min(args.num_tokens, len(data) - 1 - pos)
 
-    ids: List[int] = []
-    scalars: List[float] = []
+    lines: List[str] = []
+
+    if args.display == "token":
+        ids: List[int] = []
+        scalars: List[float] = []
+    else:
+        table = Table(show_header=False, box=None, pad_edge=False)
+        table.add_column("target", no_wrap=True)
+        table.add_column("xent", justify="right", no_wrap=True)
+        table.add_column("rank", justify="right", no_wrap=True)
+        table.add_column("p_tgt", justify="right", no_wrap=True)
+        table.add_column("p_left", justify="right", no_wrap=True)
+        for _ in range(args.topk):
+            table.add_column(justify="center", no_wrap=True)
+
+    if args.plot_metrics:
+        metrics_rank: List[float] = []
+        metrics_p_left: List[float] = []
+        metrics_p_tgt: List[float] = []
+        metrics_p_top1: List[float] = []
+        metrics_ce: List[float] = []
+        metrics_focal: List[float] = []
 
     while tokens_left > 0:
         # Build window
         seq = data[pos : pos + block + 1]
-        if len(seq) < 2: break  # not enough tokens to predict next
+        if len(seq) < 2:
+            break  # not enough tokens to predict next
 
         ctx_tok = torch.from_numpy(seq[:-1].astype(np.int64))[None].to(args.device)
         with autocast_ctx:
@@ -171,25 +213,111 @@ def main():
         ctx_len = logits.size(0)
         tgt_token = int(seq[-1])  # ground-truth next token
 
-        # chosen scalar
-        scalar_val = (
-            F.softmax(logits[-1], dim=-1)[tgt_token].item()
-            if args.mode == "softmax" else logits[-1, tgt_token].item()
-        )
-        ids.append(tgt_token)
-        scalars.append(scalar_val)
+        probs = F.softmax(logits[-1], dim=-1)
+        tgt_prob = probs[tgt_token].item()
+        tgt_logit = logits[-1, tgt_token].item()
+        rank = int((logits[-1] > logits[-1, tgt_token]).sum().item()) + 1
+        prob_left = probs[logits[-1] > logits[-1, tgt_token]].sum().item()
+        p_top1 = probs.max().item()
+        ce = -math.log(tgt_prob + 1e-12)
+        focal = ((1 - tgt_prob) ** args.focal_gamma) * ce
+
+        if args.plot_metrics:
+            metrics_rank.append(rank)
+            metrics_p_left.append(prob_left)
+            metrics_p_tgt.append(tgt_prob)
+            metrics_p_top1.append(p_top1)
+            metrics_ce.append(ce)
+            metrics_focal.append(focal)
+
+        if args.display == "token":
+            scalar_val = tgt_prob if args.mode == "softmax" else tgt_logit
+            ids.append(tgt_token)
+            scalars.append(scalar_val)
+        else:
+            topv, topi = logits[-1].topk(args.topk)
+            norm = (topv - topv.min()) / (topv.max() - topv.min() + 1e-6)
+            words: List[Text] = []
+            for idx, v in zip(topi.tolist(), norm.tolist()):
+                r = int((1 - v) * 255); g = int(v * 255)
+                style = f"#{r:02x}{g:02x}00"
+                if idx == tgt_token:
+                    if args.target_style == "underline":
+                        if args.bold_target:
+                            style += " bold"
+                        style += " underline"
+                    else:
+                        style = args.target_style
+                        if args.bold_target:
+                            style = f"bold {style}"
+                token = decode([idx])
+                if args.max_token_chars >= 0:
+                    token = token[: args.max_token_chars]
+                if args.escape_whitespace:
+                    token = _escape_ws(token)
+                words.append(Text(token, style=style))
+
+            rank_norm = 1 - (min(rank, args.rank_red) - 1) / max(args.rank_red - 1, 1)
+            r = int((1 - rank_norm) * 255); g = int(rank_norm * 255)
+            rank_text = Text(str(rank), style=f"bold #{r:02x}{g:02x}00")
+
+            v = tgt_prob
+            r = int((1 - v) * 255); g = int(v * 255)
+            p_tgt_text = Text(f"{tgt_prob:.4f}", style=f"bold #{r:02x}{g:02x}00")
+
+            v = 1 - prob_left
+            r = int((1 - v) * 255); g = int(v * 255)
+            p_left_text = Text(f"{prob_left:.4f}", style=f"bold #{r:02x}{g:02x}00")
+
+            target_word = decode([tgt_token])
+            if args.max_token_chars >= 0:
+                target_word = target_word[: args.max_token_chars]
+            if args.escape_whitespace:
+                target_word = _escape_ws(target_word)
+            if args.target_style == "underline":
+                target_style = "underline"
+            else:
+                target_style = args.target_style
+            if args.bold_target:
+                target_style = f"bold {target_style}" if target_style else "bold"
+
+            row = [Text(target_word, style=target_style), f"{ce:.4f}", rank_text, p_tgt_text, p_left_text] + words
+            table.add_row(*row)
 
         # advance
         step = 1 if args.window == "rolling" else ctx_len
         pos += step
         tokens_left -= 1 if args.window == "rolling" else min(ctx_len, tokens_left)
 
-    coloured = _colour(ids, scalars, decode)
-    console.print(coloured)
+    if args.display == "token":
+        coloured = _colour(ids, scalars, decode, escape_ws=args.escape_whitespace)
+        console.print(coloured)
+        lines.append(_ansi(coloured))
+    else:
+        console.print(table)
+        lines.append(_ansi(table))
 
     if args.output_file:
-        Path(args.output_file).write_text(_ansi(coloured), "utf-8", errors="replace")
+        Path(args.output_file).write_text("".join(lines), "utf-8", errors="replace")
         console.print(f"[cyan]Saved → {args.output_file}[/cyan]")
+
+    if args.plot_metrics:
+        from plotly.subplots import make_subplots
+        import plotly.graph_objects as go
+
+        x = list(range(len(metrics_rank)))
+        fig = make_subplots(rows=6, cols=1, shared_xaxes=True,
+                            subplot_titles=["target rank", "prob left", "p(target)",
+                                            "p(top1)", "cross entropy", "focal loss"])
+        fig.add_trace(go.Scatter(x=x, y=metrics_rank, name="rank"), row=1, col=1)
+        fig.add_trace(go.Scatter(x=x, y=metrics_p_left, name="p_left"), row=2, col=1)
+        fig.add_trace(go.Scatter(x=x, y=metrics_p_tgt, name="p_tgt"), row=3, col=1)
+        fig.add_trace(go.Scatter(x=x, y=metrics_p_top1, name="p_top1"), row=4, col=1)
+        fig.add_trace(go.Scatter(x=x, y=metrics_ce, name="cross_entropy"), row=5, col=1)
+        fig.add_trace(go.Scatter(x=x, y=metrics_focal, name="focal"), row=6, col=1)
+        fig.update_layout(height=300 * 6, showlegend=False)
+        fig.write_html(args.plot_file)
+        console.print(f"[cyan]Saved plot → {args.plot_file}[/cyan]")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- show target token and cross entropy alongside rank and probability columns in top-k table
- enable Plotly metrics graphs via `--plot_metrics` with configurable focal loss gamma
- optionally escape newline and tab characters in tokens with `--escape_whitespace`
- default to cyan target token highlighting with `--target_style` option in top-k display
- allow bolding the target token with `--bold_target/--no-bold_target`

## Testing
- `python -m py_compile colorize_dataset.py`
- `python colorize_dataset.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68b5ed1e8ef48326ab3d8a743ce3dd36