### PR TITLE
Add tokenizer for binary files and dataset utilities

### DIFF
--- a/demos/file_byte_folder_demo.sh
+++ b/demos/file_byte_folder_demo.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+# Demonstration of tokenizing a folder of files, training, and generating files
+DATA_DIR=data/file_byte_demo
+INPUT_DIR=$DATA_DIR/input
+OUT_DIR=out_file_byte_demo
+
+rm -rf $DATA_DIR $OUT_DIR
+mkdir -p $INPUT_DIR
+mkdir -p $DATA_DIR/generated
+
+# Create sample files with simple patterns
+for i in {0..19}; do
+  printf "file_%d\n" $i > $INPUT_DIR/file_${i}.txt
+done
+
+# Tokenize the folder using the file_byte tokenizer
+python data/template/prepare.py --method file_byte -t $INPUT_DIR --train_output $DATA_DIR/train.bin --val_output $DATA_DIR/val.bin --percentage_train 0.9
+
+# Train a tiny model on the dataset
+python train.py --device=cpu --out_dir $OUT_DIR --dataset file_byte_demo \
+  --batch_size 4 --block_size 16 --n_layer 2 --n_head 2 --n_embd 64 \
+  --max_iters 50 --lr_decay_iters 50 --eval_interval 10 --eval_iters 10 --dropout 0.0
+
+# Sample from the model and recover generated files
+python sample.py --out_dir $OUT_DIR --num_samples 5 --max_new_tokens 200 --start "" \
+  --file_output_dir $DATA_DIR/generated --temperature 1.0 --top_k 200
+
+echo "Generated files:"
+ls $DATA_DIR/generated
+

--- a/sample.py
+++ b/sample.py
@@ -32,6 +32,7 @@ from variations.model_variations import model_variation_dictionary
 import lm_eval
 from benchmarks.gpt_lm_eval_wrapper import NanoGPTLM
 from benchmarks import run_all
+from data.template.tokenizers import FileByteTokenizer
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Inference from trained models")
@@ -48,6 +49,7 @@ def parse_args():
     parser.add_argument("--dtype", type=str, default="bfloat16", choices=["bfloat16", "float16", "float32"], help="Torch data type for inference")
     parser.add_argument('--compile', action=argparse.BooleanOptionalAction, help="Compile the model (requires PyTorch 2.0)")
     parser.add_argument('--sample_file', type=str, default=None, help="Output file for inference")
+    parser.add_argument('--file_output_dir', type=str, default=None, help="Directory to save generated files when using file_byte tokenizer")
     parser.add_argument('--interactive', action=argparse.BooleanOptionalAction, help="Enable interactive generation")
     parser.add_argument('--stop_strings', nargs='+', type=str, default=['~W'], help="One or more strings to stop generation and allow user input. ""E.g. --stop_strings \"\n\n\" \".\"")
     parser.add_argument('--last_k_tokens', type=int, default=10, help="Number of last tokens to display in heatmaps")
@@ -768,6 +770,15 @@ def sample_with_existing_model(
                 console.print(f"[bold cyan]--- {k_tag} ---[/bold cyan]")
                 console.print("[bold green]" + plain_text + "[/bold green]")
 
+            if load_meta and meta.get('tokenizer') == 'file_byte' and args.file_output_dir:
+                tokens_full = x[0].tolist()
+                FileByteTokenizer.tokens_to_files(
+                    tokens_full,
+                    args.file_output_dir,
+                    meta['start_file_token'],
+                    meta['end_file_token'],
+                )
+
             # ---------- always store plain text once ------------------------
             if sample_file:
                 append_to_sample_file(                         # type: ignore
@@ -924,6 +935,15 @@ def get_tokenizer_functions(meta):
 
     if meta['tokenizer'] == 'byte':
         return byte_encode, byte_decode
+
+    if meta['tokenizer'] == 'file_byte':
+        start_token = meta['start_file_token']
+        def encode(s: str):
+            b = s.encode('latin-1')
+            return [start_token] + list(b)
+        def decode(ids: list[int]):
+            return bytes([i for i in ids if i != start_token and i != meta['end_file_token']]).decode('latin-1', errors='replace')
+        return encode, decode
 
     if meta['tokenizer'] == 'custom_char_with_byte_fallback':
         stoi, itos = meta['stoi'], meta['itos']
@@ -1291,6 +1311,16 @@ def main():
                     key_color="bold light_slate_blue"
                     text_color="bold cyan"
                     print(f"\n[{key_color}]{key}:[/{key_color}]\n[{text_color}]{text}[/{text_color}]")
+
+                    if meta.get('tokenizer') == 'file_byte' and args.file_output_dir:
+                        tokens_full = token_dict[key][0].tolist()
+                        FileByteTokenizer.tokens_to_files(
+                            tokens_full,
+                            args.file_output_dir,
+                            meta['start_file_token'],
+                            meta['end_file_token'],
+                        )
+
                 print("---------------")
 
                 if args.sample_file:


### PR DESCRIPTION
## Summary
- allow `file_byte` tokenizer to read directories of files and wrap data with start/end markers
- support folder ingestion and file-boundary tokens in dataset prep and sampling routines
- add demo script and tests covering binary reconstruction to files
- ensure `meta.pkl` is saved alongside dataset binaries
- expand file-byte demo to create validation split
- write generated samples to disk when using `file_byte` tokenizer
- create generated output folder in demo and train/sample longer to increase chance of files

## Testing
- `python data/template/tests.py`
- `bash demos/file_byte_folder_demo.sh` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68c70faa7f208326b49de0e39500d94e