### PR TITLE
Add tokenizer for binary files and dataset utilities

### DIFF
--- a/data/template/prepare.py
+++ b/data/template/prepare.py
@@ -8,6 +8,7 @@ from tokenizers import (
     TiktokenTokenizer,
     CustomTokenizer,
     ByteTokenizer,
+    FileByteTokenizer,
     CharTokenizer,
     CustomCharTokenizerWithByteFallback,
     JsonByteTokenizerWithByteFallback,
@@ -27,7 +28,7 @@ def parse_arguments():
 
     # Tokenizer selection and configuration
     parser.add_argument("--method", type=str,
-                       choices=["sentencepiece", "tiktoken", "char", "custom", "byte", "custom_char_byte_fallback", "json_byte_fallback"],
+                       choices=["sentencepiece", "tiktoken", "char", "custom", "byte", "file_byte", "custom_char_byte_fallback", "json_byte_fallback"],
                        default="tiktoken", help="Tokenization method")
 
     # SentencePiece arguments
@@ -68,17 +69,34 @@ def save_tokens(ids, output_file, dtype):
 def main():
     args = parse_arguments()
 
-    # Load training data
-    with open(args.train_input, 'r') as f:
-        train_data = f.read()
+    # Load training data (binary mode for file_byte tokenizer)
+    read_mode = 'rb' if args.method == 'file_byte' else 'r'
+
+    def read_folder(path):
+        files = [os.path.join(path, f) for f in sorted(os.listdir(path)) if os.path.isfile(os.path.join(path, f))]
+        contents = []
+        for fp in files:
+            with open(fp, 'rb') as fh:
+                contents.append(fh.read())
+        return contents
+
+    if args.method == 'file_byte' and os.path.isdir(args.train_input):
+        train_data = read_folder(args.train_input)
+    else:
+        with open(args.train_input, read_mode) as f:
+            train_data = f.read()
 
     # Handle validation data based on mode
     if args.val_input:
-        # Direct train/val files mode
-        with open(args.val_input, 'r') as f:
-            val_data = f.read()
+        if args.method == 'file_byte' and os.path.isdir(args.val_input):
+            val_data = read_folder(args.val_input)
+        else:
+            with open(args.val_input, read_mode) as f:
+                val_data = f.read()
     else:
-        # Automatic splitting mode
+        val_data = None
+
+    if args.val_input is None and not isinstance(train_data, list):
         n = len(train_data)
         train_data, val_data = train_data[:int(n * args.percentage_train)], train_data[int(n * args.percentage_train):]
         if args.percentage_train == 1.0:
@@ -93,6 +111,8 @@ def main():
         tokenizer = CustomTokenizer(args)
     elif args.method == "byte":
         tokenizer = ByteTokenizer(args)
+    elif args.method == "file_byte":
+        tokenizer = FileByteTokenizer(args)
     elif args.method == "char":
         tokenizer = CharTokenizer(args, train_data, val_data)
     elif args.method == "custom_char_byte_fallback":
@@ -103,8 +123,17 @@ def main():
         raise ValueError(f"Unknown tokenization method: {args.method}")
 
     # Tokenize data
-    train_ids = tokenizer.tokenize(train_data)
-    val_ids = tokenizer.tokenize(val_data) if val_data is not None else None
+    if args.method == 'file_byte' and isinstance(train_data, list):
+        train_ids = tokenizer.tokenize(train_data)
+        val_ids = tokenizer.tokenize(val_data) if isinstance(val_data, list) else None
+        if val_ids is None and args.percentage_train < 1.0:
+            n = len(train_ids)
+            split = int(n * args.percentage_train)
+            val_ids = train_ids[split:]
+            train_ids = train_ids[:split]
+    else:
+        train_ids = tokenizer.tokenize(train_data)
+        val_ids = tokenizer.tokenize(val_data) if val_data is not None else None
 
     # Determine dtype based on vocabulary size from meta.pkl
     with open("meta.pkl", "rb") as f:

--- a/demos/file_byte_folder_demo.sh
+++ b/demos/file_byte_folder_demo.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+# Demonstration of tokenizing a folder of files, training, and generating files
+DATA_DIR=data/file_byte_demo
+INPUT_DIR=$DATA_DIR/input
+OUT_DIR=out_file_byte_demo
+
+rm -rf $DATA_DIR $OUT_DIR
+mkdir -p $INPUT_DIR
+
+# Create sample files with simple patterns
+for i in {0..4}; do
+  printf "file_%d\n" $i > $INPUT_DIR/file_${i}.txt
+done
+
+# Tokenize the folder using the file_byte tokenizer
+python data/template/prepare.py --method file_byte -t $INPUT_DIR --train_output $DATA_DIR/train.bin --val_output $DATA_DIR/val.bin --percentage_train 1.0
+
+# Train a tiny model on the dataset
+python train.py --device=cpu --out_dir $OUT_DIR --dataset file_byte_demo --batch_size 4 --block_size 64 --n_layer 2 --n_head 2 --n_embd 64 --max_iters 10 --lr_decay_iters 10 --eval_interval 5 --eval_iters 5 --dropout 0.0
+
+# Sample from the model and recover generated files
+python sample.py --out_dir $OUT_DIR --num_samples 1 --max_new_tokens 100 --start "" --file_output_dir $DATA_DIR/generated
+
+echo "Generated files:" 
+ls $DATA_DIR/generated

--- a/sample.py
+++ b/sample.py
@@ -32,6 +32,7 @@ from variations.model_variations import model_variation_dictionary
 import lm_eval
 from benchmarks.gpt_lm_eval_wrapper import NanoGPTLM
 from benchmarks import run_all
+from data.template.tokenizers import FileByteTokenizer
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Inference from trained models")
@@ -48,6 +49,7 @@ def parse_args():
     parser.add_argument("--dtype", type=str, default="bfloat16", choices=["bfloat16", "float16", "float32"], help="Torch data type for inference")
     parser.add_argument('--compile', action=argparse.BooleanOptionalAction, help="Compile the model (requires PyTorch 2.0)")
     parser.add_argument('--sample_file', type=str, default=None, help="Output file for inference")
+    parser.add_argument('--file_output_dir', type=str, default=None, help="Directory to save generated files when using file_byte tokenizer")
     parser.add_argument('--interactive', action=argparse.BooleanOptionalAction, help="Enable interactive generation")
     parser.add_argument('--stop_strings', nargs='+', type=str, default=['~W'], help="One or more strings to stop generation and allow user input. ""E.g. --stop_strings \"\n\n\" \".\"")
     parser.add_argument('--last_k_tokens', type=int, default=10, help="Number of last tokens to display in heatmaps")
@@ -925,6 +927,15 @@ def get_tokenizer_functions(meta):
     if meta['tokenizer'] == 'byte':
         return byte_encode, byte_decode
 
+    if meta['tokenizer'] == 'file_byte':
+        start_token = meta['start_file_token']
+        def encode(s: str):
+            b = s.encode('latin-1')
+            return [start_token] + list(b)
+        def decode(ids: list[int]):
+            return bytes([i for i in ids if i != start_token and i != meta['end_file_token']]).decode('latin-1', errors='replace')
+        return encode, decode
+
     if meta['tokenizer'] == 'custom_char_with_byte_fallback':
         stoi, itos = meta['stoi'], meta['itos']
         encode = lambda s: custom_char_with_byte_fallback_encode(s, stoi)
@@ -1291,6 +1302,16 @@ def main():
                     key_color="bold light_slate_blue"
                     text_color="bold cyan"
                     print(f"\n[{key_color}]{key}:[/{key_color}]\n[{text_color}]{text}[/{text_color}]")
+
+                    if meta.get('tokenizer') == 'file_byte' and args.file_output_dir:
+                        tokens_full = token_dict[key][0].tolist()
+                        FileByteTokenizer.tokens_to_files(
+                            tokens_full,
+                            args.file_output_dir,
+                            meta['start_file_token'],
+                            meta['end_file_token'],
+                        )
+
                 print("---------------")
 
                 if args.sample_file:


### PR DESCRIPTION
## Summary
- allow `file_byte` tokenizer to read directories of files and wrap data with start/end markers
- support folder ingestion and file-boundary tokens in dataset prep and sampling routines
- add demo script and tests covering binary reconstruction to files

## Testing
- `python data/template/tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68c70faa7f208326b49de0e39500d94e