### PR TITLE
Track ln_f cosine similarity metric

### DIFF
--- a/optimization_and_search/run_experiments.py
+++ b/optimization_and_search/run_experiments.py
@@ -30,6 +30,7 @@ METRIC_KEYS = [
     "avg_target_prob",
     "target_rank_95",
     "left_prob_95",
+    "avg_ln_f_cosine",
 ]
 
 
@@ -211,7 +212,7 @@ def read_metrics(out_dir: str) -> dict:
     line = path.read_text().strip()
     parts = [p.strip() for p in line.split(',')]
 
-    casts = [float, int, int, float, float, float, float, float, float, float, float, float, float, float]
+    casts = [float, int, int, float, float, float, float, float, float, float, float, float, float, float, float]
     return {k: typ(v) for k, typ, v in zip(METRIC_KEYS, casts, parts)}
 
 

--- a/run_exploration_monitor.py
+++ b/run_exploration_monitor.py
@@ -179,6 +179,7 @@ class MonitorApp(App):
             "avg_target_prob",
             "target_rank_95",
             "left_prob_95",
+            "avg_ln_f_cosine",
         ] + self.param_keys
         self.all_columns = base_cols.copy()
         self.columns = base_cols.copy()
@@ -233,6 +234,7 @@ class MonitorApp(App):
             "avg_target_prob",
             "target_rank_95",
             "left_prob_95",
+            "avg_ln_f_cosine",
         ):
             return entry.get(col_name)
         return entry.get("config", {}).get(col_name)

--- a/tests/test_ln_f_cosine_config.yaml
+++ b/tests/test_ln_f_cosine_config.yaml
@@ -1,0 +1,13 @@
+- out_dir: results/lnf_cos_test
+  dataset: shakespeare_char
+  device: cpu
+  n_layer: 1
+  n_head: 1
+  n_kv_group: 1
+  n_embd: 32
+  block_size: 32
+  batch_size: 4
+  max_iters: 5
+  eval_interval: 5
+  eval_iters: 5
+  log_interval: 1

--- a/tests/test_ln_f_cosine_metric.sh
+++ b/tests/test_ln_f_cosine_metric.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# test_ln_f_cosine_metric.sh
+# Runs a tiny experiment and checks ln_f cosine similarity metric is logged.
+set -e
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$script_dir/.."
+
+log_file="exploration_logs/test_ln_f_cosine_config.yaml"
+out_dir="results/lnf_cos_test"
+# clean previous runs
+rm -f "$log_file"
+rm -rf "$out_dir"*
+
+
+dataset="shakespeare_char"
+# ensure dataset is present
+bash "data/${dataset}/get_dataset.sh"
+
+config_file="tests/test_ln_f_cosine_config.yaml"
+
+python3 optimization_and_search/run_experiments.py -c "$config_file" --config_format yaml
+
+python3 - <<'PY'
+import yaml, pathlib, math
+log_path = pathlib.Path('exploration_logs/test_ln_f_cosine_config.yaml')
+entries = list(yaml.safe_load_all(log_path.read_text()))
+assert entries, 'no entries found in log file'
+cos = entries[-1].get('avg_ln_f_cosine')
+assert cos is not None, 'avg_ln_f_cosine missing'
+assert not math.isnan(cos), 'avg_ln_f_cosine is NaN'
+print('avg_ln_f_cosine:', cos)
+PY


### PR DESCRIPTION
## Summary
- compute average cosine similarity between ln_f activations and target tokens in training and log it
- include ln_f cosine similarity in experiment metric aggregation and exploration monitor TUI
- add test script verifying ln_f cosine metric and fallback tokenizer when sample deps are missing

## Testing
- `bash tests/test_ln_f_cosine_metric.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c707204ac88326b83bb0a965739776