### PR TITLE
Improve numerical multicontext sampling support

### DIFF
--- a/data/sinewave/prepare.py
+++ b/data/sinewave/prepare.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Wrapper script that reuses the template dataset preparation logic."""
+
+from data.template.prepare import main
+
+
+if __name__ == "__main__":
+    main()

--- a/data/sinewave/s1/graph_sine_bins.py
+++ b/data/sinewave/s1/graph_sine_bins.py
@@ -1,0 +1,26 @@
+# graph_sine_bins.py
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def load_and_plot(filename, label):
+    with open(filename, "rb") as f:
+        data = np.fromfile(f, dtype=np.uint16)
+    plt.plot(data, label=label)
+
+
+def main():
+    plt.figure(figsize=(12, 4))
+    load_and_plot("train.bin", "train.bin")
+    load_and_plot("val.bin", "val.bin")
+    plt.title("Sine Wave Token Values from train.bin and val.bin")
+    plt.xlabel("Index")
+    plt.ylabel("Token Value")
+    plt.legend()
+    plt.grid(True)
+    plt.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/data/sinewave/s2/graph_sine_bins.py
+++ b/data/sinewave/s2/graph_sine_bins.py
@@ -1,0 +1,26 @@
+# graph_sine_bins.py
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def load_and_plot(filename, label):
+    with open(filename, "rb") as f:
+        data = np.fromfile(f, dtype=np.uint16)
+    plt.plot(data, label=label)
+
+
+def main():
+    plt.figure(figsize=(12, 4))
+    load_and_plot("train.bin", "train.bin")
+    load_and_plot("val.bin", "val.bin")
+    plt.title("Sine Wave Token Values from train.bin and val.bin")
+    plt.xlabel("Index")
+    plt.ylabel("Token Value")
+    plt.legend()
+    plt.grid(True)
+    plt.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/data/template/graph_sine_bins.py
+++ b/data/template/graph_sine_bins.py
@@ -1,0 +1,26 @@
+# graph_sine_bins.py
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def load_and_plot(filename, label):
+    with open(filename, "rb") as f:
+        data = np.fromfile(f, dtype=np.uint16)
+    plt.plot(data, label=label)
+
+
+def main():
+    plt.figure(figsize=(12, 4))
+    load_and_plot("train.bin", "train.bin")
+    load_and_plot("val.bin", "val.bin")
+    plt.title("Sine Wave Token Values from train.bin and val.bin")
+    plt.xlabel("Index")
+    plt.ylabel("Token Value")
+    plt.legend()
+    plt.grid(True)
+    plt.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/data/template/tokenizers.py
+++ b/data/template/tokenizers.py
@@ -7,6 +7,8 @@ import tiktoken
 from tqdm import tqdm
 from collections import defaultdict
 import json
+import math
+import numpy as np
 
 
 class Tokenizer:
@@ -571,4 +573,33 @@ class JsonByteTokenizerWithByteFallback(Tokenizer):
             out_pieces.append(all_bytes.decode('utf-8', errors='replace'))
 
         return ''.join(out_pieces)
+
+
+class SineWaveTokenizer:
+    """Generate a deterministic sequence of sine wave samples."""
+
+    def __init__(self, args):
+        self.period = args.sine_period
+        self.points_per_period = args.sine_points_per_period
+        self.num_periods = args.sine_num_periods
+        self.amplitude = args.sine_amplitude
+        self.max_val = 255
+
+    def generate_wave(self):
+        total_points = self.num_periods * self.points_per_period
+        values = []
+        for i in range(total_points):
+            x = (i * 2 * math.pi) / self.points_per_period
+            y = 64 + self.amplitude * math.sin(x * self.period)
+            y_clamped = int(max(0, min(self.max_val, round(y))))
+            values.append(y_clamped)
+        return values
+
+    def tokenize(self, data=None):
+        # `data` is unused; generation is parameter driven.
+        return self.generate_wave()
+
+    def detokenize(self, ids):
+        array = np.asarray(ids, dtype=np.int64)
+        return ','.join(map(str, array.tolist()))
 

--- a/demos/num_mc.sh
+++ b/demos/num_mc.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Demo script for numerical multi-context training with sine wave data.
+
+python train.py \
+  --training_mode multicontext \
+  --dataset sinewave/s1 \
+  --multicontext \
+  --multicontext_datasets sinewave/s1 sinewave/s2 \
+  --numerical_multicontext \
+  --numerical_mlp_hidden_dim 64 \
+  --n_layer 4 \
+  --n_head 4 \
+  --n_embd 128 \
+  --block_size 128 \
+  --batch_size 32 \
+  --max_iters 1000 \
+  --eval_interval 100 \
+  --out_dir out/numerical_mc_test

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -15,6 +15,10 @@ class GPTConfig:
     n_embd: int = 768
     mlp_down_projs: int = 1  # Number of down projections in MLP/SwiGLU
 
+    # numerical multicontext
+    numerical_multicontext: bool = False
+    numerical_mlp_hidden_dim: int = 64
+
     # Layerlists
     n_head_layerlist: List[int] = field(default_factory=list)
     n_qk_head_dim_layerlist: List[int] = field(default_factory=list)

--- a/sample.py
+++ b/sample.py
@@ -998,6 +998,18 @@ def get_tokenizer_functions(meta):
         decode = lambda l: ''.join([itos[i] for i in l])
         return encode, decode
 
+    if meta['tokenizer'] == "sinewave":
+        def encode_fn(s: str):
+            s = s.strip()
+            if not s:
+                return []
+            return [int(v) for v in s.split(',')]
+
+        def decode_fn(values):
+            return ','.join(str(int(v)) for v in values)
+
+        return encode_fn, decode_fn
+
     if meta['tokenizer'] == 'tiktoken':
         enc = tiktoken.get_encoding(meta['tiktoken_encoding'])
         encode = lambda s: enc.encode(s, allowed_special={""})
@@ -1112,9 +1124,13 @@ def main():
     os.makedirs(out_dir, exist_ok=True)
     save_args(args, out_dir)
 
+    checkpoint = None
+    checkpoint_config: Dict[str, object] = {}
+
     if args.init_from == 'resume':
         ckpt_path = os.path.join(args.out_dir, 'ckpt.pt')
         checkpoint = torch.load(ckpt_path, map_location=args.device)
+        checkpoint_config = checkpoint.get('config', {})
         checkpoint['model_args']['dropout'] = 0.0
         if args.save_avg_vector:
             print(f"saving {args.save_avg_vector}")
@@ -1155,6 +1171,18 @@ def main():
             setattr(gptconf, k, v)
         model = GPT.from_pretrained(gptconf, model_type=args.init_from)
 
+    if args.init_from == 'resume' and args.multicontext is None:
+        args.multicontext = bool(getattr(model.config, "multicontext", False))
+
+    if (
+        args.init_from == 'resume'
+        and args.multicontext
+        and args.multicontext_datasets is None
+    ):
+        datasets_from_ckpt = checkpoint_config.get('multicontext_datasets') if checkpoint_config else None
+        if datasets_from_ckpt:
+            args.multicontext_datasets = list(datasets_from_ckpt)
+
     # Load meta information if available
     load_meta = False
     meta_path = None
@@ -1177,6 +1205,7 @@ def main():
         encode = lambda s: enc.encode(s, allowed_special={""})
         decode = lambda l: enc.decode(l)
 
+    meta = None
     if load_meta:
         print(f"Loading meta from {meta_path}...")
         with open(meta_path, 'rb') as f:
@@ -1187,7 +1216,19 @@ def main():
         with open(args.start[5:], 'r', encoding='utf-8') as f:
             args.start = f.read()
 
+    if args.multicontext and args.multicontext_start is None and args.multicontext_datasets:
+        args.multicontext_start = [args.start] * len(args.multicontext_datasets)
+
     start_ids = encode(args.start)
+    if len(start_ids) == 0:
+        if meta and meta.get('tokenizer') == 'sinewave':
+            print("Start string produced no tokens for sinewave tokenizer; defaulting to '0'.")
+            start_ids = [0]
+        elif not args.multicontext:
+            raise ValueError(
+                "The provided --start text resulted in an empty context. "
+                "Please supply a non-empty prompt or comma-separated values for numerical tokenizers."
+            )
     model.eval()
     model.to(args.device)
 
@@ -1285,54 +1326,50 @@ def main():
     if args.interactive:
         interactive_generation(model, start_ids, args.device, args.max_new_tokens, args.temperature, args.top_k, args.stop_strings, decode, encode)
     elif args.multicontext:
-        assert args.multicontext_datasets is not None, (
-            "Must specify --multicontext_datasets when using --multicontext"
-        )
-        assert args.multicontext_start is not None, (
-            "Must specify --multicontext_start when using --multicontext"
-        )
+        if not args.multicontext_datasets:
+            raise ValueError("Must specify --multicontext_datasets when using --multicontext")
+        if args.multicontext_start is None:
+            raise ValueError("Must specify --multicontext_start when using --multicontext")
         if len(args.multicontext_datasets) != len(args.multicontext_start):
             raise ValueError(
                 "Number of --multicontext_datasets must match number of --multicontext_start strings."
             )
 
-        # Build a separate tokenizer for each dataset
-        token_dict = {}
-        target_dict = {}
+        dataset_names = list(args.multicontext_datasets)
+        start_strings = list(args.multicontext_start)
 
-        for i, dataset_name in enumerate(args.multicontext_datasets):
-            # 1) Find meta.pkl for this dataset, e.g. data/<dataset_name>/meta.pkl
+        dataset_meta: Dict[str, Dict[str, object]] = {}
+        decode_lookup: Dict[str, Callable[[Sequence[int]], str]] = {}
+        initial_tokens: Dict[str, torch.Tensor] = {}
+
+        for dataset_name, start_str in zip(dataset_names, start_strings):
             meta_path = os.path.join("data", dataset_name, "meta.pkl")
-            assert os.path.exists(meta_path), f"meta.pkl not found at {meta_path}"
+            if not os.path.exists(meta_path):
+                raise FileNotFoundError(f"meta.pkl not found at {meta_path}")
             with open(meta_path, "rb") as f:
-                meta = pickle.load(f)
+                dataset_meta[dataset_name] = pickle.load(f)
 
-            stoi = meta['stoi']
-            itos = meta['itos']
-            encode_i = lambda s: [stoi[c] for c in s if c in stoi]
-            decode_i = lambda l: "".join([itos[i] for i in l])
+            encode_i, decode_i = get_tokenizer_functions(dataset_meta[dataset_name])
+            token_ids = encode_i(start_str)
+            if len(token_ids) == 0:
+                if dataset_meta[dataset_name].get('tokenizer') == 'sinewave':
+                    print(
+                        f"Start string for dataset '{dataset_name}' produced no tokens; defaulting to '0'."
+                    )
+                    token_ids = [0]
+                else:
+                    raise ValueError(
+                        f"Start string for dataset '{dataset_name}' produced no tokens. "
+                        "Provide a valid prompt or comma-separated values for numerical tokenizers."
+                    )
 
-            # 3) Encode the start string for *this* context
-            start_str = args.multicontext_start[i]
-            start_ids = encode_i(start_str)
-            token_tensor = torch.tensor(
-                start_ids,
-                dtype=torch.long,
-                device=args.device
-            )[None, ...]
+            token_tensor = torch.tensor(token_ids, dtype=torch.long, device=args.device)[None, ...]
+            initial_tokens[dataset_name] = token_tensor
+            decode_lookup[dataset_name] = decode_i
 
-            # 4) Keep decode function if we want to print each context separately
-            token_dict[f"context_{i}"] = token_tensor
-            # Optionally we could store decode_i if we want to decode separately
-            # e.g. a dictionary of decode functions: decode_dict[f"context_{i}"] = decode_i
-
-        # Now do the same generation loop. We'll do the "one forward pass per time-step" approach
         block_size = args.block_size if args.block_size else model.config.block_size
         with torch.no_grad(), ctx:
-            for k in range(args.num_samples):
-                # This block handles LSV for standalone sampling. When called from train.py,
-                # lsv_size is not an arg, so we skip this to avoid an AttributeError and
-                # to respect the index already set by the trainer.
+            for sample_idx in range(args.num_samples):
                 if args.use_lsv and hasattr(args, 'lsv_size'):
                     model.set_lsv_index(sample_idx % args.lsv_size)
                     if args.lsv_scaling_factor is not None:
@@ -1343,73 +1380,70 @@ def main():
                     else:
                         model.set_lsv_mode(1)
 
+                token_state = {name: tensor.clone() for name, tensor in initial_tokens.items()}
 
-                # We'll generate args.max_new_tokens total tokens
-                for step in range(args.max_new_tokens):
+                for _ in range(args.max_new_tokens):
                     idx_cond_dict = {}
-                    # 5) Build a cropped version per context
-                    for key, tokens in token_dict.items():
-                        if tokens.size(1) <= block_size:
-                            idx_cond_dict[key] = tokens
-                        else:
-                            idx_cond_dict[key] = tokens[:, -block_size:]
+                    for name in dataset_names:
+                        tokens = token_state[name]
+                        idx_cond_dict[name] = tokens if tokens.size(1) <= block_size else tokens[:, -block_size:]
 
-                    # 6) Single forward pass for all contexts
                     logits_list, _ = model(None, token_dict=idx_cond_dict, target_dict=None)
 
-                    # import pdb; pdb.set_trace()
-                    # 7) For each context, sample next token
-                    key_list = list(idx_cond_dict.keys())
-                    for i, key in enumerate(key_list):
-                        cur_logits = logits_list[i][:, -1, :] / args.temperature
-                        # ── top-k truncation ───────────────────────────────
-                        # argparse uses `nargs='+'`, so --top_k may arrive as
-                        # an *int* or as a *list* (even when only one value is
-                        # supplied).  Convert to a plain int before `min()`.
-                        if args.top_k is not None:
-                            top_k_val = args.top_k[0] if isinstance(
-                                args.top_k, (list, tuple)
-                            ) else args.top_k
+                    for i, name in enumerate(dataset_names):
+                        if model.config.numerical_multicontext:
+                            preds = logits_list[i][:, -1]
+                            preds = preds.squeeze(-1)
+                            if preds.ndim == 0:
+                                preds = preds.unsqueeze(0)
+                            rounded = preds.round()
+                            min_val = 0.0
+                            max_val = None
+                            meta_info = dataset_meta.get(name, {})
+                            tokenizer_name = meta_info.get('tokenizer') if isinstance(meta_info, dict) else None
+                            if tokenizer_name == 'sinewave':
+                                max_val = 255.0
+                            elif isinstance(meta_info, dict) and 'vocab_size' in meta_info:
+                                max_val = float(meta_info['vocab_size'] - 1)
 
-                            k = min(top_k_val, cur_logits.size(-1))
-                            v, _ = torch.topk(cur_logits, k)
-                            cur_logits[cur_logits < v[:, [-1]]] = -float("inf")
+                            if max_val is not None:
+                                rounded = torch.clamp(rounded, min=min_val, max=max_val)
+                            else:
+                                rounded = torch.clamp(rounded, min=min_val)
 
-                        probs = F.softmax(cur_logits, dim=-1)
-                        idx_next = torch.multinomial(probs, num_samples=1)
-                        token_dict[key] = torch.cat((token_dict[key], idx_next), dim=1)
+                            idx_next = rounded.to(torch.long).unsqueeze(-1)
+                        else:
+                            cur_logits = logits_list[i][:, -1, :] / args.temperature
+                            if args.top_k is not None:
+                                top_k_val = (
+                                    args.top_k[0]
+                                    if isinstance(args.top_k, (list, tuple))
+                                    else args.top_k
+                                )
+                                k = min(top_k_val, cur_logits.size(-1))
+                                v, _ = torch.topk(cur_logits, k)
+                                cur_logits[cur_logits < v[:, [-1]]] = -float("inf")
 
-                # 8) After generation, decode each context
-                output_dict = {}
-                # Re-load the meta & decode for each context to show final text
-                for i, dataset_name in enumerate(args.multicontext_datasets):
-                    meta_path = os.path.join("data", dataset_name, "meta.pkl")
-                    with open(meta_path, "rb") as f:
-                        meta = pickle.load(f)
-                    if 'tokenizer' in meta and meta['tokenizer'] == 'tiktoken':
-                        enc_obj = tiktoken.get_encoding(meta['tiktoken_encoding'])
-                        decode_i = lambda l: enc_obj.decode(l)
-                    else:
-                        # or custom fallback
-                        stoi = meta['stoi']
-                        itos = meta['itos']
-                        decode_i = lambda l: "".join([itos[ix] for ix in l if ix in itos])
+                            probs = F.softmax(cur_logits, dim=-1)
+                            idx_next = torch.multinomial(probs, num_samples=1)
 
-                    key = f"context_{i}"
-                    tokens_i = token_dict[key][0].tolist()
-                    output_dict[key] = decode_i(tokens_i)
+                        token_state[name] = torch.cat((token_state[name], idx_next), dim=1)
 
-                # 9) Print
-                for key, text in output_dict.items():
-                    key_color="bold light_slate_blue"
-                    text_color="bold cyan"
-                    print(f"\n[{key_color}]{key}:[/{key_color}]\n[{text_color}]{text}[/{text_color}]")
+                output_dict: Dict[str, str] = {}
+                for name in dataset_names:
+                    decode_fn = decode_lookup[name]
+                    output_dict[name] = decode_fn(token_state[name][0].tolist())
+
+                for name, text in output_dict.items():
+                    key_color = "bold light_slate_blue"
+                    text_color = "bold cyan"
+                    print(f"\n[{key_color}]{name}:[/{key_color}]\n[{text_color}]{text}[/{text_color}]")
                 print("---------------")
 
                 if args.sample_file:
                     with open(args.sample_file, "w") as file:
-                        for key, text in output_dict.items():
-                            file.write(f"\n{key}: \n{text}\n")
+                        for name, text in output_dict.items():
+                            file.write(f"\n{name}: \n{text}\n")
     else:
         sample_with_existing_model(
                 model,

--- a/train.py
+++ b/train.py
@@ -1709,7 +1709,7 @@ class Trainer:
                                 loss_fn=self.loss_fn,
                             )
 
-                        if hasattr(self.optimizer, "set_entropy"):
+                        if hasattr(self.optimizer, "set_entropy") and not isinstance(logits, (list, tuple)):
                             with torch.no_grad():
                                 probs = torch.softmax(logits, dim=-1)
                                 ent = -(probs * torch.log(probs + 1e-9)).sum(dim=-1).mean()

--- a/train_args.py
+++ b/train_args.py
@@ -169,6 +169,10 @@ def parse_args():
     training_group.add_argument("--seed", default=1337, type=int)
 
     # Multicontext Training Dataset args
+    model_group.add_argument('--numerical_multicontext', default=False, action=argparse.BooleanOptionalAction,
+                                    help="Interpret multicontext inputs as numerical values and use regression heads")
+    model_group.add_argument('--numerical_mlp_hidden_dim', default=64, type=int,
+                                    help="Hidden dimension for numerical multi-context embedding/output MLPs")
     model_group.add_argument('--multicontext', default=False, action=argparse.BooleanOptionalAction,
                                     help="Enable multi-context training on multiple simultaneous datasets")
     model_group.add_argument('--multidataset_wte', default=False, action=argparse.BooleanOptionalAction,


### PR DESCRIPTION
## Summary
- auto-enable multicontext inference when resuming checkpoints and seed default prompts for sinewave tokenizers that produce empty contexts
- update multicontext sampling to use each dataset's tokenizer metadata, reset context per sample, and convert numerical outputs to bounded integer tokens
- provide clearer validation and output handling when sampling across multiple contexts

## Testing
- python -m compileall sample.py data/template/prepare.py data/template/tokenizers.py gpt_conf.py model.py train_args.py data/sinewave/prepare.py

------
https://chatgpt.com/codex/tasks/task_e_68d3767343b88326a4d2bad69f7240d3