### PR TITLE
Allow hypersphere scripts to resolve project imports when run directly

### DIFF
--- a/huggingface_model/hypersphere_gpt/README.md
+++ b/huggingface_model/hypersphere_gpt/README.md
@@ -1,0 +1,112 @@
+# Hypersphere GPT Hugging Face Workflow
+
+This directory contains a Hugging Face compatible implementation of the Hypersphere GPT
+architecture together with utilities for training on FineWeb, exporting checkpoints,
+running generation, and evaluating on the lm-evaluation-harness benchmark suites.
+
+## Normalization options
+
+The model can be instantiated with a selectable normalization strategy via
+`--norm_type` on the training script (and stored in the configuration for reuse
+at inference/export time). The following options mirror the implementations in
+[`variations/norm_variations.py`](../../variations/norm_variations.py):
+
+| `--norm_type` value | Description |
+| --- | --- |
+| `layernorm` | Standard LayerNorm without a bias vector. |
+| `rmsnorm` | Bias-free RMSNorm. |
+| `hypersphere` | HyperSphereNorm with a fixed radius (defaults to √embedding dim). |
+| `hypersphere_learned_radius` | HyperSphereNorm with a learned radius parameter. |
+| `prmsnorm` | Partial RMSNorm that normalizes over the first `--prmsnorm_pct` fraction of features. |
+
+When using one of the HyperSphereNorm variants you may optionally pin the radius
+with `--hsnorm_radius <float>`. For pRMSNorm you can choose how much of the
+channel dimension participates in the RMS calculation by supplying
+`--prmsnorm_pct` (default: `0.5`).
+
+## Training on FineWeb-Edu
+
+The hero configuration (~124M parameters) is wired into
+`train_hypersphere_gpt.py`. A minimal launch that trains with RMSNorm and saves a
+checkpoint every 200 steps looks like:
+
+> **Tip:** The helper scripts can be executed either as modules (for example,
+> `python -m huggingface_model.hypersphere_gpt.train_hypersphere_gpt`) or as
+> stand-alone files from the repository root as shown below.
+
+```bash
+python huggingface_model/hypersphere_gpt/train_hypersphere_gpt.py \
+  --output_dir runs/hypersphere-gpt-rmsnorm \
+  --dataset HuggingFaceH4/fineweb-edu \
+  --dataset_split "train[:0.1%]" \
+  --block_size 2048 \
+  --per_device_train_batch_size 2 \
+  --num_train_epochs 1 \
+  --learning_rate 3e-4 \
+  --save_steps 200 \
+  --norm_type rmsnorm
+```
+
+### Sample training → sampling → benchmarking flow (RMSNorm)
+
+```bash
+# 1. Train the model with RMSNorm
+python huggingface_model/hypersphere_gpt/train_hypersphere_gpt.py \
+  --output_dir runs/rmsnorm-hero \
+  --dataset HuggingFaceH4/fineweb-edu \
+  --dataset_split "train[:0.1%]" \
+  --norm_type rmsnorm
+
+# 2. Generate text from the latest checkpoint
+python huggingface_model/hypersphere_gpt/infer_hypersphere_gpt.py \
+  --model_path runs/rmsnorm-hero \
+  --prompt "The future of open language models"
+
+# 3. Benchmark with the lm-evaluation-harness defaults
+python huggingface_model/hypersphere_gpt/run_hypersphere_gpt_benchmarks.py \
+  --model_path runs/rmsnorm-hero \
+  --tokenizer_name gpt2
+```
+
+## Inference-only usage
+
+Once you have a directory containing a trained checkpoint, invoke
+`infer_hypersphere_gpt.py` to sample text:
+
+```bash
+python huggingface_model/hypersphere_gpt/infer_hypersphere_gpt.py \
+  --model_path runs/hypersphere-gpt-rmsnorm \
+  --prompt "Education data reveals" \
+  --max_new_tokens 128 \
+  --temperature 0.8
+```
+
+## Exporting to the Hugging Face Hub
+
+Convert a local checkpoint into a standard Hugging Face folder (optionally
+pushing to the Hub) with:
+
+```bash
+python huggingface_model/hypersphere_gpt/export_hypersphere_gpt_to_hf.py \
+  --checkpoint_dir runs/hypersphere-gpt-rmsnorm \
+  --output_dir export/hypersphere-gpt-rmsnorm \
+  --use_safetensors
+```
+
+Pass `--push_to_hub`, `--hub_model_id`, and `--hub_token` to publish the
+artifacts directly.
+
+## Running lm-eval benchmark suites
+
+`run_hypersphere_gpt_benchmarks.py` wraps lm-evaluation-harness. The default
+invocation benchmarks on a suite of standard language understanding tasks:
+
+```bash
+python huggingface_model/hypersphere_gpt/run_hypersphere_gpt_benchmarks.py \
+  --model_path export/hypersphere-gpt-rmsnorm \
+  --tokenizer_name gpt2 \
+  --tasks hellaswag,arc_easy,arc_challenge,winogrande,lambada_openai
+```
+
+Use `--device cpu` if you do not have access to a GPU, and set `--dtype float32`
+when running entirely on the CPU.

--- a/huggingface_model/hypersphere_gpt/__init__.py
+++ b/huggingface_model/hypersphere_gpt/__init__.py
@@ -1,0 +1,10 @@
+from .config import HypersphereGPTConfig
+from .modeling_hypersphere_gpt import HypersphereGPTModel, HypersphereGPTForCausalLM
+from .tokenizer import TiktokenTokenizer
+
+__all__ = [
+    "HypersphereGPTConfig",
+    "HypersphereGPTModel",
+    "HypersphereGPTForCausalLM",
+    "TiktokenTokenizer",
+]

--- a/huggingface_model/hypersphere_gpt/config.py
+++ b/huggingface_model/hypersphere_gpt/config.py
@@ -1,0 +1,79 @@
+from transformers import PretrainedConfig
+
+
+class HypersphereGPTConfig(PretrainedConfig):
+    model_type = "hypersphere-gpt"
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        vocab_size: int = 50257,
+        n_layer: int = 12,
+        n_head: int = 12,
+        n_embd: int = 768,
+        n_inner: int | None = None,
+        block_size: int = 2048,
+        dropout: float = 0.0,
+        layer_norm_epsilon: float = 1e-5,
+        norm_type: str = "hypersphere",
+        prmsnorm_pct: float = 0.5,
+        initializer_range: float = 0.02,
+        use_qk_norm: bool = True,
+        use_qk_norm_scale: bool = True,
+        use_rotary_embeddings: bool = True,
+        rope_length: int | None = None,
+        hsnorm_gain: bool = True,
+        hsnorm_radius: float | None = None,
+        hsnorm_radius_learning: bool = False,
+        use_peri_ln_attn: bool = True,
+        use_peri_ln_mlp: bool = True,
+        bias: bool = False,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            pad_token_id=vocab_size - 1,
+            bos_token_id=50256,
+            eos_token_id=50256,
+            tie_word_embeddings=True,
+            **kwargs,
+        )
+
+        self.vocab_size = vocab_size
+        self.n_layer = n_layer
+        self.n_head = n_head
+        self.n_embd = n_embd
+        self.n_inner = n_inner if n_inner is not None else 4 * n_embd
+        self.block_size = block_size
+        self.dropout = dropout
+        self.layer_norm_epsilon = layer_norm_epsilon
+        norm_type = norm_type.lower()
+        valid_norms = {
+            "layernorm",
+            "rmsnorm",
+            "hypersphere",
+            "hypersphere_learned_radius",
+            "prmsnorm",
+        }
+        if norm_type not in valid_norms:
+            raise ValueError(
+                f"Unsupported norm_type '{norm_type}'. Expected one of: {sorted(valid_norms)}"
+            )
+        self.norm_type = norm_type
+        if self.norm_type == "prmsnorm":
+            if not (0.0 < prmsnorm_pct <= 1.0):
+                raise ValueError("prmsnorm_pct must be in the interval (0, 1].")
+        self.prmsnorm_pct = prmsnorm_pct
+        self.initializer_range = initializer_range
+        self.use_qk_norm = use_qk_norm
+        self.use_qk_norm_scale = use_qk_norm_scale
+        self.use_rotary_embeddings = use_rotary_embeddings
+        self.rope_length = rope_length
+        self.hsnorm_gain = hsnorm_gain
+        self.hsnorm_radius = hsnorm_radius
+        self.hsnorm_radius_learning = hsnorm_radius_learning or (
+            self.norm_type == "hypersphere_learned_radius"
+        )
+        self.use_peri_ln_attn = use_peri_ln_attn
+        self.use_peri_ln_mlp = use_peri_ln_mlp
+        self.bias = bias
+        self.use_cache = kwargs.get("use_cache", True)

--- a/huggingface_model/hypersphere_gpt/export_hypersphere_gpt_to_hf.py
+++ b/huggingface_model/hypersphere_gpt/export_hypersphere_gpt_to_hf.py
@@ -1,0 +1,113 @@
+"""Utility script to export Hypersphere GPT checkpoints to the Hugging Face format."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from transformers import GenerationConfig, GPT2TokenizerFast
+
+if __package__ is None or __package__ == "":  # pragma: no cover - runtime convenience
+    PACKAGE_ROOT = Path(__file__).resolve().parent
+    PROJECT_ROOT = PACKAGE_ROOT.parent
+    REPO_ROOT = PROJECT_ROOT.parent
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.append(str(PROJECT_ROOT))
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.append(str(REPO_ROOT))
+    from hypersphere_gpt.modeling_hypersphere_gpt import HypersphereGPTForCausalLM  # type: ignore
+else:
+    from .modeling_hypersphere_gpt import HypersphereGPTForCausalLM
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--checkpoint_dir",
+        type=Path,
+        required=True,
+        help="Directory containing the trained Hypersphere GPT checkpoint",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=Path,
+        required=True,
+        help="Directory to write the Hugging Face compatible artifacts",
+    )
+    parser.add_argument(
+        "--tokenizer_name",
+        type=str,
+        default="gpt2",
+        help="Hugging Face tokenizer identifier to bundle with the export",
+    )
+    parser.add_argument(
+        "--use_safetensors",
+        action="store_true",
+        help="Export weights using the safetensors format",
+    )
+    parser.add_argument(
+        "--push_to_hub",
+        action="store_true",
+        help="Push the exported model and tokenizer to the Hugging Face Hub",
+    )
+    parser.add_argument(
+        "--hub_model_id",
+        type=str,
+        default=None,
+        help="Hub repository name to push to (e.g. username/hypersphere-gpt)",
+    )
+    parser.add_argument(
+        "--hub_token",
+        type=str,
+        default=None,
+        help="Optional Hugging Face access token for pushing to the hub",
+    )
+    parser.add_argument(
+        "--private",
+        action="store_true",
+        help="Create the hub repository as private when pushing",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    model = HypersphereGPTForCausalLM.from_pretrained(args.checkpoint_dir)
+    tokenizer = GPT2TokenizerFast.from_pretrained(args.tokenizer_name)
+
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    model.save_pretrained(args.output_dir, safe_serialization=args.use_safetensors)
+    tokenizer.save_pretrained(args.output_dir)
+
+    generation_config = GenerationConfig(
+        max_length=model.config.block_size,
+        eos_token_id=tokenizer.eos_token_id,
+        pad_token_id=tokenizer.pad_token_id,
+        bos_token_id=tokenizer.bos_token_id,
+    )
+    generation_config.save_pretrained(args.output_dir)
+
+    if args.push_to_hub:
+        if not args.hub_model_id:
+            raise ValueError("--hub_model_id must be specified when --push_to_hub is set")
+        print(f"Pushing artifacts to the Hugging Face Hub repository {args.hub_model_id}")
+        model.push_to_hub(
+            args.hub_model_id,
+            safe_serialization=args.use_safetensors,
+            private=args.private,
+            token=args.hub_token,
+        )
+        tokenizer.push_to_hub(args.hub_model_id, token=args.hub_token)
+        generation_config.push_to_hub(args.hub_model_id, token=args.hub_token)
+
+    print(f"Export complete. Artifacts saved to {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/huggingface_model/hypersphere_gpt/infer_hypersphere_gpt.py
+++ b/huggingface_model/hypersphere_gpt/infer_hypersphere_gpt.py
@@ -1,0 +1,54 @@
+import argparse
+import sys
+from pathlib import Path
+
+import torch
+
+if __package__ is None or __package__ == "":  # pragma: no cover - runtime convenience
+    PACKAGE_ROOT = Path(__file__).resolve().parent
+    PROJECT_ROOT = PACKAGE_ROOT.parent
+    REPO_ROOT = PROJECT_ROOT.parent
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.append(str(PROJECT_ROOT))
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.append(str(REPO_ROOT))
+    from hypersphere_gpt.modeling_hypersphere_gpt import HypersphereGPTForCausalLM  # type: ignore
+    from hypersphere_gpt.tokenizer import TiktokenTokenizer  # type: ignore
+else:
+    from .modeling_hypersphere_gpt import HypersphereGPTForCausalLM
+    from .tokenizer import TiktokenTokenizer
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run inference with a trained Hypersphere GPT model")
+    parser.add_argument("--model_path", type=str, required=True, help="Path to the trained model directory")
+    parser.add_argument("--prompt", type=str, required=True, help="Prompt text")
+    parser.add_argument("--max_new_tokens", type=int, default=128, help="Number of tokens to generate")
+    parser.add_argument("--temperature", type=float, default=1.0, help="Sampling temperature")
+    parser.add_argument("--top_k", type=int, default=0, help="Top-k sampling")
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    tokenizer = TiktokenTokenizer()
+
+    model = HypersphereGPTForCausalLM.from_pretrained(args.model_path).to(device)
+    model.eval()
+
+    input_ids = torch.tensor([tokenizer.encode(args.prompt)], dtype=torch.long, device=device)
+    attention_mask = torch.ones_like(input_ids, device=device)
+
+    with torch.no_grad():
+        generated = model.generate(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            max_new_tokens=args.max_new_tokens,
+            temperature=args.temperature,
+            top_k=args.top_k,
+        )
+
+    output_text = tokenizer.decode(generated[0].tolist())
+    print(output_text)
+
+
+if __name__ == "__main__":
+    main()

--- a/huggingface_model/hypersphere_gpt/modeling_hypersphere_gpt.py
+++ b/huggingface_model/hypersphere_gpt/modeling_hypersphere_gpt.py
@@ -1,0 +1,419 @@
+import math
+from typing import List, Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+from torch.nn import functional as F
+from transformers import AutoConfig, AutoModelForCausalLM
+from transformers.modeling_outputs import (
+    BaseModelOutputWithPast,
+    CausalLMOutputWithCrossAttentions,
+)
+from transformers.modeling_utils import PreTrainedModel
+
+from .config import HypersphereGPTConfig
+
+try:
+    from variations.norm_variations import HyperSphereNorm, LayerNorm, RMSNorm, pRMSNorm
+    from variations.position_encoding_variations import RotaryEmbedding
+except ModuleNotFoundError:  # pragma: no cover - runtime convenience
+    import sys
+    from pathlib import Path
+
+    PROJECT_ROOT = Path(__file__).resolve().parents[2]
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.append(str(PROJECT_ROOT))
+
+    from variations.norm_variations import HyperSphereNorm, LayerNorm, RMSNorm, pRMSNorm  # type: ignore
+    from variations.position_encoding_variations import RotaryEmbedding  # type: ignore
+
+
+def _make_causal_mask(
+    input_shape: torch.Size,
+    dtype: torch.dtype,
+    device: torch.device,
+    past_key_values_length: int = 0,
+) -> torch.Tensor:
+    batch_size, target_length = input_shape
+    mask = torch.full((target_length, target_length), float("-inf"), dtype=dtype, device=device)
+    mask_cond = torch.arange(mask.size(-1), device=device)
+    mask = mask.masked_fill(mask_cond.unsqueeze(0) <= mask_cond.unsqueeze(-1), 0.0)
+    mask = mask.unsqueeze(0).unsqueeze(0)  # (1, 1, target_length, target_length)
+
+    if past_key_values_length > 0:
+        past_mask = torch.zeros((target_length, past_key_values_length), dtype=dtype, device=device)
+        mask = torch.cat([past_mask.unsqueeze(0).unsqueeze(0), mask], dim=-1)
+
+    return mask.expand(batch_size, -1, -1, -1)
+
+
+def _expand_mask(
+    mask: torch.Tensor,
+    dtype: torch.dtype,
+    target_length: Optional[int] = None,
+) -> torch.Tensor:
+    batch_size, source_length = mask.size()
+    target_length = target_length if target_length is not None else source_length
+
+    expanded_mask = mask[:, None, None, :].expand(batch_size, 1, target_length, source_length).to(dtype)
+    inverted_mask = (1.0 - expanded_mask) * torch.finfo(dtype).min
+    return inverted_mask
+
+
+class HypersphereGPTPreTrainedModel(PreTrainedModel):
+    config_class = HypersphereGPTConfig
+    base_model_prefix = "transformer"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["HypersphereBlock"]
+
+    def _init_weights(self, module: nn.Module) -> None:
+        if isinstance(module, nn.Linear):
+            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+        elif isinstance(module, nn.Embedding):
+            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+
+
+def _build_norm_layer(config: HypersphereGPTConfig) -> nn.Module:
+    norm_type = config.norm_type
+    if norm_type == "layernorm":
+        return LayerNorm(config)
+    if norm_type == "rmsnorm":
+        return RMSNorm(config)
+    if norm_type in {"hypersphere", "hypersphere_learned_radius"}:
+        return HyperSphereNorm(config)
+    if norm_type == "prmsnorm":
+        return pRMSNorm(config)
+    raise ValueError(f"Unsupported norm_type '{norm_type}'")
+
+
+class HypersphereSelfAttention(nn.Module):
+    def __init__(self, config: HypersphereGPTConfig) -> None:
+        super().__init__()
+        if config.n_embd % config.n_head != 0:
+            raise ValueError("n_embd must be divisible by n_head")
+
+        self.n_head = config.n_head
+        self.head_dim = config.n_embd // config.n_head
+        self.scale = 1.0 / math.sqrt(self.head_dim)
+        self.dropout = nn.Dropout(config.dropout)
+
+        self.q_proj = nn.Linear(config.n_embd, config.n_embd, bias=False)
+        self.k_proj = nn.Linear(config.n_embd, config.n_embd, bias=False)
+        self.v_proj = nn.Linear(config.n_embd, config.n_embd, bias=False)
+        self.out_proj = nn.Linear(config.n_embd, config.n_embd, bias=False)
+
+        self.use_qk_norm = config.use_qk_norm
+        self.use_qk_norm_scale = config.use_qk_norm_scale
+        if self.use_qk_norm_scale:
+            self.qk_norm_factor = nn.Parameter(torch.tensor(self.scale))
+        else:
+            self.register_parameter("qk_norm_factor", None)
+
+        self.use_rotary = config.use_rotary_embeddings
+        if self.use_rotary:
+            self.rotary_q = RotaryEmbedding(config=config, size=self.head_dim)
+            self.rotary_k = RotaryEmbedding(config=config, size=self.head_dim)
+        else:
+            self.rotary_q = None
+            self.rotary_k = None
+
+        self.register_buffer(
+            "bias",
+            torch.tril(torch.ones(config.block_size, config.block_size, dtype=torch.bool)),
+            persistent=False,
+        )
+
+    def _shape(self, tensor: torch.Tensor, seq_len: int, batch_size: int) -> torch.Tensor:
+        return tensor.view(batch_size, seq_len, self.n_head, self.head_dim).transpose(1, 2)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        layer_past: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        use_cache: bool = False,
+    ) -> Tuple[torch.Tensor, Optional[Tuple[torch.Tensor, torch.Tensor]]]:
+        batch_size, seq_length, _ = hidden_states.size()
+
+        query = self.q_proj(hidden_states)
+        key = self.k_proj(hidden_states)
+        value = self.v_proj(hidden_states)
+
+        query = self._shape(query, seq_length, batch_size)
+        key = self._shape(key, seq_length, batch_size)
+        value = self._shape(value, seq_length, batch_size)
+
+        if self.use_rotary:
+            query = self.rotary_q(query)
+            key = self.rotary_k(key)
+
+        if layer_past is not None:
+            past_key, past_value = layer_past
+            key = torch.cat([past_key, key], dim=-2)
+            value = torch.cat([past_value, value], dim=-2)
+        present = (key, value) if use_cache else None
+
+        if self.use_qk_norm:
+            query = query / (query.norm(dim=-1, keepdim=True) + 1e-6)
+            key = key / (key.norm(dim=-1, keepdim=True) + 1e-6)
+
+        attn_weights = torch.matmul(query, key.transpose(-2, -1))
+        if self.use_qk_norm_scale:
+            attn_weights = attn_weights * self.qk_norm_factor
+        else:
+            attn_weights = attn_weights * self.scale
+
+        causal_mask = self.bias[: seq_length, : key.size(-2)]
+        causal_mask = causal_mask.view(1, 1, seq_length, key.size(-2))
+        attn_weights = attn_weights.masked_fill(~causal_mask, float("-inf"))
+
+        if attention_mask is not None:
+            attn_weights = attn_weights + attention_mask
+
+        attn_probs = F.softmax(attn_weights, dim=-1)
+        attn_probs = self.dropout(attn_probs)
+
+        attn_output = torch.matmul(attn_probs, value)
+        attn_output = attn_output.transpose(1, 2).contiguous().view(batch_size, seq_length, -1)
+        attn_output = self.out_proj(attn_output)
+        attn_output = self.dropout(attn_output)
+
+        return attn_output, present
+
+
+class HypersphereMLP(nn.Module):
+    def __init__(self, config: HypersphereGPTConfig) -> None:
+        super().__init__()
+        self.fc_in = nn.Linear(config.n_embd, config.n_inner, bias=False)
+        self.act = nn.GELU()
+        self.fc_out = nn.Linear(config.n_inner, config.n_embd, bias=False)
+        self.dropout = nn.Dropout(config.dropout)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.fc_in(hidden_states)
+        hidden_states = self.act(hidden_states)
+        hidden_states = self.fc_out(hidden_states)
+        hidden_states = self.dropout(hidden_states)
+        return hidden_states
+
+
+class HypersphereBlock(nn.Module):
+    def __init__(self, config: HypersphereGPTConfig) -> None:
+        super().__init__()
+        self.pre_attn_norm = _build_norm_layer(config)
+        self.attn = HypersphereSelfAttention(config)
+        self.peri_attn_norm = (
+            _build_norm_layer(config) if config.use_peri_ln_attn else nn.Identity()
+        )
+
+        self.pre_mlp_norm = _build_norm_layer(config)
+        self.mlp = HypersphereMLP(config)
+        self.peri_mlp_norm = (
+            _build_norm_layer(config) if config.use_peri_ln_mlp else nn.Identity()
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        layer_past: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        use_cache: bool = False,
+    ) -> Tuple[torch.Tensor, Optional[Tuple[torch.Tensor, torch.Tensor]]]:
+        residual = hidden_states
+        normed_states = self.pre_attn_norm(hidden_states)
+        attn_output, present = self.attn(normed_states, attention_mask=attention_mask, layer_past=layer_past, use_cache=use_cache)
+        attn_output = self.peri_attn_norm(attn_output) if not isinstance(self.peri_attn_norm, nn.Identity) else attn_output
+        hidden_states = residual + attn_output
+
+        residual = hidden_states
+        normed_states = self.pre_mlp_norm(hidden_states)
+        mlp_output = self.mlp(normed_states)
+        mlp_output = self.peri_mlp_norm(mlp_output) if not isinstance(self.peri_mlp_norm, nn.Identity) else mlp_output
+        hidden_states = residual + mlp_output
+
+        return hidden_states, present
+
+
+class HypersphereGPTModel(HypersphereGPTPreTrainedModel):
+    def __init__(self, config: HypersphereGPTConfig) -> None:
+        super().__init__(config)
+        self.wte = nn.Embedding(config.vocab_size, config.n_embd)
+        self.drop = nn.Dropout(config.dropout)
+        self.h = nn.ModuleList([HypersphereBlock(config) for _ in range(config.n_layer)])
+        self.ln_f = _build_norm_layer(config)
+        self.gradient_checkpointing = False
+        self.post_init()
+
+    def forward(
+        self,
+        input_ids: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        past_key_values: Optional[List[Tuple[torch.Tensor, torch.Tensor]]] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+    ) -> Union[Tuple[torch.Tensor, ...], BaseModelOutputWithPast]:
+        if input_ids is not None and inputs_embeds is not None:
+            raise ValueError("You cannot provide both input_ids and inputs_embeds")
+        elif input_ids is None and inputs_embeds is None:
+            raise ValueError("You must provide input_ids or inputs_embeds")
+
+        if input_ids is not None:
+            input_shape = input_ids.size()
+            input_ids = input_ids.view(-1, input_shape[-1])
+        else:
+            input_shape = inputs_embeds.size()[:-1]
+
+        batch_size = input_shape[0]
+        device = input_ids.device if input_ids is not None else inputs_embeds.device
+        inputs_embeds = self.wte(input_ids) if inputs_embeds is None else inputs_embeds
+
+        hidden_states = self.drop(inputs_embeds)
+
+        use_cache = use_cache if use_cache is not None else self.config.use_cache
+        output_attentions = output_attentions if output_attentions is not None else False
+        output_hidden_states = output_hidden_states if output_hidden_states is not None else False
+        return_dict = return_dict if return_dict is not None else True
+
+        all_hidden_states = () if output_hidden_states else None
+        presents = () if use_cache else None
+
+        past_key_values = past_key_values or [None] * len(self.h)
+        past_key_values_length = past_key_values[0][0].size(-2) if past_key_values[0] is not None else 0
+
+        if attention_mask is not None:
+            attention_mask = attention_mask.to(device)
+            attn_mask = _expand_mask(attention_mask, hidden_states.dtype, target_length=hidden_states.size(1))
+            if past_key_values_length > 0:
+                zeros = torch.zeros(
+                    batch_size,
+                    1,
+                    hidden_states.size(1),
+                    past_key_values_length,
+                    dtype=hidden_states.dtype,
+                    device=device,
+                )
+                attn_mask = torch.cat([zeros, attn_mask], dim=-1)
+        else:
+            attn_mask = None
+
+        causal_mask = _make_causal_mask(input_shape, hidden_states.dtype, device, past_key_values_length)
+        attention_mask_combined = causal_mask if attn_mask is None else (causal_mask + attn_mask)
+
+        for block_idx, (block, layer_past) in enumerate(zip(self.h, past_key_values)):
+            if output_hidden_states:
+                all_hidden_states = all_hidden_states + (hidden_states,)
+
+            hidden_states, present = block(
+                hidden_states,
+                attention_mask=attention_mask_combined,
+                layer_past=layer_past,
+                use_cache=use_cache,
+            )
+
+            if use_cache:
+                presents = presents + (present,)
+
+        hidden_states = self.ln_f(hidden_states)
+
+        if output_hidden_states:
+            all_hidden_states = all_hidden_states + (hidden_states,)
+
+        if not return_dict:
+            outputs = (hidden_states, presents, all_hidden_states)
+            return tuple(v for v in outputs if v is not None)
+
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            past_key_values=presents,
+            hidden_states=all_hidden_states,
+        )
+
+
+class HypersphereGPTForCausalLM(HypersphereGPTPreTrainedModel):
+    def __init__(self, config: HypersphereGPTConfig) -> None:
+        super().__init__(config)
+        self.transformer = HypersphereGPTModel(config)
+        self.lm_head = nn.Linear(config.n_embd, config.vocab_size, bias=False)
+
+        self.post_init()
+
+        # Weight tying
+        self.lm_head.weight = self.transformer.wte.weight
+
+    def get_input_embeddings(self) -> nn.Embedding:
+        return self.transformer.wte
+
+    def set_input_embeddings(self, value: nn.Embedding) -> None:
+        self.transformer.wte = value
+        self.lm_head.weight = value.weight
+
+    def forward(
+        self,
+        input_ids: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        labels: Optional[torch.Tensor] = None,
+        past_key_values: Optional[List[Tuple[torch.Tensor, torch.Tensor]]] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+    ) -> Union[Tuple[torch.Tensor, ...], CausalLMOutputWithCrossAttentions]:
+        transformer_outputs = self.transformer(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            inputs_embeds=inputs_embeds,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+
+        hidden_states = transformer_outputs[0]
+        logits = self.lm_head(hidden_states)
+
+        loss = None
+        if labels is not None:
+            shift_logits = logits[..., :-1, :].contiguous()
+            shift_labels = labels[..., 1:].contiguous()
+            loss_fct = nn.CrossEntropyLoss()
+            loss = loss_fct(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
+
+        if not return_dict:
+            output = (logits,) + transformer_outputs[1:]
+            return ((loss,) + output) if loss is not None else output
+
+        return CausalLMOutputWithCrossAttentions(
+            loss=loss,
+            logits=logits,
+            past_key_values=transformer_outputs.past_key_values,
+            hidden_states=transformer_outputs.hidden_states,
+            attentions=None,
+            cross_attentions=None,
+        )
+
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        past_key_values=None,
+        attention_mask=None,
+        **kwargs,
+    ):
+        if past_key_values:
+            input_ids = input_ids[:, -1:]
+            if attention_mask is not None:
+                attention_mask = attention_mask[:, -1:]
+        return {
+            "input_ids": input_ids,
+            "past_key_values": past_key_values,
+            "attention_mask": attention_mask,
+            "use_cache": kwargs.get("use_cache", True),
+        }
+
+
+AutoConfig.register("hypersphere-gpt", HypersphereGPTConfig)
+AutoModelForCausalLM.register(HypersphereGPTConfig, HypersphereGPTForCausalLM)

--- a/huggingface_model/hypersphere_gpt/run_hypersphere_gpt_benchmarks.py
+++ b/huggingface_model/hypersphere_gpt/run_hypersphere_gpt_benchmarks.py
@@ -1,0 +1,143 @@
+"""Run the Hypersphere GPT model on standard Hugging Face evaluation benchmarks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+try:
+    import lm_eval
+except ImportError as exc:  # pragma: no cover - optional dependency for runtime
+    raise RuntimeError(
+        "lm-evaluation-harness must be installed to run the benchmark script"
+    ) from exc
+
+
+DEFAULT_TASKS = [
+    "hellaswag",
+    "arc_easy",
+    "arc_challenge",
+    "winogrande",
+    "lambada_openai",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--model_path",
+        type=str,
+        required=True,
+        help="Path or Hugging Face identifier of the exported Hypersphere GPT model",
+    )
+    parser.add_argument(
+        "--tokenizer_name",
+        type=str,
+        default="gpt2",
+        help="Tokenizer identifier used for evaluation (default: gpt2)",
+    )
+    parser.add_argument(
+        "--tasks",
+        type=str,
+        default=",".join(DEFAULT_TASKS),
+        help="Comma separated list of lm-eval tasks to run",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=4,
+        help="Batch size for evaluation",
+    )
+    parser.add_argument(
+        "--fewshot",
+        type=int,
+        default=0,
+        help="Number of few-shot examples to use for each task",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Optional limit on the number of evaluation samples per task",
+    )
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default="bfloat16",
+        help="Computation dtype to use in evaluation (e.g. float32, bfloat16)",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cuda",
+        help="Device specification passed to lm-eval (e.g. cuda, cpu)",
+    )
+    parser.add_argument(
+        "--output_path",
+        type=Path,
+        default=None,
+        help="Optional path to write the aggregated benchmark JSON results",
+    )
+    parser.add_argument(
+        "--trust_remote_code",
+        action="store_true",
+        help="Allow loading custom code when using remote checkpoints",
+    )
+    return parser.parse_args()
+
+
+def build_model_args(model_path: str, device: str, dtype: str, trust_remote_code: bool) -> str:
+    args: List[str] = [f"pretrained={model_path}"]
+    if device:
+        args.append(f"device={device}")
+    if dtype:
+        args.append(f"dtype={dtype}")
+    if trust_remote_code:
+        args.append("trust_remote_code=True")
+    return ",".join(args)
+
+
+def main() -> None:
+    args = parse_args()
+
+    tasks = [task.strip() for task in args.tasks.split(",") if task.strip()]
+    if not tasks:
+        raise ValueError("At least one benchmark task must be provided")
+
+    model_args = build_model_args(
+        args.model_path, args.device, args.dtype, args.trust_remote_code
+    )
+    tokenizer_args = f"pretrained={args.tokenizer_name}"
+
+    print(f"Running lm-eval tasks: {', '.join(tasks)}")
+    results = lm_eval.simple_evaluate(
+        model="hf-causal",
+        tokenizer="hf",
+        model_args=model_args,
+        tokenizer_args=tokenizer_args,
+        tasks=tasks,
+        batch_size=args.batch_size,
+        num_fewshot=args.fewshot,
+        limit=args.limit,
+    )
+
+    print(json.dumps(results["results"], indent=2))
+
+    output_path = args.output_path
+    if output_path is None:
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        output_path = Path(f"lm_eval_results_{timestamp}.json")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as f:
+        json.dump(results, f, indent=2)
+        f.write("\n")
+
+    print(f"Saved full benchmark results to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/huggingface_model/hypersphere_gpt/tokenizer.py
+++ b/huggingface_model/hypersphere_gpt/tokenizer.py
@@ -1,0 +1,34 @@
+"""Utilities for working with the tiktoken tokenizer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+try:
+    import tiktoken
+except ImportError as exc:  # pragma: no cover - optional dependency for runtime
+    raise RuntimeError(
+        "tiktoken must be installed to use the Hypersphere GPT tokenizer utilities"
+    ) from exc
+
+
+@dataclass
+class TiktokenTokenizer:
+    """Thin wrapper that mimics the Hugging Face tokenizer API."""
+
+    name: str = "gpt2"
+
+    def __post_init__(self) -> None:
+        self.encoding = tiktoken.get_encoding(self.name)
+        self.eos_token_id = self.encoding.eot_token
+        self.pad_token_id = self.eos_token_id
+        self.vocab_size = self.encoding.n_vocab
+
+    def encode(self, text: str) -> List[int]:
+        ids = self.encoding.encode(text, allowed_special={""})
+        ids.append(self.eos_token_id)
+        return ids
+
+    def decode(self, ids: List[int]) -> str:
+        return self.encoding.decode(ids)

--- a/huggingface_model/hypersphere_gpt/train_hypersphere_gpt.py
+++ b/huggingface_model/hypersphere_gpt/train_hypersphere_gpt.py
@@ -1,0 +1,170 @@
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List
+
+import torch
+from datasets import load_dataset
+from torch.utils.data import Dataset
+from transformers import Trainer, TrainingArguments
+
+if __package__ is None or __package__ == "":  # pragma: no cover - runtime convenience
+    PACKAGE_ROOT = Path(__file__).resolve().parent
+    PROJECT_ROOT = PACKAGE_ROOT.parent
+    REPO_ROOT = PROJECT_ROOT.parent
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.append(str(PROJECT_ROOT))
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.append(str(REPO_ROOT))
+    from hypersphere_gpt.config import HypersphereGPTConfig  # type: ignore
+    from hypersphere_gpt.modeling_hypersphere_gpt import HypersphereGPTForCausalLM  # type: ignore
+    from hypersphere_gpt.tokenizer import TiktokenTokenizer  # type: ignore
+else:
+    from .config import HypersphereGPTConfig
+    from .modeling_hypersphere_gpt import HypersphereGPTForCausalLM
+    from .tokenizer import TiktokenTokenizer
+
+
+@dataclass
+class ConstantLengthDataset(Dataset):
+    examples: List[List[int]]
+
+    def __len__(self) -> int:
+        return len(self.examples)
+
+    def __getitem__(self, idx: int) -> Dict[str, List[int]]:
+        ids = self.examples[idx]
+        return {"input_ids": ids, "labels": ids}
+
+
+def tokenize_example(tokenizer: TiktokenTokenizer, text: str) -> List[int]:
+    return tokenizer.encode(text)
+
+
+def build_dataset(tokenizer: TiktokenTokenizer, block_size: int, dataset_name: str, dataset_split: str) -> ConstantLengthDataset:
+    raw_dataset = load_dataset(dataset_name, split=dataset_split)
+    tokenized = raw_dataset.map(
+        lambda batch: {"input_ids": [tokenize_example(tokenizer, text) for text in batch["text"]]},
+        batched=True,
+        remove_columns=raw_dataset.column_names,
+        desc="Tokenizing",
+    )
+
+    flat_tokens: List[int] = []
+    for ids in tokenized["input_ids"]:
+        flat_tokens.extend(ids)
+
+    total_length = (len(flat_tokens) // block_size) * block_size
+    flat_tokens = flat_tokens[:total_length]
+
+    sequences = [flat_tokens[i : i + block_size] for i in range(0, total_length, block_size)]
+    if not sequences:
+        raise ValueError("No sequences were constructed. Increase dataset size or reduce block size.")
+
+    return ConstantLengthDataset(sequences)
+
+
+class SimpleDataCollator:
+    def __init__(self, block_size: int) -> None:
+        self.block_size = block_size
+
+    def __call__(self, features: List[Dict[str, List[int]]]) -> Dict[str, torch.Tensor]:
+        batch_input_ids = torch.tensor([f["input_ids"] for f in features], dtype=torch.long)
+        batch_labels = torch.tensor([f["labels"] for f in features], dtype=torch.long)
+        return {"input_ids": batch_input_ids, "labels": batch_labels}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train the Hypersphere GPT model on fineweb-edu")
+    parser.add_argument("--output_dir", type=str, default="./hypersphere-124m", help="Directory for checkpoints")
+    parser.add_argument("--dataset", type=str, default="HuggingFaceH4/fineweb-edu", help="Dataset identifier")
+    parser.add_argument("--dataset_split", type=str, default="train[:0.1%]", help="Dataset split for training")
+    parser.add_argument("--block_size", type=int, default=2048, help="Sequence length")
+    parser.add_argument("--per_device_train_batch_size", type=int, default=2, help="Batch size per device")
+    parser.add_argument("--num_train_epochs", type=int, default=1, help="Number of training epochs")
+    parser.add_argument("--learning_rate", type=float, default=3e-4, help="Learning rate")
+    parser.add_argument("--weight_decay", type=float, default=0.1, help="Weight decay")
+    parser.add_argument("--save_steps", type=int, default=200, help="Save checkpoint every n steps")
+    parser.add_argument("--logging_steps", type=int, default=50, help="Logging interval")
+    parser.add_argument("--gradient_accumulation_steps", type=int, default=1, help="Gradient accumulation steps")
+    parser.add_argument(
+        "--norm_type",
+        type=str,
+        default="hypersphere",
+        choices=[
+            "layernorm",
+            "rmsnorm",
+            "hypersphere",
+            "hypersphere_learned_radius",
+            "prmsnorm",
+        ],
+        help="Normalization strategy to use across the network",
+    )
+    parser.add_argument(
+        "--prmsnorm_pct",
+        type=float,
+        default=0.5,
+        help="Fraction of channels used for pRMSNorm (only used when norm_type=prmsnorm)",
+    )
+    parser.add_argument(
+        "--hsnorm_radius",
+        type=float,
+        default=None,
+        help="Optional fixed radius for HyperSphereNorm variants",
+    )
+    args = parser.parse_args()
+
+    tokenizer = TiktokenTokenizer()
+
+    config = HypersphereGPTConfig(
+        vocab_size=tokenizer.vocab_size,
+        block_size=args.block_size,
+        dropout=0.0,
+        use_qk_norm=True,
+        use_qk_norm_scale=True,
+        use_rotary_embeddings=True,
+        use_peri_ln_attn=True,
+        use_peri_ln_mlp=True,
+        norm_type=args.norm_type,
+        prmsnorm_pct=args.prmsnorm_pct,
+        hsnorm_radius=args.hsnorm_radius,
+    )
+
+    model = HypersphereGPTForCausalLM(config)
+
+    total_params = sum(p.numel() for p in model.parameters())
+    print(f"Model parameters: {total_params / 1e6:.2f}M")
+
+    dataset = build_dataset(tokenizer, args.block_size, args.dataset, args.dataset_split)
+    print(f"Prepared {len(dataset)} sequences of length {args.block_size}")
+    data_collator = SimpleDataCollator(args.block_size)
+
+    training_args = TrainingArguments(
+        output_dir=args.output_dir,
+        per_device_train_batch_size=args.per_device_train_batch_size,
+        num_train_epochs=args.num_train_epochs,
+        gradient_accumulation_steps=args.gradient_accumulation_steps,
+        learning_rate=args.learning_rate,
+        weight_decay=args.weight_decay,
+        save_steps=args.save_steps,
+        logging_steps=args.logging_steps,
+        save_total_limit=5,
+        report_to="none",
+        bf16=torch.cuda.is_available(),
+        remove_unused_columns=False,
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=dataset,
+        data_collator=data_collator,
+    )
+
+    trainer.train()
+    trainer.save_model(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add project root fallbacks for the training, inference, and export CLIs so they can import the variations package when run from the repo root
- guard the modeling module with a runtime sys.path adjustment if the variations package is not yet on sys.path

## Testing
- python3 huggingface_model/hypersphere_gpt/train_hypersphere_gpt.py --help *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68d90580f5ac8326b8a7a406d7096b3f