### PR TITLE
Add fake PTQ utility and demo script

### DIFF
--- a/demos/ptq_demo.sh
+++ b/demos/ptq_demo.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# demos/ptq_demo.sh
+
+# 1. Prepare minipile dataset
+pushd data/minipile
+if [ ! -f "train.bin" ] || [ ! -f "val.bin" ] || [ ! -f "meta.pkl" ]; then
+  bash get_dataset.sh
+  python3 prepare.py -t input.txt --method tiktoken
+else
+  echo "train.bin val.bin and meta.pkl already found for minipile"
+fi
+popd
+
+# 2. Train a larger model on minipile
+out_dir="out_ptq_demo"
+run_name_before="ptq_fp32"
+python3 train.py \
+  --dataset minipile \
+  --out_dir "$out_dir" \
+  --n_layer 6 \
+  --n_head 6 \
+  --n_embd 384 \
+  --block_size 256 \
+  --max_iters 10000 \
+  --log_interval 10 \
+  --tensorboard_run_name "$run_name_before"
+
+# 3. Compute model stats before quantization
+python3 train.py \
+  --dataset minipile \
+  --out_dir "$out_dir" \
+  --eval_only \
+  --compute_model_stats \
+  --print_model_stats_table "${run_name_before}.csv" \
+  --tensorboard_run_name "$run_name_before"
+
+# 4. Report validation loss before quantization
+python3 sample.py \
+  --out_dir "$out_dir" \
+  --eval_only \
+  --eval_dataset minipile
+
+# 5. Sample from the original model
+python3 sample.py \
+  --out_dir "$out_dir" \
+  --num_samples 1 \
+  --max_new_tokens 50 \
+  --start "Hello" \
+  --sample_file before_ptq.txt
+
+# 6. Apply fake PTQ (8-bit uniform)
+python3 quantizations/ptq/fake_quantize_ckpt.py "$out_dir" --num_bits 8 --out_dir "${out_dir}_ptq"
+
+# 7. Compute model stats after quantization
+run_name_after="ptq_int8"
+python3 train.py \
+  --dataset minipile \
+  --out_dir "${out_dir}_ptq" \
+  --eval_only \
+  --compute_model_stats \
+  --print_model_stats_table "${run_name_after}.csv" \
+  --tensorboard_run_name "$run_name_after"
+
+# 8. Report validation loss after quantization
+python3 sample.py \
+  --out_dir "${out_dir}_ptq" \
+  --eval_only \
+  --eval_dataset minipile
+
+# 9. Sample from the quantized model
+python3 sample.py \
+  --out_dir "${out_dir}_ptq" \
+  --num_samples 1 \
+  --max_new_tokens 50 \
+  --start "Hello" \
+  --sample_file after_ptq.txt

--- a/quantizations/ptq/fake_quantize_ckpt.py
+++ b/quantizations/ptq/fake_quantize_ckpt.py
@@ -1,0 +1,62 @@
+import argparse
+import os
+import shutil
+import torch
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Apply uniform fake quantization to all weights in a checkpoint"
+    )
+    parser.add_argument(
+        "ckpt_dir",
+        type=str,
+        help="Directory containing ckpt.pt and meta.pkl from a previous training run",
+    )
+    parser.add_argument(
+        "--out_dir",
+        type=str,
+        default=None,
+        help="Directory to write the quantized checkpoint (defaults to <ckpt_dir>_ptq)",
+    )
+    parser.add_argument(
+        "--num_bits",
+        type=int,
+        default=8,
+        help="Number of bits for uniform quantization",
+    )
+    return parser.parse_args()
+
+def fake_quant_tensor(tensor: torch.Tensor, num_bits: int) -> torch.Tensor:
+    """Uniform quantize then dequantize a tensor."""
+    if not torch.is_floating_point(tensor):
+        return tensor
+    qmax = 2 ** (num_bits - 1) - 1
+    if qmax <= 0:
+        return tensor
+    scale = tensor.abs().max() / qmax
+    if scale == 0:
+        return tensor
+    q = torch.clamp(torch.round(tensor / scale), -qmax - 1, qmax)
+    return (q * scale).to(tensor.dtype)
+
+def main():
+    args = parse_args()
+    ckpt_path = os.path.join(args.ckpt_dir, "ckpt.pt")
+    checkpoint = torch.load(ckpt_path, map_location="cpu", weights_only=True)
+    state_dict = checkpoint.get("model", checkpoint)
+
+    for k, v in state_dict.items():
+        if torch.is_tensor(v):
+            state_dict[k] = fake_quant_tensor(v, args.num_bits)
+
+    out_dir = args.out_dir or f"{args.ckpt_dir}_ptq"
+    os.makedirs(out_dir, exist_ok=True)
+    torch.save(checkpoint, os.path.join(out_dir, "ckpt.pt"))
+
+    meta_in = os.path.join(args.ckpt_dir, "meta.pkl")
+    meta_out = os.path.join(out_dir, "meta.pkl")
+    if os.path.exists(meta_in):
+        shutil.copy(meta_in, meta_out)
+
+if __name__ == "__main__":
+    main()

--- a/quantizations/ptq/fake_quantize_ckpt.py
+++ b/quantizations/ptq/fake_quantize_ckpt.py
@@ -1,9 +1,12 @@
 import argparse
+import math
 import os
 import shutil
+from collections.abc import MutableMapping
 from typing import Iterable, Tuple
 
 import torch
+
 
 def parse_args():
     parser = argparse.ArgumentParser(
@@ -26,20 +29,97 @@ def parse_args():
         default=8,
         help="Number of bits for uniform quantization",
     )
+    parser.add_argument(
+        "--quantization",
+        type=str,
+        default="symmetric",
+        choices=("symmetric", "asymmetric"),
+        help=(
+            "Quantization scheme to use: symmetric signed (two's complement) or "
+            "asymmetric unsigned"
+        ),
+    )
     return parser.parse_args()
 
-def fake_quant_tensor(tensor: torch.Tensor, num_bits: int) -> torch.Tensor:
-    """Uniform quantize then dequantize a tensor."""
-    if not torch.is_floating_point(tensor):
-        return tensor
-    qmax = 2 ** (num_bits - 1) - 1
+
+def _fake_quant_symmetric(tensor: torch.Tensor, num_bits: int) -> torch.Tensor:
+    # Signed two's-complement style quantization covering
+    #   qmin = -2^{B-1} and qmax = 2^{B-1} - 1
+    qmax = (1 << (num_bits - 1)) - 1
+    qmin = -1 << (num_bits - 1)
     if qmax <= 0:
         return tensor
-    scale = tensor.abs().max() / qmax
-    if scale == 0:
+
+    if tensor.numel() == 0:
         return tensor
-    q = torch.clamp(torch.round(tensor / scale), -qmax - 1, qmax)
+
+    max_abs = tensor.abs().max()
+    if max_abs.numel() == 0:
+        return tensor
+    max_abs_val = max_abs.item()
+    if max_abs_val == 0.0 or not math.isfinite(max_abs_val):
+        return tensor
+
+    scale = max_abs_val / qmax
+    if scale == 0.0 or not math.isfinite(scale):
+        return tensor
+
+    q = torch.clamp(torch.round(tensor / scale), qmin, qmax)
     return (q * scale).to(tensor.dtype)
+
+
+def _fake_quant_asymmetric(tensor: torch.Tensor, num_bits: int) -> torch.Tensor:
+    # Unsigned quantization with range [0, 2^{B}-1]
+    qmin = 0
+    qmax = (1 << num_bits) - 1
+    if qmax <= qmin:
+        return tensor
+
+    if tensor.numel() == 0:
+        return tensor
+
+    # min/max provide scalar tensors; handle degenerate ranges gracefully
+    min_val = tensor.min()
+    max_val = tensor.max()
+    if min_val.numel() == 0 or max_val.numel() == 0:
+        return tensor
+
+    min_float = min_val.item()
+    max_float = max_val.item()
+    if not (math.isfinite(min_float) and math.isfinite(max_float)):
+        return tensor
+    if max_float <= min_float:
+        return tensor
+
+    scale = (max_float - min_float) / float(qmax - qmin)
+    if scale == 0.0 or not math.isfinite(scale):
+        return tensor
+
+    zero_point = qmin - round(min_float / scale)
+    zero_point = max(qmin, min(qmax, int(zero_point)))
+
+    q = torch.round(tensor / scale + zero_point)
+    q = torch.clamp(q, qmin, qmax)
+    return ((q - zero_point) * scale).to(tensor.dtype)
+
+
+def fake_quant_tensor(
+    tensor: torch.Tensor, num_bits: int, scheme: str
+) -> torch.Tensor:
+    """Uniform quantize then dequantize a tensor."""
+
+    if not torch.is_floating_point(tensor):
+        return tensor
+
+    if num_bits <= 0:
+        return tensor
+
+    if scheme == "symmetric":
+        return _fake_quant_symmetric(tensor, num_bits)
+    if scheme == "asymmetric":
+        return _fake_quant_asymmetric(tensor, num_bits)
+
+    raise ValueError(f"Unsupported quantization scheme: {scheme}")
 
 
 def iter_state_tensors(state_dict) -> Iterable[torch.Tensor]:
@@ -85,14 +165,37 @@ def format_size(num_bytes: float) -> str:
 def main():
     args = parse_args()
     ckpt_path = os.path.join(args.ckpt_dir, "ckpt.pt")
-    checkpoint = torch.load(ckpt_path, map_location="cpu", weights_only=True)
-    state_dict = checkpoint.get("model", checkpoint)
+    checkpoint = torch.load(ckpt_path, map_location="cpu")
 
-    original_bytes, quantized_bytes = estimate_checkpoint_sizes(state_dict, args.num_bits)
+    if isinstance(checkpoint, dict) and "model" in checkpoint:
+        state_obj = checkpoint["model"]
+    else:
+        state_obj = checkpoint
 
-    for k, v in state_dict.items():
-        if torch.is_tensor(v):
-            state_dict[k] = fake_quant_tensor(v, args.num_bits)
+    if isinstance(state_obj, MutableMapping):
+        state_dict = state_obj
+    else:
+        to_state_dict = getattr(state_obj, "state_dict", None)
+        if callable(to_state_dict):
+            state_dict = to_state_dict()
+            if isinstance(checkpoint, dict) and "model" in checkpoint:
+                checkpoint["model"] = state_dict
+            else:
+                checkpoint = state_dict
+        else:
+            raise TypeError(
+                "Unsupported checkpoint format: expected a mapping for the model state"
+            )
+
+    original_bytes, quantized_bytes = estimate_checkpoint_sizes(
+        state_dict, args.num_bits
+    )
+
+    for key, value in state_dict.items():
+        if torch.is_tensor(value):
+            state_dict[key] = fake_quant_tensor(
+                value, args.num_bits, args.quantization
+            )
 
     out_dir = args.out_dir or f"{args.ckpt_dir}_ptq"
     os.makedirs(out_dir, exist_ok=True)
@@ -104,6 +207,7 @@ def main():
         shutil.copy(meta_in, meta_out)
 
     print("Quantization summary:")
+    print(f"  Scheme: {args.quantization}, bits: {args.num_bits}")
     print("  Estimated checkpoint size before quantization:")
     print(f"    {format_size(original_bytes)}")
     print("  Estimated checkpoint size after quantization:")

--- a/quantizations/ptq/fake_quantize_ckpt.py
+++ b/quantizations/ptq/fake_quantize_ckpt.py
@@ -1,6 +1,8 @@
 import argparse
 import os
 import shutil
+from typing import Iterable, Tuple
+
 import torch
 
 def parse_args():
@@ -39,11 +41,54 @@ def fake_quant_tensor(tensor: torch.Tensor, num_bits: int) -> torch.Tensor:
     q = torch.clamp(torch.round(tensor / scale), -qmax - 1, qmax)
     return (q * scale).to(tensor.dtype)
 
+
+def iter_state_tensors(state_dict) -> Iterable[torch.Tensor]:
+    if isinstance(state_dict, torch.nn.Module):
+        iterable = state_dict.state_dict().values()
+    elif isinstance(state_dict, dict):
+        iterable = state_dict.values()
+    else:
+        iterable = getattr(state_dict, "state_dict", lambda: {})().values()
+
+    for value in iterable:
+        if torch.is_tensor(value):
+            yield value
+
+
+def estimate_checkpoint_sizes(state_dict, num_bits: int) -> Tuple[float, float]:
+    """Estimate raw and quantized storage requirements for tensors in a state dict."""
+
+    original_bytes = 0.0
+    quantized_bytes = 0.0
+
+    for tensor in iter_state_tensors(state_dict):
+        numel = tensor.numel()
+        elem_bytes = tensor.element_size()
+        original_bytes += numel * elem_bytes
+        if torch.is_floating_point(tensor):
+            quantized_bytes += numel * num_bits / 8.0
+        else:
+            quantized_bytes += numel * elem_bytes
+
+    return original_bytes, quantized_bytes
+
+
+def format_size(num_bytes: float) -> str:
+    kb = num_bytes / 1024.0
+    mb = kb / 1024.0
+    gb = mb / 1024.0
+    return (
+        f"{num_bytes:,.0f} bytes "
+        f"({kb:,.2f} KB / {mb:,.2f} MB / {gb:,.4f} GB)"
+    )
+
 def main():
     args = parse_args()
     ckpt_path = os.path.join(args.ckpt_dir, "ckpt.pt")
     checkpoint = torch.load(ckpt_path, map_location="cpu", weights_only=True)
     state_dict = checkpoint.get("model", checkpoint)
+
+    original_bytes, quantized_bytes = estimate_checkpoint_sizes(state_dict, args.num_bits)
 
     for k, v in state_dict.items():
         if torch.is_tensor(v):
@@ -57,6 +102,26 @@ def main():
     meta_out = os.path.join(out_dir, "meta.pkl")
     if os.path.exists(meta_in):
         shutil.copy(meta_in, meta_out)
+
+    print("Quantization summary:")
+    print("  Estimated checkpoint size before quantization:")
+    print(f"    {format_size(original_bytes)}")
+    print("  Estimated checkpoint size after quantization:")
+    print(f"    {format_size(quantized_bytes)}")
+    if original_bytes > 0:
+        if quantized_bytes > 0:
+            ratio = original_bytes / quantized_bytes
+            pct_of_original = (quantized_bytes / original_bytes) * 100.0
+            reduction_pct = 100.0 - pct_of_original
+            print(
+                "  Estimated compression factor:"
+                f" {ratio:.2f}x ({reduction_pct:.2f}% size reduction, "
+                f"{pct_of_original:.2f}% of original size)"
+            )
+        else:
+            print("  Estimated compression factor: ∞ (100.00% size reduction)")
+    else:
+        print("  Estimated compression factor: n/a")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add uniform fake quantization script for applying post-training quantization to checkpoint weights
- demo minipile training with sampling before and after PTQ, now logging TensorBoard run names and model stats

## Testing
- `python -m py_compile quantizations/ptq/fake_quantize_ckpt.py`
- `bash -n demos/ptq_demo.sh`
- `python quantizations/ptq/fake_quantize_ckpt.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'jamo'; ModuleNotFoundError: No module named 'yakinori')*

------
https://chatgpt.com/codex/tasks/task_e_68b7e9f94d708326a15478b69c098876