### PR TITLE
Add Shakespeare checkpoint analysis demo

### DIFF
--- a/analysis/checkpoint_analysis/checkpoint_explorer.py
+++ b/analysis/checkpoint_analysis/checkpoint_explorer.py
@@ -1,10 +1,14 @@
-import os
-import sys
 import argparse
+import sys
+from pathlib import Path
+
 import torch
 
-# Add top level dir
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+# Ensure the repository root is on the import path regardless of CWD
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from model import GPT, GPTConfig
 
@@ -45,6 +49,9 @@ def get_parameter_tree(state_dict):
         current_level[parts[-1]] = state_dict[full_key]
     return tree
 
+IMAGES_DIR = SCRIPT_DIR / "images"
+
+
 def display_heatmap(tensor, full_key):
     import numpy as np
     import seaborn as sns
@@ -57,12 +64,11 @@ def display_heatmap(tensor, full_key):
         return
 
     # Create the images directory if it doesn't exist
-    images_dir = os.path.join('checkpoint_analysis', 'images')
-    os.makedirs(images_dir, exist_ok=True)
+    IMAGES_DIR.mkdir(exist_ok=True)
 
     # Clean the full_key to create a valid filename
     filename = full_key.replace('.', '_').replace('/', '_')
-    image_path = os.path.join(images_dir, f"{filename}_heatmap.png")
+    image_path = IMAGES_DIR / f"{filename}_heatmap.png"
 
     # Generate the heatmap
     plt.figure(figsize=(10, 8))
@@ -125,12 +131,11 @@ def display_histogram(tensor, full_key):
             print("Invalid input. Please enter a positive integer.")
 
     # Create the images directory if it doesn't exist
-    images_dir = os.path.join('checkpoint_analysis', 'images')
-    os.makedirs(images_dir, exist_ok=True)
+    IMAGES_DIR.mkdir(exist_ok=True)
 
     # Clean the full_key to create a valid filename
     filename = full_key.replace('.', '_').replace('/', '_')
-    image_path = os.path.join(images_dir, f"{filename}_histogram.png")
+    image_path = IMAGES_DIR / f"{filename}_histogram.png"
 
     # Generate the histogram using seaborn
     plt.figure(figsize=(10, 8))

--- a/analysis/checkpoint_analysis/checkpoint_regex_explorer.py
+++ b/analysis/checkpoint_analysis/checkpoint_regex_explorer.py
@@ -1,0 +1,471 @@
+"""Utility to explore checkpoint parameters that match a regular expression."""
+
+import argparse
+import math
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import torch
+from rich import box
+from rich.console import Console
+from rich.table import Table
+
+# Ensure the repository root is on the import path regardless of CWD
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from model import GPTConfig, GPT
+
+
+@dataclass
+class L2NormStats:
+    """Summary statistics for directional L2 norms of a tensor."""
+
+    parameter: str
+    axis: int
+    axis_size: int
+    num_vectors: int
+    min: float
+    max: float
+    mean: float
+    std: float
+    kurtosis: float
+    histogram_path: Optional[Path]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Display statistics for checkpoint parameters matching a regex pattern."
+    )
+    parser.add_argument("ckpt_path", help="Path to the checkpoint file")
+    parser.add_argument("pattern", help="Regular expression used to filter parameter names")
+    parser.add_argument(
+        "--device", type=str, default="cpu", help="Device used to load the checkpoint"
+    )
+    parser.add_argument(
+        "--max-rows",
+        type=int,
+        default=None,
+        help="Optional limit on the number of matching parameters displayed",
+    )
+    parser.add_argument(
+        "--embedding-dim",
+        type=int,
+        default=None,
+        help="Embedding dimension used to compute directional L2 norm statistics. Defaults to the checkpoint configuration.",
+    )
+    parser.add_argument(
+        "--max-l2-rows",
+        type=int,
+        default=None,
+        help="Optional limit on the number of directional L2 norm rows displayed",
+    )
+    parser.add_argument(
+        "--histogram-dir",
+        type=Path,
+        default=None,
+        help="If set, save histograms of L2 norms for matching dimensions to this directory",
+    )
+    parser.add_argument(
+        "--histogram-bins",
+        type=int,
+        default=50,
+        help="Number of bins used when plotting L2 norm histograms",
+    )
+    return parser.parse_args()
+
+
+def load_state_dict(
+    ckpt_path: str, device: str
+) -> Tuple[Dict[str, torch.Tensor], GPTConfig]:
+    checkpoint = torch.load(ckpt_path, map_location=device)
+    model_args = checkpoint.get("model_args")
+    state_dict = checkpoint.get("model")
+
+    if model_args is None:
+        raise SystemExit("Model arguments not found in checkpoint.")
+    if state_dict is None:
+        raise SystemExit("Model state dictionary not found in checkpoint.")
+
+    # Instantiate the model so that buffers are materialized in a consistent format
+    model = GPT(GPTConfig(**model_args))
+    sanitized_state = {}
+    for key, value in state_dict.items():
+        if key.startswith("_orig_mod."):
+            sanitized_state[key[len("_orig_mod."):]] = value
+        else:
+            sanitized_state[key] = value
+
+    missing, unexpected = model.load_state_dict(sanitized_state, strict=False)
+    if missing:
+        Console().print(
+            f"[yellow]Warning:[/] Missing keys when loading checkpoint: {', '.join(missing)}"
+        )
+    if unexpected:
+        Console().print(
+            f"[yellow]Warning:[/] Unexpected keys when loading checkpoint: {', '.join(unexpected)}"
+        )
+
+    model.to(device)
+    model.eval()
+
+    state_dict = {
+        name: parameter.detach().to("cpu") for name, parameter in model.state_dict().items()
+    }
+    return state_dict, model.config
+
+
+def tensor_stats(tensor: torch.Tensor) -> Dict[str, float]:
+    with torch.no_grad():
+        tensor = tensor.detach()
+        if tensor.numel() == 0:
+            return {
+                "shape": tuple(tensor.shape),
+                "numel": 0,
+                "min": float("nan"),
+                "max": float("nan"),
+                "mean": float("nan"),
+                "std": float("nan"),
+                "median": float("nan"),
+                "q1": float("nan"),
+                "q3": float("nan"),
+                "abs_mean": float("nan"),
+                "zeros": 0,
+                "zero_pct": float("nan"),
+            }
+
+        flat = tensor.to(torch.float32).view(-1)
+        numel = flat.numel()
+        min_val = flat.min().item()
+        max_val = flat.max().item()
+        mean = flat.mean().item()
+        std = flat.std(unbiased=False).item()
+        median = flat.median().item()
+        q1 = torch.quantile(flat, 0.25).item()
+        q3 = torch.quantile(flat, 0.75).item()
+        abs_mean = flat.abs().mean().item()
+        zeros = (flat == 0).sum().item()
+        zero_pct = (zeros / numel) * 100 if numel else float("nan")
+
+        return {
+            "shape": tuple(tensor.shape),
+            "numel": numel,
+            "min": min_val,
+            "max": max_val,
+            "mean": mean,
+            "std": std,
+            "median": median,
+            "q1": q1,
+            "q3": q3,
+            "abs_mean": abs_mean,
+            "zeros": zeros,
+            "zero_pct": zero_pct,
+        }
+
+
+def update_global_summary(summary: Dict[str, float], stats: Dict[str, float], tensor: torch.Tensor) -> None:
+    numel = stats["numel"]
+    if numel == 0:
+        return
+
+    flat = tensor.to(torch.float32).view(-1)
+    summary["numel"] += numel
+    summary["sum"] += flat.sum().item()
+    summary["sum_sq"] += torch.sum(flat * flat).item()
+    summary["abs_sum"] += flat.abs().sum().item()
+    summary["zeros"] += stats["zeros"]
+    summary["min"] = min(summary["min"], stats["min"])
+    summary["max"] = max(summary["max"], stats["max"])
+
+
+def compute_l2_norm_stats(
+    name: str,
+    tensor: torch.Tensor,
+    embedding_dim: Optional[int],
+    histogram_dir: Optional[Path],
+    histogram_bins: int,
+) -> List[L2NormStats]:
+    if not embedding_dim:
+        return []
+
+    tensor = tensor.detach().to(torch.float32)
+    results: List[L2NormStats] = []
+
+    for axis, axis_size in enumerate(tensor.shape):
+        if axis_size != embedding_dim:
+            continue
+
+        moved = tensor.movedim(axis, -1)
+        vectors = moved.reshape(-1, embedding_dim)
+        if vectors.numel() == 0:
+            continue
+
+        norms = torch.linalg.norm(vectors, dim=-1)
+        if norms.numel() == 0:
+            continue
+
+        min_norm = norms.min().item()
+        max_norm = norms.max().item()
+        mean_norm = norms.mean().item()
+        std_norm = norms.std(unbiased=False).item()
+        var_norm = norms.var(unbiased=False).item()
+        if var_norm > 0:
+            kurtosis = torch.mean((norms - mean_norm) ** 4).item() / (var_norm ** 2)
+        else:
+            kurtosis = float("nan")
+
+        histogram_path: Optional[Path] = None
+        if histogram_dir is not None:
+            histogram_path = save_l2_histogram(
+                norms,
+                histogram_dir,
+                name,
+                axis,
+                bins=histogram_bins,
+            )
+
+        results.append(
+            L2NormStats(
+                parameter=name,
+                axis=axis,
+                axis_size=axis_size,
+                num_vectors=norms.numel(),
+                min=min_norm,
+                max=max_norm,
+                mean=mean_norm,
+                std=std_norm,
+                kurtosis=kurtosis,
+                histogram_path=histogram_path,
+            )
+        )
+
+    return results
+
+
+def save_l2_histogram(
+    norms: torch.Tensor,
+    histogram_dir: Path,
+    name: str,
+    axis: int,
+    *,
+    bins: int,
+) -> Path:
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg", force=True)
+        import matplotlib.pyplot as plt
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise SystemExit(
+            "matplotlib is required for --histogram-dir but is not installed"
+        ) from exc
+
+    histogram_dir.mkdir(parents=True, exist_ok=True)
+    sanitized_name = name.replace("/", "_").replace(".", "_")
+    file_name = f"{sanitized_name}_axis{axis}.png"
+    file_path = histogram_dir / file_name
+
+    plt.figure(figsize=(8, 4))
+    plt.hist(norms.cpu().numpy(), bins=bins, color="#4C72B0", edgecolor="black", alpha=0.8)
+    plt.title(f"L2 norm histogram for {name} (axis {axis})")
+    plt.xlabel("L2 norm")
+    plt.ylabel("Frequency")
+    plt.tight_layout()
+    plt.savefig(file_path, dpi=150)
+    plt.close()
+
+    return file_path
+
+
+def render_table(rows: Iterable[Tuple[str, Dict[str, float]]], max_rows: int | None) -> None:
+    rows = list(rows)
+    total_rows = len(rows)
+    display_rows = rows if max_rows is None else rows[:max_rows]
+    table = Table(
+        title="Parameter statistics",
+        box=box.SIMPLE_HEAVY,
+        header_style="bold magenta",
+        show_lines=False,
+    )
+    table.add_column("Parameter", overflow="fold")
+    table.add_column("Shape", justify="center")
+    table.add_column("# Elem", justify="right")
+    table.add_column("Min", justify="right")
+    table.add_column("Max", justify="right")
+    table.add_column("Mean", justify="right")
+    table.add_column("Std", justify="right")
+    table.add_column("Median", justify="right")
+    table.add_column("Q1", justify="right")
+    table.add_column("Q3", justify="right")
+    table.add_column("|Mean|", justify="right")
+    table.add_column("Zeros %", justify="right")
+
+    count = 0
+    for name, stats in display_rows:
+        table.add_row(
+            name,
+            str(stats["shape"]),
+            f"{stats['numel']:,}",
+            f"{stats['min']:.6g}",
+            f"{stats['max']:.6g}",
+            f"{stats['mean']:.6g}",
+            f"{stats['std']:.6g}",
+            f"{stats['median']:.6g}",
+            f"{stats['q1']:.6g}",
+            f"{stats['q3']:.6g}",
+            f"{stats['abs_mean']:.6g}",
+            f"{stats['zero_pct']:.3g}%" if not math.isnan(stats["zero_pct"]) else "n/a",
+        )
+        count += 1
+
+    console = Console()
+    console.print(table)
+    if max_rows is not None and total_rows > max_rows:
+        console.print(
+            f"[dim]Displayed {count} of {total_rows} rows (limited by --max-rows). Use a larger value to see more.[/]"
+        )
+
+
+def render_l2_table(rows: List[L2NormStats], max_rows: int | None) -> None:
+    if not rows:
+        return
+
+    rows = sorted(rows, key=lambda item: (item.parameter, item.axis))
+    total_rows = len(rows)
+    display_rows = rows if max_rows is None else rows[:max_rows]
+    has_histograms = any(row.histogram_path is not None for row in rows)
+
+    table = Table(
+        title="Directional L2 norm statistics",
+        box=box.SIMPLE_HEAVY,
+        header_style="bold blue",
+        show_lines=False,
+    )
+    table.add_column("Parameter", overflow="fold")
+    table.add_column("Axis", justify="center")
+    table.add_column("# Vectors", justify="right")
+    table.add_column("Min", justify="right")
+    table.add_column("Max", justify="right")
+    table.add_column("Mean", justify="right")
+    table.add_column("Std", justify="right")
+    table.add_column("Kurtosis", justify="right")
+    if has_histograms:
+        table.add_column("Histogram", overflow="fold")
+
+    for row in display_rows:
+        values = [
+            row.parameter,
+            f"dim {row.axis} (size={row.axis_size})",
+            f"{row.num_vectors:,}",
+            f"{row.min:.6g}",
+            f"{row.max:.6g}",
+            f"{row.mean:.6g}",
+            f"{row.std:.6g}",
+            f"{row.kurtosis:.6g}" if not math.isnan(row.kurtosis) else "n/a",
+        ]
+        if has_histograms:
+            values.append(str(row.histogram_path) if row.histogram_path else "—")
+        table.add_row(*values)
+
+    console = Console()
+    console.print(table)
+    if max_rows is not None and total_rows > max_rows:
+        console.print(
+            f"[dim]Displayed {len(display_rows)} of {total_rows} rows (limited by --max-l2-rows). Use a larger value to see more.[/]"
+        )
+
+
+def render_summary(summary: Dict[str, float], matched: int) -> None:
+    table = Table(title="Aggregate statistics", box=box.SQUARE)
+    table.add_column("Metric", style="bold magenta")
+    table.add_column("Value", style="bold cyan", justify="right")
+
+    table.add_row("Matched parameters", str(matched))
+    table.add_row("Total elements", f"{int(summary['numel']):,}")
+
+    if summary["numel"]:
+        mean = summary["sum"] / summary["numel"]
+        var = summary["sum_sq"] / summary["numel"] - mean * mean
+        std = math.sqrt(max(var, 0.0))
+        abs_mean = summary["abs_sum"] / summary["numel"]
+        zero_pct = (summary["zeros"] / summary["numel"]) * 100
+        table.add_row("Min", f"{summary['min']:.6g}")
+        table.add_row("Max", f"{summary['max']:.6g}")
+        table.add_row("Mean", f"{mean:.6g}")
+        table.add_row("Std", f"{std:.6g}")
+        table.add_row("|Mean|", f"{abs_mean:.6g}")
+        table.add_row("Zeros %", f"{zero_pct:.3g}%")
+    else:
+        table.add_row("Note", "No elements matched the provided pattern")
+
+    Console().print(table)
+
+
+def main() -> None:
+    args = parse_args()
+    console = Console()
+
+    try:
+        state_dict, config = load_state_dict(args.ckpt_path, args.device)
+    except FileNotFoundError as exc:
+        raise SystemExit(f"Checkpoint not found: {exc}") from exc
+
+    pattern = re.compile(args.pattern)
+
+    embedding_dim = args.embedding_dim if args.embedding_dim else getattr(config, "n_embd", None)
+    if embedding_dim is None:
+        console.print(
+            "[yellow]Embedding dimension not found in checkpoint configuration; skipping L2 norm statistics.[/]"
+        )
+
+    histogram_dir = args.histogram_dir
+    if histogram_dir is not None:
+        histogram_dir = histogram_dir.expanduser().resolve()
+
+    rows = []
+    l2_rows: List[L2NormStats] = []
+    summary = {
+        "numel": 0,
+        "sum": 0.0,
+        "sum_sq": 0.0,
+        "abs_sum": 0.0,
+        "zeros": 0,
+        "min": float("inf"),
+        "max": float("-inf"),
+    }
+
+    for name, tensor in state_dict.items():
+        if pattern.search(name):
+            stats = tensor_stats(tensor)
+            rows.append((name, stats))
+            update_global_summary(summary, stats, tensor)
+            if embedding_dim:
+                l2_rows.extend(
+                    compute_l2_norm_stats(
+                        name,
+                        tensor,
+                        embedding_dim=embedding_dim,
+                        histogram_dir=histogram_dir,
+                        histogram_bins=args.histogram_bins,
+                    )
+                )
+
+    if not rows:
+        console.print("[red]No parameters matched the provided pattern.[/]")
+        return
+
+    rows.sort(key=lambda item: item[0])
+    render_table(rows, args.max_rows)
+    render_summary(summary, matched=len(rows))
+    if l2_rows:
+        render_l2_table(l2_rows, args.max_l2_rows)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/demos/shakespeare_checkpoint_analysis_demo.sh
+++ b/demos/shakespeare_checkpoint_analysis_demo.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# shakespeare_checkpoint_analysis_demo.sh
+# Demonstrates training on the shakespeare_char dataset and exploring checkpoints.
+
+set -euo pipefail
+
+DATA_DIR="data/shakespeare_char"
+OUT_DIR="out_shakespeare_checkpoint_demo"
+HIST_DIR="${OUT_DIR}/regex_histograms"
+CKPT_PATH="${OUT_DIR}/ckpt.pt"
+
+# Ensure the dataset is available.
+pushd "${DATA_DIR}" > /dev/null
+bash get_dataset.sh
+popd > /dev/null
+
+# Train a compact model to produce a checkpoint for analysis.
+rm -rf "${OUT_DIR}"
+python3 train.py \
+  --dataset shakespeare_char \
+  --out_dir "${OUT_DIR}" \
+  --max_iters 200 \
+  --block_size 64 \
+  --batch_size 64 \
+  --n_layer 4 \
+  --n_head 4 \
+  --n_embd 128 \
+  --learning_rate 3e-4 \
+  --eval_interval 100 \
+  --eval_iters 20 \
+  --log_interval 10 \
+  --always_save_checkpoint \
+  --no-tensorboard_log
+
+if [[ ! -f "${CKPT_PATH}" ]]; then
+  echo "Expected checkpoint not found at ${CKPT_PATH}" >&2
+  exit 1
+fi
+
+# Use the interactive explorer to inspect embedding statistics.
+echo "\nRunning checkpoint explorer to inspect transformer.wte.weight statistics..."
+python3 analysis/checkpoint_analysis/checkpoint_explorer.py "${CKPT_PATH}" <<'EOINPUT'
+0
+0
+0
+4
+
+b
+b
+b
+q
+EOINPUT
+
+# Use the regex explorer to summarize attention projection weights and save histograms.
+echo "\nRunning checkpoint regex explorer for attention projection weights..."
+python3 analysis/checkpoint_analysis/checkpoint_regex_explorer.py \
+  "${CKPT_PATH}" \
+  "transformer\\.h\\.[0-9]+\\.attn\\.(c_attn|c_proj)\\.weight" \
+  --max-rows 8 \
+  --max-l2-rows 8 \
+  --histogram-dir "${HIST_DIR}" \
+  --histogram-bins 40
+
+echo "\nHistogram images saved under ${HIST_DIR}"


### PR DESCRIPTION
## Summary
- add a Shakespeare checkpoint analysis demo that prepares the dataset and trains a compact model
- showcase the checkpoint explorer by automatically drilling into the token embedding statistics
- run the regex explorer with histogram output to summarize attention projection weights

## Testing
- bash -n demos/shakespeare_checkpoint_analysis_demo.sh

------
https://chatgpt.com/codex/tasks/task_e_68c8fc7f97288326bca4c14dc48f5814