### PR TITLE
Add flexible residual combination options

### DIFF
--- a/explorations/resid_sweep_100M_param.yaml
+++ b/explorations/resid_sweep_100M_param.yaml
@@ -1,4 +1,4 @@
-# explorations/residual_combination_sweep.yaml
+# explorations/resid_sweep_100M_param.yaml
 ---
 
 # QK Norm

--- a/explorations/resid_sweep_100M_param.yaml
+++ b/explorations/resid_sweep_100M_param.yaml
@@ -1,0 +1,90 @@
+# explorations/residual_combination_sweep.yaml
+---
+
+# QK Norm
+use_qk_norm: [true]
+use_qk_norm_scale: [true]
+
+# Peri Norm
+use_peri_ln: [true, false]
+
+# Embeddings
+use_rotary_embeddings: [true]
+use_abs_pos_embeddings: [false]
+
+# Attn Variations
+softmax_variant_attn: ["softmax", "relu2max"]
+
+max_iters: [10000]
+eval_interval: [10000]
+eta_variant: ["iteration"]
+n_layer: [12]
+n_head: [12]
+n_embd: [768]
+block_size: [1024]
+device: ["cuda"]
+dtype: ["bfloat16"]
+dataset: ["minipile"]
+# use_parallel_mlp: [false, true]
+
+# Activation Statistics
+# compute_model_stats: [true]
+# print_model_stats: ["./print_stats/${RUN_NAME}"]
+
+# Memory
+compile: [true]
+
+parameter_groups:
+  # Add
+  - mlp_residual_combination: ["add"]
+    attn_residual_combination: ["add"]
+    seed:
+      range:
+        start: 1330
+        end: 1339
+        step: 1
+
+
+  # Slerp
+  - mlp_residual_combination: ["slerp"]
+    attn_residual_combination: ["slerp"]
+    mlp_residual_alpha_type: ["fixed"]
+    attn_residual_alpha_type: ["fixed"]
+    attn_residual_alpha: [0.1, 0.05, 0.025]
+    mlp_residual_alpha: [0.1, 0.05, 0.025]
+
+  - mlp_residual_combination: ["slerp"]
+    attn_residual_combination: ["slerp"]
+    mlp_residual_alpha_type: ["learned"]
+    attn_residual_alpha_type: ["learned"]
+    attn_residual_alpha: [0.1, 0.05, 0.025]
+    mlp_residual_alpha: [0.1, 0.05, 0.025]
+
+  - mlp_residual_combination: ["slerp"]
+    attn_residual_combination: ["slerp"]
+    mlp_residual_alpha_type: ["dot"]
+    attn_residual_alpha_type: ["dot"]
+    attn_residual_alpha: [0.1, 0.05, 0.025]
+    mlp_residual_alpha: [0.1, 0.05, 0.025]
+
+  # Lerp
+  - mlp_residual_combination: ["lerp"]
+    attn_residual_combination: ["lerp"]
+    mlp_residual_alpha_type: ["fixed"]
+    attn_residual_alpha_type: ["fixed"]
+    attn_residual_alpha: [0.1, 0.05, 0.025]
+    mlp_residual_alpha: [0.1, 0.05, 0.025]
+
+  - mlp_residual_combination: ["lerp"]
+    attn_residual_combination: ["lerp"]
+    mlp_residual_alpha_type: ["learned"]
+    attn_residual_alpha_type: ["learned"]
+    attn_residual_alpha: [0.1, 0.05, 0.025]
+    mlp_residual_alpha: [0.1, 0.05, 0.025]
+
+  - mlp_residual_combination: ["lerp"]
+    attn_residual_combination: ["lerp"]
+    mlp_residual_alpha_type: ["dot"]
+    attn_residual_alpha_type: ["dot"]
+    attn_residual_alpha: [0.1, 0.05, 0.025]
+    mlp_residual_alpha: [0.1, 0.05, 0.025]

--- a/explorations/residual_combination_sweep.yaml
+++ b/explorations/residual_combination_sweep.yaml
@@ -1,0 +1,86 @@
+# explorations/residual_combination_sweep.yaml
+---
+parameter_groups:
+  # Add
+  - mlp_residual_combination: ["add"]
+    attn_residual_combination: ["add"]
+    mlp_residual_alpha_type: ["fixed"]
+    attn_residual_alpha_type: ["fixed"]
+
+  - mlp_residual_combination: ["add"]
+    attn_residual_combination: ["add"]
+    mlp_residual_alpha_type: ["learned"]
+    attn_residual_alpha_type: ["learned"]
+
+  - mlp_residual_combination: ["add"]
+    attn_residual_combination: ["add"]
+    mlp_residual_alpha_type: ["dot"]
+    attn_residual_alpha_type: ["dot"]
+
+  # Slerp
+  - mlp_residual_combination: ["slerp"]
+    attn_residual_combination: ["slerp"]
+    mlp_residual_alpha_type: ["fixed"]
+    attn_residual_alpha_type: ["fixed"]
+
+  - mlp_residual_combination: ["slerp"]
+    attn_residual_combination: ["slerp"]
+    mlp_residual_alpha_type: ["learned"]
+    attn_residual_alpha_type: ["learned"]
+
+  - mlp_residual_combination: ["slerp"]
+    attn_residual_combination: ["slerp"]
+    mlp_residual_alpha_type: ["dot"]
+    attn_residual_alpha_type: ["dot"]
+
+  # Lerp
+  - mlp_residual_combination: ["lerp"]
+    attn_residual_combination: ["lerp"]
+    mlp_residual_alpha_type: ["fixed"]
+    attn_residual_alpha_type: ["fixed"]
+
+  - mlp_residual_combination: ["lerp"]
+    attn_residual_combination: ["lerp"]
+    mlp_residual_alpha_type: ["learned"]
+    attn_residual_alpha_type: ["learned"]
+
+  - mlp_residual_combination: ["lerp"]
+    attn_residual_combination: ["lerp"]
+    mlp_residual_alpha_type: ["dot"]
+    attn_residual_alpha_type: ["dot"]
+
+attn_residual_alpha: [0.05]
+mlp_residual_alpha: [0.05]
+
+# QK Norm
+use_qk_norm: [true]
+use_qk_norm_scale: [true]
+
+# Peri Norm
+use_peri_ln: [true, false]
+
+# Embeddings
+use_rotary_embeddings: [true]
+use_abs_pos_embeddings: [false]
+
+# Attn Variations
+softmax_variant_attn: ["softmax", "relu2max"]
+
+max_iters: [5000]
+eval_interval: [5000]
+eta_variant: ["iteration"]
+n_layer: [6]
+n_head: [6]
+n_embd: [384]
+block_size: [256]
+device: ["cuda"]
+dtype: ["bfloat16"]
+dataset: ["minipile"]
+use_parallel_mlp: [false, true]
+
+# Activation Statistics
+compute_model_stats: [true]
+print_model_stats: ["./print_stats/${RUN_NAME}"]
+
+# Memory
+compile: [true]

--- a/explorations/residual_combination_sweep.yaml
+++ b/explorations/residual_combination_sweep.yaml
@@ -4,18 +4,6 @@ parameter_groups:
   # Add
   - mlp_residual_combination: ["add"]
     attn_residual_combination: ["add"]
-    mlp_residual_alpha_type: ["fixed"]
-    attn_residual_alpha_type: ["fixed"]
-
-  - mlp_residual_combination: ["add"]
-    attn_residual_combination: ["add"]
-    mlp_residual_alpha_type: ["learned"]
-    attn_residual_alpha_type: ["learned"]
-
-  - mlp_residual_combination: ["add"]
-    attn_residual_combination: ["add"]
-    mlp_residual_alpha_type: ["dot"]
-    attn_residual_alpha_type: ["dot"]
 
   # Slerp
   - mlp_residual_combination: ["slerp"]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -351,6 +351,13 @@ class GPTConfig:
     learn_mlp_resid_const: bool = False
     resid_gaussian_mean_init: float = 0.0
     resid_gaussian_std_init: float = 0.02
+    attn_residual_combination: str = "add"
+    mlp_residual_combination: str = "add"
+    residual_slerp_eps: float = 0.0
+    attn_residual_alpha: float = 0.05
+    mlp_residual_alpha: float = 0.05
+    attn_residual_alpha_type: str = "fixed"
+    mlp_residual_alpha_type: str = "fixed"
 
     # Layernorm Alternatives and Options
     norm_variant_attn: str = "rmsnorm"

--- a/train_args.py
+++ b/train_args.py
@@ -569,6 +569,54 @@ def parse_args():
     model_group.add_argument('--resid_gaussian_mean_init', type=float, default=0.0, help='Gaussian residual init setting, mean value.')
     model_group.add_argument('--resid_gaussian_std_init', type=float, default=0.02, help='Gaussian residual init setting, standard deviation.')
 
+    # Residual combination options
+    model_group.add_argument(
+        '--attn_residual_combination',
+        type=str,
+        default='add',
+        choices=['add', 'lerp', 'slerp'],
+        help='Residual combination method for attention block'
+    )
+    model_group.add_argument(
+        '--mlp_residual_combination',
+        type=str,
+        default='add',
+        choices=['add', 'lerp', 'slerp'],
+        help='Residual combination method for MLP block'
+    )
+    model_group.add_argument(
+        '--residual_slerp_eps',
+        type=float,
+        default=0.0,
+        help='Threshold below which LERP is used instead of SLERP; 0 means no fallback to LERP (SLERP is always used)'
+    )
+    model_group.add_argument(
+        '--attn_residual_alpha',
+        type=float,
+        default=0.05,
+        help='Alpha parameter for attention residual LERP/SLERP'
+    )
+    model_group.add_argument(
+        '--mlp_residual_alpha',
+        type=float,
+        default=0.05,
+        help='Alpha parameter for MLP residual LERP/SLERP'
+    )
+    model_group.add_argument(
+        '--attn_residual_alpha_type',
+        type=str,
+        default='fixed',
+        choices=['fixed', 'learned', 'dot'],
+        help='Alpha mode for attention residual combination'
+    )
+    model_group.add_argument(
+        '--mlp_residual_alpha_type',
+        type=str,
+        default='fixed',
+        choices=['fixed', 'learned', 'dot'],
+        help='Alpha mode for MLP residual combination'
+    )
+
 
     # NORM VARIATIONS
     norm_variations = [

--- a/variations/block_variations.py
+++ b/variations/block_variations.py
@@ -417,8 +417,8 @@ class Block(nn.Module):
         self.mlp_resid_type = getattr(config, "mlp_residual_combination", "add")
         self.residual_slerp_eps = getattr(config, "residual_slerp_eps", 0.0)
 
-        self.attn_alpha = getattr(config, "attn_residual_alpha", 1.0)
-        self.mlp_alpha = getattr(config, "mlp_residual_alpha", 1.0)
+        self.attn_alpha = getattr(config, "attn_residual_alpha", 0.05)
+        self.mlp_alpha = getattr(config, "mlp_residual_alpha", 0.05)
         self.attn_alpha_mode = getattr(config, "attn_residual_alpha_type", "fixed")
         self.mlp_alpha_mode = getattr(config, "mlp_residual_alpha_type", "fixed")
 

--- a/variations/block_variations.py
+++ b/variations/block_variations.py
@@ -226,7 +226,9 @@ def edgellm_asic_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor:
     # Note:
     # chip_output = x_quantized_residual_initial + mlp_out + attn_out
     # Therefore subtract initial before merging
-    x = (chip_output - x_quantized_residual_initial) + x
+    # x = (chip_output - x_quantized_residual_initial) + x
+    adj_chip_output = chip_output - x_quantized_residual_initial
+    x = block._combine_resid("mlp", x, adj_chip_output)
 
     if block.quantization_dict["quantize_asic_offchip_residual"]:
         num_bits = block.quantization_dict["quantize_asic_bits"]

--- a/variations/block_variations.py
+++ b/variations/block_variations.py
@@ -60,7 +60,7 @@ def make_alpha_fn(mode: str, init: float, param=None, vec=None):
     if mode == "learned":
         return lambda _out: param
     if mode == "dot":
-        return lambda out: init * (1 + (out * vec).sum(dim=-1, keepdim=True))
+        return lambda out: init * (param + (out * vec).sum(dim=-1, keepdim=True))
     raise ValueError(f"unknown alpha mode {mode}")
 
 # -----------------------
@@ -428,10 +428,12 @@ class Block(nn.Module):
             self.attn_alpha_param = nn.Parameter(torch.tensor(self.attn_alpha))
         elif self.attn_alpha_mode == "dot":
             self.attn_alpha_vec = nn.Parameter(torch.zeros(config.n_embd))
+            self.attn_alpha_param = nn.Parameter(torch.tensor(self.attn_alpha))
         if self.mlp_alpha_mode == "learned":
             self.mlp_alpha_param = nn.Parameter(torch.tensor(self.mlp_alpha))
         elif self.mlp_alpha_mode == "dot":
             self.mlp_alpha_vec = nn.Parameter(torch.zeros(config.n_embd))
+            self.mlp_alpha_param = nn.Parameter(torch.tensor(self.mlp_alpha))
 
         self.alpha_fns = {
             "attn": make_alpha_fn(self.attn_alpha_mode, self.attn_alpha,


### PR DESCRIPTION
## Summary
- expose residual combination methods (add, lerp, slerp) for attention and MLP blocks
- add alpha controls and SLERP epsilon with clarified help text
- implement SLERP/LERP helpers and integrate them into transformer blocks

## Testing
- `pytest` *(fails: no such file or directory: /usr/local/etc/mecabrc)*

------
https://chatgpt.com/codex/tasks/task_e_68c794abd56c8326a4a9cb94bca7ae60