### PR TITLE
Add matrix-based learned confidence scaling option

### DIFF
--- a/documentation/Learned_Confidence.md
+++ b/documentation/Learned_Confidence.md
@@ -1,13 +1,13 @@
 # Learned Confidence Residual Scaling
 
-This feature lets each transformer block learn a scalar "confidence" for its output before adding it back to the residual stream. A learned vector takes a dot product with the attention or MLP output, optionally adds a constant, and the result scales the activation.
+This feature lets each transformer block learn a scalar "confidence" for its output before adding it back to the residual stream. A learned vector takes a dot product with the attention or MLP output, optionally adds a constant, and the result scales the activation. A matrix variant instead multiplies the activation by a learned matrix, sums the resulting values, and uses that scalar to scale the activation.
 
 ## Configuration
 
 Enable the scalers and choose their initialization in `gpt_conf.py` or via `train_args.py`:
 
 - `--use_attn_resid_scaling`, `--use_mlp_resid_scaling`
-- `--attn_confidence_variant`, `--mlp_confidence_variant` (`zeros`, `ones`, `gaussian`)
+- `--attn_confidence_variant`, `--mlp_confidence_variant` (`zeros`, `ones`, `gaussian`, `matrix`)
 - `--use_attn_resid_const`, `--attn_resid_const`, `--learn_attn_resid_const`
 - `--use_mlp_resid_const`, `--mlp_resid_const`, `--learn_mlp_resid_const`
 

--- a/train_args.py
+++ b/train_args.py
@@ -543,11 +543,11 @@ def parse_args():
     model_group.add_argument('--shared_attn_seq', default=1, type=int, help="Sequence length for cyclic sharing of attention layers")
 
     ## Learned Confidence Residual Scaling
-    confidence_variants = ["zeros", "ones", "gaussian"]
+    confidence_variants = ["zeros", "ones", "gaussian", "matrix"]
 
     ### Attn scaling
     model_group.add_argument('--use_attn_resid_scaling', default=False, action=argparse.BooleanOptionalAction, help='Apply learned confidence scaling to attention outputs')
-    model_group.add_argument('--attn_confidence_variant', type=str, default='zeros', choices=confidence_variants, help='Initialization for attention residual scaling vector')
+    model_group.add_argument('--attn_confidence_variant', type=str, default='zeros', choices=confidence_variants, help='Variant for attention residual scaling parameter')
 
     model_group.add_argument('--use_attn_resid_const', default=False, action=argparse.BooleanOptionalAction, help='Add constant term to attention residual scaling dot product')
     model_group.add_argument('--attn_resid_const', type=float, default=0.0, help='Constant added to attention residual scaling dot product')
@@ -555,7 +555,7 @@ def parse_args():
 
     ### MLP scaling
     model_group.add_argument('--use_mlp_resid_scaling', default=False, action=argparse.BooleanOptionalAction, help='Apply learned confidence scaling to MLP outputs')
-    model_group.add_argument('--mlp_confidence_variant', type=str, default='zeros', choices=confidence_variants, help='Initialization for MLP residual scaling vector')
+    model_group.add_argument('--mlp_confidence_variant', type=str, default='zeros', choices=confidence_variants, help='Variant for MLP residual scaling parameter')
 
     model_group.add_argument('--use_mlp_resid_const', default=False, action=argparse.BooleanOptionalAction, help='Add constant term to MLP residual scaling dot product')
     model_group.add_argument('--mlp_resid_const', type=float, default=0.0, help='Constant added to MLP residual scaling dot product')


### PR DESCRIPTION
## Summary
- Introduce matrix-based residual scaler where a learned matrix projects activations before summing to a scaling factor
- Expose new `matrix` confidence variant in training arguments
- Document matrix learned confidence variant

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'jamo', No module named 'yakinori')*
- `pip install torch jamo yakinori -q` *(cancelled: installation terminated before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68bc72e4ff4083269c7ebdc89f33c194