### PR TITLE
Add token & epoch training limits and log metrics

### DIFF
--- a/optimization_and_search/run_experiments.py
+++ b/optimization_and_search/run_experiments.py
@@ -23,6 +23,8 @@ METRIC_KEYS = [
     "btc_per_param",
     "peak_gpu_mb",
     "iter_latency_avg",
+    "tokens_trained",
+    "epochs_trained",
     "avg_top1_prob",
     "avg_top1_correct",
     "avg_target_rank",
@@ -160,7 +162,24 @@ def read_metrics(out_dir: str) -> dict:
     line = path.read_text().strip()
     parts = [p.strip() for p in line.split(',')]
 
-    casts = [float, int, int, float, float, float, float, float, float, float, float, float, float, float]
+    casts = [
+        float,  # best_val_loss
+        int,    # best_val_iter
+        int,    # num_params
+        float,  # better_than_chance
+        float,  # btc_per_param
+        float,  # peak_gpu_mb
+        float,  # iter_latency_avg
+        int,    # tokens_trained
+        float,  # epochs_trained
+        float,  # avg_top1_prob
+        float,  # avg_top1_correct
+        float,  # avg_target_rank
+        float,  # avg_target_left_prob
+        float,  # avg_target_prob
+        float,  # target_rank_95
+        float,  # left_prob_95
+    ]
     return {k: typ(v) for k, typ, v in zip(METRIC_KEYS, casts, parts)}
 
 

--- a/run_exploration_monitor.py
+++ b/run_exploration_monitor.py
@@ -172,6 +172,8 @@ class MonitorApp(App):
             "num_params",
             "peak_gpu_mb",
             "iter_latency_avg",
+            "tokens_trained",
+            "epochs_trained",
             "avg_top1_prob",
             "avg_top1_correct",
             "avg_target_rank",

--- a/train.py
+++ b/train.py
@@ -99,6 +99,7 @@ class Trainer:
         self.grad_norm = None
         self.grad_std = None
         self.tokens_trained = 0
+        self.current_epoch = 0.0 if self.args.dataset_list is None else float('nan')
         self.peak_gpu_usage = 0.0
         self.total_training_time_ms: float = 0.0   # total run-time from start of training
         self.time_remaining_ms: float= 0.0
@@ -158,6 +159,8 @@ class Trainer:
             # Track tokens and epochs trained per dataset
             self.tokens_trained_dict = {dataset: 0 for dataset in self.args.dataset_list}
             self.epochs_trained_dict = {dataset: 0 for dataset in self.args.dataset_list}
+            # No global epoch concept when training across multiple datasets
+            self.current_epoch = float('nan')
 
             # Also, set self.args.dataset to the first dataset in the list
             self.args.dataset = self.args.dataset_list[0]
@@ -1380,7 +1383,7 @@ class Trainer:
         t0 = t_start
         local_iter_num = 0
         running_mfu = -1.0
-        current_epoch = 0.0
+        self.current_epoch = 0.0 if self.args.dataset_list is None else float('nan')
         self.evaluations_remaining = (self.args.max_iters - self.iter_num) // self.args.eval_interval + 1
         self.eta = build_eta_estimator(self.args, t_start, self.evaluations_remaining, self.formatted_completion_eta)
         num_steps_with_worse_loss = 0
@@ -1503,7 +1506,7 @@ class Trainer:
                             log_message+=f", tokens_trained {self.tokens_trained:.2e}"
                             self.console.print(log_message)
                             better_than_chance = self.vocab_sizes[dataset] / math.exp(dataset_losses['val'].item())
-                            self.log_metrics(dataset_losses, running_mfu, current_epoch, self.tokens_trained, dataset, better_than_chance)
+                            self.log_metrics(dataset_losses, running_mfu, self.current_epoch, self.tokens_trained, dataset, better_than_chance)
                     else:
                         # Default behavior for a single dataset
                         better_than_chance = self.model_args['vocab_size'] / math.exp(losses['val'].item())
@@ -1520,7 +1523,7 @@ class Trainer:
                         log_message+=f", batch_size {self.args.batch_size}"
                         log_message+=f", lr {self.lr:.4f}"
                         self.console.print(log_message)
-                        self.log_metrics(losses, running_mfu, current_epoch, self.tokens_trained, current_dataset, better_than_chance)
+                        self.log_metrics(losses, running_mfu, self.current_epoch, self.tokens_trained, current_dataset, better_than_chance)
 
                     if math.isnan(losses["val"]):
                         # If val loss is nan, then exit.
@@ -1552,6 +1555,8 @@ class Trainer:
                                         f"{chance_ratio/self.model.num_param:.3e}",
                                         f"{peak_mb:.1f}",
                                         f"{self.iter_latency_avg:.1f}",
+                                        f"{self.tokens_trained}",
+                                        f"{self.current_epoch:.6f}",
                                         f"{losses.get('top1_prob', float('nan')):.6f}",
                                         f"{losses.get('top1_correct', float('nan')):.6f}",
                                         f"{losses.get('target_rank', float('nan')):.2f}",
@@ -1654,19 +1659,21 @@ class Trainer:
 
                     prior_dataset = current_dataset
                     tokens_trained_this_batch = self.args.batch_size * self.args.block_size
+                    # Always track aggregate tokens across all datasets
+                    self.tokens_trained += tokens_trained_this_batch
                     if self.args.dataset_list:
-                        # Update per–dataset count
+                        # Update per-dataset count as well
                         self.tokens_trained_dict[current_dataset] += tokens_trained_this_batch
-                        self.tokens_trained = self.tokens_trained_dict[current_dataset]
+                        current_epoch = (
+                            self.tokens_trained_dict[current_dataset]
+                            / self.dataset_size_tokens[current_dataset]
+                        )
+                        self.epochs_trained_dict[current_dataset] = current_epoch
+                        # No meaningful global epoch in multi-dataset mode
+                        self.current_epoch = float('nan')
                     else:
-                        self.tokens_trained += tokens_trained_this_batch
-
-                    # Compute epoch for logging:
-                        if self.args.dataset_list:
-                            current_epoch = self.tokens_trained_dict[current_dataset] / self.dataset_size_tokens[current_dataset]
-                            self.epochs_trained_dict[current_dataset] = current_epoch
-                        else:
-                            current_epoch = self.tokens_trained / self.dataset_size_tokens
+                        current_epoch = self.tokens_trained / self.dataset_size_tokens
+                        self.current_epoch = current_epoch
 
                     self.scaler.scale(loss).backward()
 
@@ -1760,7 +1767,7 @@ class Trainer:
                         log_message+= f", tokens_trained {self.tokens_trained_dict[prior_dataset]:.2e}"
                         log_message+= f", dataset: {prior_dataset}"
                     else:
-                        log_message+= f", epoch {current_epoch:6.2f}"
+                        log_message+= f", epoch {self.current_epoch:6.2f}"
                         log_message+= f", tokens_trained {self.tokens_trained:.2e}"
                     log_message+= f", mfu {running_mfu*100:.2f}%"
                     if self.args.gns_type is not None:
@@ -1786,9 +1793,9 @@ class Trainer:
                         self.log_metrics_non_validation(lossf, running_mfu, self.epochs_trained_dict[prior_dataset], self.tokens_trained_dict[prior_dataset], prior_dataset, better_than_chance)
                     if self.args.multicontext_datasets:
                         for i, mc_dataset in enumerate(self.args.multicontext_datasets):
-                            self.log_metrics_non_validation(training_losses[i].item(), running_mfu, current_epoch, self.tokens_trained, mc_dataset, self.mc_btc_train[mc_dataset])
+                            self.log_metrics_non_validation(training_losses[i].item(), running_mfu, self.current_epoch, self.tokens_trained, mc_dataset, self.mc_btc_train[mc_dataset])
                     else:
-                        self.log_metrics_non_validation(lossf, running_mfu, current_epoch, self.tokens_trained, prior_dataset, better_than_chance)
+                        self.log_metrics_non_validation(lossf, running_mfu, self.current_epoch, self.tokens_trained, prior_dataset, better_than_chance)
 
                 if self.args.create_statistics and local_iter_num % self.args.softmax_io_log_interval == 0:
                     create_statistics(self, graph_y_labels)
@@ -1819,7 +1826,15 @@ class Trainer:
                 live.update(Group(progress.get_renderable(), cli_text))
 
                 # End of training actions
-                if self.iter_num > self.args.max_iters:
+                if (
+                    self.iter_num > self.args.max_iters
+                    or (self.args.tokens_limit is not None and self.tokens_trained >= self.args.tokens_limit)
+                    or (
+                        self.args.dataset_list is None
+                        and self.args.epochs_limit is not None
+                        and self.current_epoch >= self.args.epochs_limit
+                    )
+                ):
                     print(self.best_val_loss, self.best_iter)
                     if self.args.only_save_checkpoint_at_end:
                         if not self.args.never_save_checkpoint:

--- a/train_args.py
+++ b/train_args.py
@@ -1075,6 +1075,19 @@ def parse_args():
     model_group.add_argument("--lpe_mlp_variant", type=str, default="mlp", choices=mlp_variants, help="MLP variation type")
     # Optimizer args
     training_group.add_argument('--max_iters', default=3500, type=int)
+    training_group.add_argument(
+        '--tokens_limit',
+        default=None,
+        type=int,
+        help='If set, stop training after this many tokens have been processed. '
+             'In multi-dataset mode this counts tokens across all datasets.',
+    )
+    training_group.add_argument(
+        '--epochs_limit',
+        default=None,
+        type=float,
+        help='If set, stop training after this many epochs (single-dataset training only)',
+    )
     training_group.add_argument('--weight_decay', default=1e-1, type=float)
     training_group.add_argument('--beta1', default=0.9, type=float)
     training_group.add_argument('--beta2', default=0.99, type=float)


### PR DESCRIPTION
## Summary
- add `--tokens_limit` and `--epochs_limit` options to training arguments
- halt training when either limit is reached and record tokens/epochs in metrics
- expose tokens/epoch metrics in exploration runner and monitor
- count tokens across all datasets in multi-dataset runs and ignore `epochs_limit`

## Testing
- `pytest -q` *(fails: MeCab configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b50c5ca6608326be64342cc2e721f0