### PR TITLE
Add CSV dataset utility and update dataset script

### DIFF
--- a/data/template/get_dataset.sh
+++ b/data/template/get_dataset.sh
@@ -6,6 +6,9 @@
 # 3. (Optionally) Modify the "value_prefixes" array to set prefixes for each value, use "" for empty prefixes
 # 4. Set "--skip_empty" to true if you want to skip empty fields, or false if not needed.
 # 5. Set "--no_output_text" to true if you plan to process the intermediate json files in a custom manner.
+# 6. For CSV files with BOM headers, pass "--input_encoding utf-8-sig" to the helper script.
+# 7. For CSV cells that contain multi-line text, use "--split_multiline_values" to emit one line per entry or
+#    "--newline_replacement" to substitute newline characters with custom text.
 
 # Run the Python script with the specified arguments
 
@@ -31,6 +34,9 @@ url="INSERT_URL_WITH_FILES"
 #   --include_keys "instruction" "response" \
 #   --value_prefixes $'#U:\n' $'#B:\n' \
 #   --split_by_prefix
+#   # Uncomment one of the following lines to control newline handling:
+#   # --split_multiline_values \
+#   # --newline_replacement "\\n" \
 #
 
 # uncomment for direct to json


### PR DESCRIPTION
## Summary
- add a CSV dataset helper that downloads Hugging Face CSV files or processes local CSVs while supporting include keys, value prefixes, and optional per-prefix outputs
- document the new helper in `get_dataset.sh` so template users can see how to call it

## Testing
- python -m compileall data/template/utils/get_csv_dataset.py

------
https://chatgpt.com/codex/tasks/task_e_68cae7f0b2548326b54ef508eaff6e7b