### PR TITLE
feat: track tokens for best validation loss

### DIFF
--- a/optimization_and_search/run_experiments.py
+++ b/optimization_and_search/run_experiments.py
@@ -18,6 +18,7 @@ METRICS_FILENAME = "best_val_loss_and_iter.txt"
 METRIC_KEYS = [
     "best_val_loss",
     "best_val_iter",
+    "best_val_tokens",
     "num_params",
     "better_than_chance",
     "btc_per_param",
@@ -211,7 +212,7 @@ def read_metrics(out_dir: str) -> dict:
     line = path.read_text().strip()
     parts = [p.strip() for p in line.split(',')]
 
-    casts = [float, int, int, float, float, float, float, float, float, float, float, float, float, float]
+    casts = [float, int, int, int, float, float, float, float, float, float, float, float, float, float, float]
     return {k: typ(v) for k, typ, v in zip(METRIC_KEYS, casts, parts)}
 
 

--- a/run_exploration_monitor.py
+++ b/run_exploration_monitor.py
@@ -169,6 +169,7 @@ class MonitorApp(App):
         base_cols = [
             "best_val_loss",
             "best_val_iter",
+            "best_val_tokens",
             "num_params",
             "peak_gpu_mb",
             "iter_latency_avg",
@@ -223,6 +224,7 @@ class MonitorApp(App):
         if col_name in (
             "best_val_loss",
             "best_val_iter",
+            "best_val_tokens",
             "num_params",
             "peak_gpu_mb",
             "iter_latency_avg",


### PR DESCRIPTION
## Summary
- show token count alongside best val loss in training progress
- record best-val tokens in metrics file and expose in experiments monitor

## Testing
- `python -m py_compile train.py optimization_and_search/run_experiments.py run_exploration_monitor.py`
- `python optimization_and_search/run_experiments.py -c /tmp/minimal.yaml --config_format yaml` *(fails: ModuleNotFoundError: No module named 'plotly')*


------
https://chatgpt.com/codex/tasks/task_e_68c72125b7ec8326a7c8f15dc134536f