### PR TITLE
Track ln_f cosine similarity metric

### DIFF
--- a/optimization_and_search/run_experiments.py
+++ b/optimization_and_search/run_experiments.py
@@ -30,6 +30,8 @@ METRIC_KEYS = [
     "avg_target_prob",
     "target_rank_95",
     "left_prob_95",
+    "avg_ln_f_cosine",
+    "ln_f_cosine_95",
 ]
 
 
@@ -211,7 +213,7 @@ def read_metrics(out_dir: str) -> dict:
     line = path.read_text().strip()
     parts = [p.strip() for p in line.split(',')]
 
-    casts = [float, int, int, float, float, float, float, float, float, float, float, float, float, float]
+    casts = [float, int, int, float, float, float, float, float, float, float, float, float, float, float, float, float]
     return {k: typ(v) for k, typ, v in zip(METRIC_KEYS, casts, parts)}
 
 

--- a/run_exploration_monitor.py
+++ b/run_exploration_monitor.py
@@ -179,6 +179,8 @@ class MonitorApp(App):
             "avg_target_prob",
             "target_rank_95",
             "left_prob_95",
+            "avg_ln_f_cosine",
+            "ln_f_cosine_95",
         ] + self.param_keys
         self.all_columns = base_cols.copy()
         self.columns = base_cols.copy()
@@ -233,6 +235,8 @@ class MonitorApp(App):
             "avg_target_prob",
             "target_rank_95",
             "left_prob_95",
+            "avg_ln_f_cosine",
+            "ln_f_cosine_95",
         ):
             return entry.get(col_name)
         return entry.get("config", {}).get(col_name)

--- a/tests/test_ln_f_cosine_metric.sh
+++ b/tests/test_ln_f_cosine_metric.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# test_ln_f_cosine_metric.sh
+# Runs a minimal training loop and verifies ln_f cosine metric is produced.
+
+set -euo pipefail
+
+# Run from repo root
+pushd "$(dirname "$0")/.." >/dev/null
+
+LOGFILE=$(mktemp)
+
+python train.py \
+    --device cpu \
+    --no-compile \
+    --max_iters 1 \
+    --eval_iters 1 \
+    --eval_interval 1 \
+    --block_size 8 \
+    --batch_size 4 \
+    --n_layer 1 \
+    --n_head 1 \
+    --n_embd 32 \
+    >"$LOGFILE" 2>&1
+
+grep -E "lnf_cos" "$LOGFILE"
+grep -E "lnf_cos95" "$LOGFILE"
+
+popd >/dev/null

--- a/train.py
+++ b/train.py
@@ -114,6 +114,8 @@ class Trainer:
         self.latest_target_left_prob = float('nan')
         self.latest_rank_95 = float('nan')
         self.latest_left_prob_95 = float('nan')
+        self.latest_ln_f_cosine = float('nan')
+        self.latest_ln_f_cosine_95 = float('nan')
 
         # store overall statistics for weights and activations
         self.latest_overall_weight_stats = {
@@ -895,9 +897,14 @@ class Trainer:
                 print(f"Calculating loss for dataset: {dataset}")
                 dataset_losses = {'train': torch.zeros(self.args.eval_iters), 'val': torch.zeros(self.args.eval_iters)}
                 top1_probs, top1_corrects, target_ranks, target_probs, target_left_probs, left_inclusive_probs = [], [], [], [], [], []
+                ln_f_cosines = []
                 for split in ['train', 'val']:
                     for k in range(self.args.eval_iters):
                         X, Y, test_dataset = self.get_batch(split, target_dataset=dataset)
+                        ln_f_out: list[torch.Tensor] = []
+                        handle = self.model.transformer.ln_f.register_forward_hook(
+                            lambda _m, _i, o: ln_f_out.append(o.detach())
+                        )
                         with self.ctx:
                             idx = self.args.dataset_list.index(dataset)
                             logits, loss = self.model(
@@ -907,6 +914,7 @@ class Trainer:
                                 dataset_idx=idx if self.args.multidataset_wte else None,
                                 loss_fn=self.loss_fn,
                             )
+                        handle.remove()
                         dataset_losses[split][k] = loss.item()
                         if split == 'val':
                             probs = F.softmax(logits, dim=-1)
@@ -921,6 +929,16 @@ class Trainer:
                             left_prob = (probs * (probs > target_prob.unsqueeze(-1))).sum(dim=-1).float()
                             target_left_probs.append(left_prob)
                             left_inclusive_probs.append(left_prob + target_prob)
+                            lm_head = (
+                                self.model.transformer[f'lm_head_{idx}']
+                                if self.args.multidataset_wte
+                                else self.model.lm_head
+                            )
+                            target_vecs = lm_head.weight[Y]
+                            cos = F.cosine_similarity(
+                                ln_f_out[0].float(), target_vecs.float(), dim=-1
+                            )
+                            ln_f_cosines.append(cos)
                 out['datasets'][dataset] = {
                         'train': dataset_losses['train'].mean(),
                         'train_std': dataset_losses['train'].std(),
@@ -933,6 +951,8 @@ class Trainer:
                         'target_prob': torch.cat(target_probs).mean() if target_probs else torch.tensor(float('nan')),
                         'target_rank_95': torch.quantile(torch.cat(target_ranks), 0.95) if target_ranks else torch.tensor(float('nan')),
                         'left_prob_95': torch.quantile(torch.cat(left_inclusive_probs).float(), 0.95) if left_inclusive_probs else torch.tensor(float('nan')),
+                        'ln_f_cosine': torch.cat(ln_f_cosines).mean() if ln_f_cosines else torch.tensor(float('nan')),
+                        'ln_f_cosine_95': torch.quantile(torch.cat(ln_f_cosines), 0.95) if ln_f_cosines else torch.tensor(float('nan')),
                         }
             out['val'] = out['datasets'][self.args.dataset]['val']
             out['val_std'] = out['datasets'][self.args.dataset]['val_std']
@@ -945,6 +965,8 @@ class Trainer:
             out['target_prob'] = out['datasets'][self.args.dataset]['target_prob']
             out['target_rank_95'] = out['datasets'][self.args.dataset]['target_rank_95']
             out['left_prob_95'] = out['datasets'][self.args.dataset]['left_prob_95']
+            out['ln_f_cosine'] = out['datasets'][self.args.dataset]['ln_f_cosine']
+            out['ln_f_cosine_95'] = out['datasets'][self.args.dataset]['ln_f_cosine_95']
         elif self.args.training_mode == "multicontext":
             for i, dataset in enumerate(self.args.multicontext_datasets):
                 out['datasets'][dataset] = {}
@@ -993,8 +1015,13 @@ class Trainer:
             for split in ['train', 'val']:
                 losses = torch.zeros(self.args.eval_iters)
                 top1_probs, top1_corrects, target_ranks, target_probs, target_left_probs, left_inclusive_probs = [], [], [], [], [], []
+                ln_f_cosines = []
                 for k in range(self.args.eval_iters):
                     X, Y, _ = self.get_batch(split)
+                    ln_f_out: list[torch.Tensor] = []
+                    handle = self.model.transformer.ln_f.register_forward_hook(
+                        lambda _m, _i, o: ln_f_out.append(o.detach())
+                    )
                     with self.ctx:
                         logits, loss = self.model(
                             X,
@@ -1003,6 +1030,7 @@ class Trainer:
                             dataset_idx=0 if self.args.multidataset_wte else None,
                             loss_fn=self.loss_fn,
                         )
+                    handle.remove()
                     losses[k] = loss.item()
                     if split == 'val':
                         probs = F.softmax(logits, dim=-1)
@@ -1017,6 +1045,16 @@ class Trainer:
                         left_prob = (probs * (probs > target_prob.unsqueeze(-1))).sum(dim=-1).float()
                         target_left_probs.append(left_prob)
                         left_inclusive_probs.append(left_prob + target_prob)
+                        lm_head = (
+                            self.model.transformer['lm_head_0']
+                            if self.args.multidataset_wte
+                            else self.model.lm_head
+                        )
+                        target_vecs = lm_head.weight[Y]
+                        cos = F.cosine_similarity(
+                            ln_f_out[0].float(), target_vecs.float(), dim=-1
+                        )
+                        ln_f_cosines.append(cos)
                 out[split] = losses.mean()
                 out[split + "_std"] = losses.std()
                 if split == 'val':
@@ -1027,6 +1065,8 @@ class Trainer:
                     out['target_prob'] = torch.cat(target_probs).mean() if target_probs else torch.tensor(float('nan'))
                     out['target_rank_95'] = torch.quantile(torch.cat(target_ranks), 0.95) if target_ranks else torch.tensor(float('nan'))
                     out['left_prob_95'] = torch.quantile(torch.cat(left_inclusive_probs).float(), 0.95) if left_inclusive_probs else torch.tensor(float('nan'))
+                    out['ln_f_cosine'] = torch.cat(ln_f_cosines).mean() if ln_f_cosines else torch.tensor(float('nan'))
+                    out['ln_f_cosine_95'] = torch.quantile(torch.cat(ln_f_cosines), 0.95) if ln_f_cosines else torch.tensor(float('nan'))
 
         # compute statistics from a single validation batch
         if self.compute_model_stats:
@@ -1218,6 +1258,10 @@ class Trainer:
                 self.writer.add_scalar(f"{target_dataset}/avg_target_prob", losses['target_prob'], self.iter_num)
                 self.writer.add_scalar(f"{target_dataset}/target_rank_95", losses['target_rank_95'], self.iter_num)
                 self.writer.add_scalar(f"{target_dataset}/left_prob_95", losses['left_prob_95'], self.iter_num)
+            if 'ln_f_cosine' in losses:
+                self.writer.add_scalar(f"{target_dataset}/avg_ln_f_cosine", losses['ln_f_cosine'], self.iter_num)
+            if 'ln_f_cosine_95' in losses:
+                self.writer.add_scalar(f"{target_dataset}/ln_f_cosine_95", losses['ln_f_cosine_95'], self.iter_num)
 
             if self.args.gns_type is not None:
                 self.writer.add_scalar(f"{target_dataset}/gns_iters", self.gns, self.iter_num)
@@ -1419,6 +1463,8 @@ class Trainer:
                 TextColumn("[bold dark_magenta]TLP:[/bold dark_magenta]{task.fields[tlp]}"),
                 TextColumn("[bold dark_magenta]R95:[/bold dark_magenta]{task.fields[r95]}"),
                 TextColumn("[bold dark_magenta]P95:[/bold dark_magenta]{task.fields[p95]}"),
+                TextColumn("-- [bold dark_cyan]LnFcos:[/bold dark_cyan]{task.fields[lnf_cos]}"),
+                TextColumn("[bold dark_cyan]LnFcos95:[/bold dark_cyan]{task.fields[lnf_cos95]}"),
                 console=self.console
                 )
 
@@ -1442,6 +1488,8 @@ class Trainer:
                     tlp=f"{self.latest_target_left_prob:.6f}",
                     r95=f"{self.latest_rank_95:.2f}",
                     p95=f"{self.latest_left_prob_95:.6f}",
+                    lnf_cos=f"{self.latest_ln_f_cosine:.6f}",
+                    lnf_cos95=f"{self.latest_ln_f_cosine_95:.6f}",
                     )
 
             while True:
@@ -1461,6 +1509,8 @@ class Trainer:
                     self.latest_target_left_prob = losses.get('target_left_prob', float('nan'))
                     self.latest_rank_95 = losses.get('target_rank_95', float('nan'))
                     self.latest_left_prob_95 = losses.get('left_prob_95', float('nan'))
+                    self.latest_ln_f_cosine = losses.get('ln_f_cosine', float('nan'))
+                    self.latest_ln_f_cosine_95 = losses.get('ln_f_cosine_95', float('nan'))
 
                     if self.args.gns_type is not None:
                         self.gns = self.gns_ema.get_gns()
@@ -1566,6 +1616,8 @@ class Trainer:
                                         f"{losses.get('target_prob', float('nan')):.6f}",
                                         f"{losses.get('target_rank_95', float('nan')):.2f}",
                                         f"{losses.get('left_prob_95', float('nan')):.6f}",
+                                        f"{losses.get('ln_f_cosine', float('nan')):.6f}",
+                                        f"{losses.get('ln_f_cosine_95', float('nan')):.6f}",
                                         f"{self.latest_overall_weight_stats['stdev']:.6f}",
                                         f"{self.latest_overall_weight_stats['kurtosis']:.6f}",
                                         f"{self.latest_overall_weight_stats['max']:.6f}",
@@ -1822,6 +1874,8 @@ class Trainer:
                         tlp=f"{self.latest_target_left_prob:.6f}",
                         r95=f"{self.latest_rank_95:.2f}",
                         p95=f"{self.latest_left_prob_95:.6f}",
+                        lnf_cos=f"{self.latest_ln_f_cosine:.6f}",
+                        lnf_cos95=f"{self.latest_ln_f_cosine_95:.6f}",
                         )
                 live.update(Group(progress.get_renderable(), cli_text))
 


### PR DESCRIPTION
## Summary
- compute average and p95 cosine similarity between ln_f activations and target tokens in training and log it
- include ln_f cosine metrics in experiment aggregation and exploration monitor TUI
- add regression script exercising a tiny training run and grepping for new ln_f cosine fields

## Testing
- `bash tests/test_ln_f_cosine_metric.sh` *(fails: Error: File not found - data/shakespeare_char/meta.pkl)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'jamo'; ModuleNotFoundError: No module named 'yakinori')*


------
https://chatgpt.com/codex/tasks/task_e_68c707204ac88326b83bb0a965739776