### PR TITLE
Add SLED decoding support for inference

### DIFF
--- a/model.py
+++ b/model.py
@@ -19,6 +19,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
+from typing import List, Optional, Sequence, Tuple
 
 # Config
 from gpt_conf import GPTConfig
@@ -614,6 +615,156 @@ class GPT(nn.Module):
                 loss = None
 
             return logits, loss
+
+    @torch.no_grad()
+    def forward_with_layer_logits(
+        self,
+        idx: torch.Tensor,
+        iter_num: Optional[int] = None,
+        dataset_idx: Optional[int] = None,
+        layer_indices: Optional[Sequence[int]] = None,
+    ) -> Tuple[torch.Tensor, List[Tuple[int, torch.Tensor]]]:
+        """Return final and intermediate logits for the last token.
+
+        Parameters
+        ----------
+        idx:
+            Token ids with shape ``(B, T)``.
+        iter_num:
+            Optional iteration number used by certain variations.
+        dataset_idx:
+            Index selecting the embedding / lm head when multi-dataset WTE is
+            enabled.
+        layer_indices:
+            Optional iterable of 1-indexed layer numbers whose logits should be
+            returned.  When ``None`` logits from all early layers are returned.
+
+        Returns
+        -------
+        Tuple[torch.Tensor, List[Tuple[int, torch.Tensor]]]
+            The final layer logits for the last token and a list containing
+            tuples ``(layer_index, logits)`` for the requested early layers.
+        """
+
+        if idx is None:
+            raise ValueError("forward_with_layer_logits expects an input tensor `idx`.")
+
+        device = idx.device
+        b, t = idx.size()
+
+        if self.config.multidataset_wte and dataset_idx is not None:
+            tok_emb = self.transformer[f'wte_{dataset_idx}'](idx)
+        else:
+            tok_emb = self.transformer.wte(idx)
+
+        if self.n_embd_wte:
+            tok_emb = self.transformer.scale_up(tok_emb)
+
+        if self.config.use_embedding_scale:
+            tok_emb = tok_emb * self.embedding_scale
+
+        if self.config.use_abs_pos_embeddings:
+            pos = torch.arange(0, t, dtype=torch.long, device=device)
+            tok_emb = tok_emb + self.transformer.wpe(pos)
+
+        x = self.transformer.drop(tok_emb)
+
+        learned_sum = None
+        if self.config.n_lpe != 0 and self.config.target_layer_in_lpe == 0:
+            for lpe in self.learned_position_embeddings:
+                out = lpe(b, t, x, iter_num)
+                learned_sum = out if learned_sum is None else learned_sum + out
+
+        if self.config.n_lpe != 0 and self.config.target_layer_out_lpe == 0:
+            x = x + learned_sum
+
+        if self.use_lsv and self.config.apply_lsv_at_layer_idx == 0:
+            x = self.lsv_matrix(x)
+
+        layer_outputs: List[torch.Tensor] = []
+        if self.use_ln_f_input_mixer:
+            layer_outputs.append(x)
+
+        num_layers = len(self.transformer.h)
+        if layer_indices is not None:
+            selected_layers = sorted({int(i) for i in layer_indices if 1 <= int(i) < num_layers})
+            selected_set = set(selected_layers)
+            if not selected_layers:
+                selected_set = None
+        else:
+            selected_set = None
+
+        collected_states: List[Tuple[int, torch.Tensor]] = []
+
+        layer_idx = 1
+        for block in self.transformer.h:
+            x = block(x, iter_num)
+
+            if self.config.n_lpe != 0 and self.config.target_layer_in_lpe == layer_idx:
+                for lpe in self.learned_position_embeddings:
+                    out = lpe(b, t, x, iter_num)
+                    learned_sum = out if learned_sum is None else learned_sum + out
+
+            if self.config.n_lpe != 0 and self.config.target_layer_out_lpe == layer_idx:
+                x = x + learned_sum
+
+            if self.use_lsv and layer_idx == self.config.apply_lsv_at_layer_idx:
+                x = self.lsv_matrix(x)
+
+            if (
+                self.config.apply_vector_at_layer_idx is not None
+                and layer_idx == self.config.apply_vector_at_layer_idx
+            ):
+                x = self.apply_vector_to_layer_output(x)
+
+            if (
+                self.config.obtain_vector_at_layer_idx is not None
+                and layer_idx == self.config.obtain_vector_at_layer_idx
+            ):
+                x = self.obtain_vector_from_layer_output(x)
+
+            if layer_idx < num_layers and (selected_set is None or layer_idx in selected_set):
+                collected_states.append((layer_idx, x[:, [-1], :].clone()))
+
+            if self.use_ln_f_input_mixer:
+                layer_outputs.append(x)
+
+            layer_idx += 1
+
+        pre_ln_final = x
+        if self.use_ln_f_input_mixer:
+            pre_ln_final = self.ln_f_mixer(layer_outputs)
+
+        def project_last_token(hidden: torch.Tensor) -> torch.Tensor:
+            if hidden.dim() == 2:
+                last_hidden = hidden.unsqueeze(1)
+            elif hidden.size(1) == 1:
+                last_hidden = hidden
+            else:
+                last_hidden = hidden[:, [-1], :]
+
+            last_hidden = self.transformer.ln_f(last_hidden)
+            if self.n_embd_wte:
+                last_hidden = F.linear(last_hidden, self.transformer.scale_down.weight.t())
+
+            if self.config.multidataset_wte and dataset_idx is not None:
+                logits = self.transformer[f'lm_head_{dataset_idx}'](last_hidden)
+            else:
+                logits = self.lm_head(last_hidden)
+
+            if self.final_logit_softcapping is not None:
+                logits = torch.tanh(logits / self.final_logit_softcapping) \
+                         * self.final_logit_softcapping
+
+            return logits.squeeze(1)
+
+        early_logits = [
+            (layer_id, project_last_token(hidden))
+            for layer_id, hidden in collected_states
+        ]
+
+        final_logits = project_last_token(pre_ln_final)
+        return final_logits, early_logits
     # ------------------------------------------------------------------
     #  LATENT-CHAINING
     # ------------------------------------------------------------------

--- a/sample.py
+++ b/sample.py
@@ -28,6 +28,7 @@ from torch.nn import functional as F
 from model import GPT, GPTConfig
 from utils.model_info import print_summary, print_module_structure, print_model_blocks
 from variations.model_variations import model_variation_dictionary
+from utils.sled import apply_sled
 
 import lm_eval
 from benchmarks.gpt_lm_eval_wrapper import NanoGPTLM
@@ -66,6 +67,45 @@ def parse_args():
         help="Apply a penalty to logits based on cosine similarity to recent tokens. "
             "Use alone for defaults (N=5, alpha=1.0). "
              "Optionally provide lookback window N and penalty strength alpha. Ex: --cosine_penalty 5 1.5"
+    )
+
+    # SLED decoding options
+    parser.add_argument(
+        '--use_sled',
+        default=False,
+        action=argparse.BooleanOptionalAction,
+        help="Enable Self Logits Evolution Decoding (SLED) during generation.",
+    )
+    parser.add_argument(
+        '--sled_alpha',
+        type=float,
+        default=0.5,
+        help="Evolution rate alpha used by SLED to update logits.",
+    )
+    parser.add_argument(
+        '--sled_top_k',
+        type=int,
+        default=5,
+        help="Number of top tokens considered during the SLED update.",
+    )
+    parser.add_argument(
+        '--sled_eta',
+        type=float,
+        default=-1e9,
+        help="Logit value assigned to tokens outside the SLED top-k set.",
+    )
+    parser.add_argument(
+        '--sled_layers',
+        type=int,
+        nargs='+',
+        default=None,
+        help="1-indexed layer numbers to use for SLED (defaults to all early layers).",
+    )
+    parser.add_argument(
+        '--sled_temperature',
+        type=float,
+        default=None,
+        help="Temperature used within SLED; defaults to the sampling temperature if omitted.",
     )
 
 
@@ -572,8 +612,27 @@ def sample_with_existing_model(
                         else x[:, -model.config.block_size :]
                     )
 
-                    model_logits, _ = model(idx_cond, dataset_idx=dataset_idx)
-                    raw_logits_row = model_logits[:, -1, :]      # Raw logits from model
+                    use_sled = args is not None and getattr(args, "use_sled", False)
+                    if use_sled:
+                        sled_layers = getattr(args, "sled_layers", None)
+                        final_logits, early_logits = model.forward_with_layer_logits(
+                            idx_cond,
+                            dataset_idx=dataset_idx,
+                            layer_indices=sled_layers,
+                        )
+                        sled_temp = args.sled_temperature if args.sled_temperature is not None else args.temperature
+                        early_values = [layer_logits for (_, layer_logits) in early_logits]
+                        raw_logits_row = apply_sled(
+                            final_logits,
+                            early_values,
+                            alpha=args.sled_alpha,
+                            top_k=args.sled_top_k,
+                            temperature=sled_temp,
+                            eta=args.sled_eta,
+                        )
+                    else:
+                        logits_tensor, _ = model(idx_cond, dataset_idx=dataset_idx)
+                        raw_logits_row = logits_tensor[:, -1, :]
 
                     # --- Apply Cosine Similarity Penalty (if enabled) ---
                     if args.cosine_penalty is not None:
@@ -781,17 +840,65 @@ def sample_with_existing_model(
                 )
 
 
-def interactive_generation(model, start_ids, device, max_new_tokens, temperature, top_k, stop_string, decode, encode):
+def interactive_generation(model, start_ids, args, decode, encode, dataset_idx=None):
+    device = args.device
+    stop_strings = args.stop_strings
+    if isinstance(stop_strings, str):
+        stop_strings = [stop_strings]
+
     x = torch.tensor(start_ids, dtype=torch.long, device=device)[None, ...]
+
     while True:
-        x, generated_text = model.generate_with_stop(x, max_new_tokens, stop_string, decode, temperature, top_k)
+        generated_text = ""
+        buffer = ""
+
+        for _ in range(args.max_new_tokens):
+            idx_cond = x if x.size(1) <= model.config.block_size else x[:, -model.config.block_size:]
+
+            use_sled = getattr(args, "use_sled", False)
+            if use_sled:
+                final_logits, early_logits = model.forward_with_layer_logits(
+                    idx_cond,
+                    dataset_idx=dataset_idx,
+                    layer_indices=args.sled_layers,
+                )
+                sled_temp = args.sled_temperature if args.sled_temperature is not None else args.temperature
+                early_values = [layer_logits for (_, layer_logits) in early_logits]
+                raw_logits_row = apply_sled(
+                    final_logits,
+                    early_values,
+                    alpha=args.sled_alpha,
+                    top_k=args.sled_top_k,
+                    temperature=sled_temp,
+                    eta=args.sled_eta,
+                )
+            else:
+                logits_tensor, _ = model(idx_cond, dataset_idx=dataset_idx)
+                raw_logits_row = logits_tensor[:, -1, :]
+
+            logits = raw_logits_row / args.temperature
+            if args.top_k is not None:
+                top_k_val = args.top_k[0] if isinstance(args.top_k, (list, tuple)) else args.top_k
+                v, _ = torch.topk(logits, min(top_k_val, logits.size(-1)))
+                logits[logits < v[:, [-1]]] = -float("inf")
+
+            probs = F.softmax(logits, dim=-1)
+            idx_next = torch.multinomial(probs, num_samples=1)
+            x = torch.cat((x, idx_next), dim=1)
+
+            next_token_text = decode(idx_next[0].tolist())
+            generated_text += next_token_text
+            buffer += next_token_text
+
+            if any(buffer.endswith(s) for s in stop_strings):
+                break
+
         print("[bold green]" + generated_text)
 
         user_input = input("User input (or 'exit' to quit): ")
         if user_input.lower() == 'exit':
             break
 
-        # Append the user input directly after the stop string
         x = torch.cat((x, torch.tensor(encode(user_input), dtype=torch.long, device=device)[None, ...]), dim=1)
 
 
@@ -1170,7 +1277,7 @@ def main():
         print(f"Obtained vector saved to {args.save_avg_vector}")
 
     if args.interactive:
-        interactive_generation(model, start_ids, args.device, args.max_new_tokens, args.temperature, args.top_k, args.stop_strings, decode, encode)
+        interactive_generation(model, start_ids, args, decode, encode, dataset_idx=0)
     elif args.multicontext:
         assert args.multicontext_datasets is not None, (
             "Must specify --multicontext_datasets when using --multicontext"

--- a/utils/sled.py
+++ b/utils/sled.py
@@ -1,0 +1,148 @@
+"""Utilities for Self Logits Evolution Decoding (SLED).
+
+This module implements the SLED algorithm described in
+"SLED: Self Logits Evolution Decoding for Improving Factuality in Large
+Language Models" (arXiv:2411.02433).
+
+The implementation follows Algorithm 1 from the paper and operates purely on
+logits.  Given the logits from the final layer and a collection of logits from
+earlier layers, SLED contrasts these distributions to expose the model's latent
+knowledge and nudges the final logits toward it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import torch
+import torch.nn.functional as F
+
+
+@dataclass
+class SLEDConfig:
+    """Configuration container for SLED.
+
+    Attributes
+    ----------
+    alpha:
+        Evolution rate ``α`` controlling the magnitude of the update applied to
+        the final logits.
+    top_k:
+        Number of tokens retained for the self-evolution step.  Tokens outside
+        this set are assigned ``eta`` to suppress their probability mass.
+    temperature:
+        Temperature ``τ`` used to transform logits into probabilities while
+        computing the latent distribution.
+    eta:
+        Logit value applied to tokens outside of the top-``k`` set.  The paper
+        recommends using a very negative value so that these tokens are ignored
+        during sampling.
+    """
+
+    alpha: float = 0.5
+    top_k: int = 5
+    temperature: float = 1.0
+    eta: float = -1e9
+
+
+def apply_sled(
+    final_logits: torch.Tensor,
+    early_layer_logits: Sequence[torch.Tensor],
+    *,
+    alpha: float,
+    top_k: int,
+    temperature: float,
+    eta: float = -1e9,
+) -> torch.Tensor:
+    """Apply the SLED update to ``final_logits``.
+
+    Parameters
+    ----------
+    final_logits:
+        Tensor of shape ``(B, V)`` holding the final-layer logits for the next
+        token.
+    early_layer_logits:
+        Sequence containing tensors with shape ``(B, V)`` representing logits
+        from earlier transformer layers.  Each tensor should correspond to the
+        same position as ``final_logits``.
+    alpha:
+        Evolution rate ``α`` controlling the strength of the update.
+    top_k:
+        Number of tokens to retain during the evolution step.  If ``top_k`` is
+        greater than the vocabulary size, all tokens are retained.
+    temperature:
+        Temperature ``τ`` used when converting logits into probabilities.
+    eta:
+        Logit value assigned to tokens outside of the selected ``top_k`` set.
+
+    Returns
+    -------
+    torch.Tensor
+        Updated logits with the same shape as ``final_logits``.
+    """
+
+    if not early_layer_logits:
+        return final_logits
+
+    if top_k <= 0:
+        return final_logits
+
+    # All computations are performed in float32 for numerical stability and
+    # converted back to the original dtype at the end.
+    original_dtype = final_logits.dtype
+    final_logits_f = final_logits.float()
+    early_logits_f = [logits.float() for logits in early_layer_logits]
+
+    batch_size, vocab_size = final_logits_f.shape
+    tau = float(temperature)
+    if tau <= 0:
+        raise ValueError("SLED requires a positive temperature")
+
+    k = min(int(top_k), vocab_size)
+    topk_values, topk_indices = torch.topk(final_logits_f, k, dim=-1)
+
+    final_probs = F.softmax(final_logits_f / tau, dim=-1)
+
+    layer_scores: list[torch.Tensor] = []
+    eps = 1e-12
+
+    for logits_n in early_logits_f:
+        diff = logits_n - final_logits_f
+        diff_norm = diff.norm(dim=-1).clamp_min(eps)
+
+        probs_n = F.softmax(logits_n / tau, dim=-1)
+        diff_dot_probs = (diff * probs_n).sum(dim=-1)
+        probs_sq_sum = (probs_n * probs_n).sum(dim=-1)
+
+        diff_i = diff.gather(-1, topk_indices)
+        probs_i = probs_n.gather(-1, topk_indices)
+
+        numerator = diff_dot_probs.unsqueeze(-1) - diff_i
+        denom_vector = torch.sqrt((probs_sq_sum.unsqueeze(-1) - 2.0 * probs_i + 1.0).clamp_min(eps))
+        denom = diff_norm.unsqueeze(-1) * denom_vector
+
+        cos_sim = numerator / denom
+        cos_sim = torch.nan_to_num(cos_sim, nan=0.0, posinf=0.0, neginf=0.0)
+        cos_sim = torch.clamp(cos_sim, min=0.0)
+
+        layer_scores.append(cos_sim ** 2)
+
+    stacked = torch.stack(layer_scores, dim=0)  # (L, B, K)
+
+    totals = stacked.sum(dim=(0, 2))  # (B,)
+    totals = totals.clamp_min(eps)
+    latent_topk = stacked.sum(dim=0) / totals.unsqueeze(-1)
+
+    adjusted = final_logits_f.clone()
+    if k < vocab_size:
+        adjusted.fill_(eta)
+
+    final_probs_topk = final_probs.gather(-1, topk_indices)
+    updates = topk_values - (alpha / tau) * (final_probs_topk - latent_topk)
+    adjusted.scatter_(-1, topk_indices, updates)
+
+    return adjusted.to(dtype=original_dtype)
+
+
+__all__ = ["SLEDConfig", "apply_sled"]


### PR DESCRIPTION
## Summary
- add a SLED utility for updating logits based on early layer distributions
- expose a helper on GPT to return per-layer logits for the final token
- wire SLED into sampling/interactive flows with new CLI controls

## Testing
- python -m compileall model.py sample.py utils/sled.py

------
https://chatgpt.com/codex/tasks/task_e_68cfb3e09c18832684f34b2092bbc47b