### PR TITLE
Add option to trim tensorboard run names to varying parameters

### DIFF
--- a/optimization_and_search/run_experiments.py
+++ b/optimization_and_search/run_experiments.py
@@ -63,6 +63,13 @@ def parse_args() -> argparse.Namespace:
         '--use_timestamp', action='store_true',
         help="Prepend timestamp to run names and out_dir."
     )
+    parser.add_argument(
+        '--trim_tensorboard_run_name', action='store_true',
+        help=(
+            "Limit the tensorboard run name to parameters that vary across "
+            "all generated configurations."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -198,7 +205,40 @@ def format_run_name(combo: dict, base: str, prefix: str) -> str:
     """
     parts = [str(v) for v in combo.values()
              if not (isinstance(v, str) and RUN_NAME_VAR in v)]
-    return f"{prefix}{base}-{'-'.join(parts)}"
+    joined = "-".join(parts)
+    return f"{prefix}{base}" if not joined else f"{prefix}{base}-{joined}"
+
+
+def _normalize_value(value):
+    """Normalize values for set/dict comparisons."""
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, list):
+        return tuple(_normalize_value(v) for v in value)
+    if isinstance(value, dict):
+        return tuple(sorted((k, _normalize_value(v)) for k, v in value.items()))
+    return repr(value)
+
+
+def determine_varying_keys(combos: list[dict]) -> set[str]:
+    """Return parameter keys whose values differ across combos."""
+    if not combos:
+        return set()
+
+    sentinel = object()
+    all_keys: set[str] = set()
+    for combo in combos:
+        all_keys.update(combo.keys())
+
+    varying: set[str] = set()
+    for key in all_keys:
+        seen = set()
+        for combo in combos:
+            seen.add(_normalize_value(combo.get(key, sentinel)))
+            if len(seen) > 1:
+                varying.add(key)
+                break
+    return varying
 
 
 def read_metrics(out_dir: str) -> dict:
@@ -267,7 +307,8 @@ def build_command(combo: dict) -> list[str]:
 def run_experiment(
     combo: dict,
     base: str,
-    args: argparse.Namespace
+    args: argparse.Namespace,
+    varying_keys: set[str] | None = None,
 ) -> None:
     """
     Execute one experiment combo: skip if done, run train.py, record metrics.
@@ -284,7 +325,16 @@ def run_experiment(
     combo['out_dir'] = os.path.join(args.output_dir, out_dir_name)
 
     # Prepare tensorboard run name
-    combo['tensorboard_run_name'] = run_name
+    if args.trim_tensorboard_run_name and varying_keys:
+        trimmed_combo = {k: combo[k] for k in combo if k in varying_keys}
+        if trimmed_combo:
+            combo['tensorboard_run_name'] = format_run_name(
+                trimmed_combo, base, args.prefix
+            )
+        else:
+            combo['tensorboard_run_name'] = f"{args.prefix}{base}"
+    else:
+        combo['tensorboard_run_name'] = run_name
 
     # Substitute special run-name token in string parameters
     combo = _substitute_run_name(combo, run_name)
@@ -321,7 +371,9 @@ def main():
     # Precompute all combinations to know total experiment count
     all_combos = []
     for cfg in configs:
-        all_combos.extend(list(generate_combinations(cfg)))
+        all_combos.extend([dict(combo) for combo in generate_combinations(cfg)])
+
+    varying_keys = determine_varying_keys(all_combos) if args.trim_tensorboard_run_name else set()
 
     total = len(all_combos)
     start_time = datetime.now()
@@ -352,7 +404,7 @@ def main():
             )
             print(f"[green]{message}[/]")
             append_progress(progress_log, message)
-        run_experiment(combo, base, args)
+        run_experiment(combo, base, args, varying_keys if varying_keys else None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add a command line flag to opt into trimming tensorboard run names to only varying parameters
- compute varying configuration keys and reuse them when formatting tensorboard run names
- avoid mutating generated configurations before logging and prevent empty run name suffixes

## Testing
- python -m compileall optimization_and_search/run_experiments.py

------
https://chatgpt.com/codex/tasks/task_e_68d957603a74832699c029d077e33002