### PR TITLE
Add RMSNormPreGain variant and norm sweep exploration

### DIFF
--- a/explorations/attn_peri_output_norms.yaml
+++ b/explorations/attn_peri_output_norms.yaml
@@ -1,0 +1,46 @@
+# attn_peri_output_norms.yaml
+---
+
+parameter_groups:
+  - norm_variant_attn: ["rmsnorm"]
+    norm_variant_attn_pre: ["rmsnorm", "rmsnorm_linear_post", "hyperspherenorm"]
+    norm_variant_attn_peri: ["rmsnorm_pre_gain", "rmsnorm_linear_pre", "hyperspherenorm"]
+    norm_variant_output: ["rmsnorm", "hyperspherenorm", "rmsnorm_pre_gain", "rmsnorm_linear_post"]
+    rmsnorm_linear_post_init: ["default", "identity"]
+    rmsnorm_linear_pre_init: ["default", "identity"]
+    rmsnorm_linear_post_divisor_mode: ["default", "constant", "learnable"]
+    rmsnorm_linear_pre_divisor_mode: ["default", "constant", "learnable"]
+    hsnorm_radius_mode: ["fixed", "learned_param"]
+
+# GPT-2 124M architecture
+n_layer: [12]
+n_head: [12]
+n_embd: [768]
+block_size: [1024]
+
+device: ["cuda"]
+dtype: ["bfloat16"]
+dataset: ["minipile"]
+batch_size: [16]
+learning_rate: ["6e-4"]
+min_lr: ["6e-5"]
+beta1: [0.9]
+beta2: [0.95]
+max_iters: [30000]
+lr_decay_iters: [30000]
+warmup_iters: [3000]
+decay_lr: [true]
+eval_interval: [5000]
+
+# normalization extras
+use_peri_ln: [true]
+use_qk_norm: [true]
+use_qk_norm_scale: [true]
+
+# positional embeddings
+use_rotary_embeddings: [true]
+use_abs_pos_embeddings: [false]
+
+# compilation and checkpointing
+compile: [true]
+only_save_checkpoint_at_end: [true]

--- a/explorations/hsnorm.json
+++ b/explorations/hsnorm.json
@@ -1,35 +1,83 @@
-
 [
     {
-      "parameter_groups": [
-          {
-          "norm_variant_attn" : ["rmsnorm"],
-          "norm_variant_output" : ["rmsnorm"],
-          "tensorboard_log_name": ["regular_rmsnorm"]
-          },
-          {
-          "norm_variant_attn" : ["hyperspherenorm"],
-          "norm_variant_output" : ["hyperspherenorm"],
-          "hsnorm_radius": ["5", "10", "15", "20", "25"],
-          "hsnorm_radius_learning": [true, false],
-          "tensorboard_log_name": ["set_radius"]
-          },
-          {
-          "norm_variant_attn" : ["hyperspherenorm"],
-          "norm_variant_output" : ["hyperspherenorm"],
-          "hsnorm_radius_learning": [true, false],
-          "tensorboard_log_name": ["root_embd_dim_radius"]
-          }
-      ],
-      "max_iters": ["3500"],
-      "n_layer": ["6"],
-      "n_kv_group": ["6"],
-      "n_head": ["6"],
-      "n_embd": ["384"],
-      "block_size":["256"],
-      "device": ["cuda"],
-      "dtype": ["float16", "bfloat16", "float32"],
-      "compile": [true]
+        "parameter_groups": [
+            {
+                "norm_variant_attn": [
+                    "rmsnorm"
+                ],
+                "norm_variant_output": [
+                    "rmsnorm"
+                ],
+                "tensorboard_log_name": [
+                    "regular_rmsnorm"
+                ]
+            },
+            {
+                "norm_variant_attn": [
+                    "hyperspherenorm"
+                ],
+                "norm_variant_output": [
+                    "hyperspherenorm"
+                ],
+                "hsnorm_radius": [
+                    "5",
+                    "10",
+                    "15",
+                    "20",
+                    "25"
+                ],
+                "tensorboard_log_name": [
+                    "set_radius"
+                ],
+                "hsnorm_radius_mode": [
+                    "fixed",
+                    "learned_param"
+                ]
+            },
+            {
+                "norm_variant_attn": [
+                    "hyperspherenorm"
+                ],
+                "norm_variant_output": [
+                    "hyperspherenorm"
+                ],
+                "tensorboard_log_name": [
+                    "root_embd_dim_radius"
+                ],
+                "hsnorm_radius_mode": [
+                    "dynamic",
+                    "learned_param"
+                ]
+            }
+        ],
+        "max_iters": [
+            "3500"
+        ],
+        "n_layer": [
+            "6"
+        ],
+        "n_kv_group": [
+            "6"
+        ],
+        "n_head": [
+            "6"
+        ],
+        "n_embd": [
+            "384"
+        ],
+        "block_size": [
+            "256"
+        ],
+        "device": [
+            "cuda"
+        ],
+        "dtype": [
+            "float16",
+            "bfloat16",
+            "float32"
+        ],
+        "compile": [
+            true
+        ]
     }
 ]
-

--- a/explorations/rmsnorm_linear_vs_hsnorm.yaml
+++ b/explorations/rmsnorm_linear_vs_hsnorm.yaml
@@ -1,0 +1,59 @@
+# rmsnorm_linear_vs_hsnorm.yaml
+---
+
+parameter_groups:
+  # rmsnorm_linear_post variants
+  - norm_variant_attn: ["rmsnorm_linear_post"]
+    norm_variant_output: ["rmsnorm_linear_post"]
+    rmsnorm_linear_post_init: ["default", "identity"]
+    rmsnorm_linear_post_divisor_mode: ["default", "constant", "learnable"]
+
+  # rmsnorm_linear_pre variants
+  - norm_variant_attn: ["rmsnorm_linear_pre"]
+    norm_variant_output: ["rmsnorm_linear_pre"]
+    rmsnorm_linear_pre_init: ["default", "identity"]
+    rmsnorm_linear_pre_divisor_mode: ["default", "constant", "learnable"]
+
+  # HyperSphereNorm variants
+  - norm_variant_attn: ["hyperspherenorm"]
+    norm_variant_output: ["hyperspherenorm"]
+    hsnorm_radius_mode: ["dynamic", "fixed", "learned_param"]
+  - norm_variant_attn: ["hyperspherenorm"]
+    norm_variant_output: ["hyperspherenorm"]
+    hsnorm_radius_mode: ["fixed", "learned_param"]
+    hsnorm_radius: [27.7128]
+
+# GPT-2 124M architecture
+n_layer: [12]
+n_head: [12]
+n_embd: [768]
+block_size: [1024]
+
+device: ["cuda"]
+dtype: ["bfloat16"]
+dataset: ["minipile"]
+batch_size: [16]
+learning_rate: ["6e-4"]
+min_lr: ["6e-5"]
+beta1: [0.9]
+beta2: [0.95]
+max_iters: [30000]
+lr_decay_iters: [30000]
+warmup_iters: [3000]
+decay_lr: [true]
+eval_interval: [5000]
+
+# normalization extras
+use_peri_ln: [true, false]
+use_qk_norm: [true]
+use_qk_norm_scale: [true]
+
+# positional embeddings
+use_rotary_embeddings: [true]
+use_abs_pos_embeddings: [false]
+
+# compilation and checkpointing
+compile: [true]
+only_save_checkpoint_at_end: [true]
+
+tensorboard_run_name: ["rmsnorm_linear_vs_hsnorm"]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -365,7 +365,14 @@ class GPTConfig:
 
     # Layernorm Alternatives and Options
     norm_variant_attn: str = "rmsnorm"
+    norm_variant_attn_pre: str | None = None
+    norm_variant_attn_peri: str | None = None
+    norm_variant_attn_post: str | None = None
     norm_variant_output: str = "rmsnorm"
+    rmsnorm_linear_post_init: str = "default"
+    rmsnorm_linear_pre_init: str = "default"
+    rmsnorm_linear_post_divisor_mode: str = "default"
+    rmsnorm_linear_pre_divisor_mode: str = "default"
     bias: bool = False # True: bias in Linears and LayerNorms, like GPT-2. False: a bit better and faster
     prmsnorm_pct: float = 0.0625
     krmsnorm_num: float = 10
@@ -373,9 +380,8 @@ class GPTConfig:
     krmsnorm_enable_gain: bool = True
     krmsnorm_selection_type: str = 'last'
     krmsnorm_recompute_percentage: float = 0.05
-    hsnorm_gain: bool = False
-    hsnorm_radius: float = 1.0
-    hsnorm_radius_learning: bool = False
+    hsnorm_radius: float | None = None
+    hsnorm_radius_mode: str = "fixed"
 
     dact_alpha_init: float = 1.0
     dact_activation: str = 'tanh'

--- a/train_args.py
+++ b/train_args.py
@@ -627,6 +627,9 @@ def parse_args():
             "krmsnorm",
             "prmsnorm",
             "rmsnorm",
+            "rmsnorm_pre_gain",
+            "rmsnorm_linear_post",
+            "rmsnorm_linear_pre",
             "layernorm",
             "hyperspherenorm",
             "dact",
@@ -634,7 +637,57 @@ def parse_args():
             ]
 
     model_group.add_argument("--norm_variant_attn", type=str, default="rmsnorm", choices=norm_variations)
+    model_group.add_argument(
+        "--norm_variant_attn_pre",
+        type=str,
+        default=None,
+        choices=norm_variations,
+        help="Override the normalization variant used for pre-layernorm stages when specified.",
+    )
+    model_group.add_argument(
+        "--norm_variant_attn_peri",
+        type=str,
+        default=None,
+        choices=norm_variations,
+        help="Override the normalization variant used for peri-layernorm stages when specified.",
+    )
+    model_group.add_argument(
+        "--norm_variant_attn_post",
+        type=str,
+        default=None,
+        choices=norm_variations,
+        help="Override the normalization variant used for post-layernorm stages when specified.",
+    )
     model_group.add_argument("--norm_variant_output", type=str, default="rmsnorm", choices=norm_variations)
+
+    model_group.add_argument(
+        "--rmsnorm_linear_post_init",
+        type=str,
+        default="default",
+        choices=["default", "identity"],
+        help="Initialization for the linear matrix used in rmsnorm_linear_post."
+    )
+    model_group.add_argument(
+        "--rmsnorm_linear_post_divisor_mode",
+        type=str,
+        default="default",
+        choices=["default", "constant", "learnable"],
+        help="Divisor mode for the normalization step in rmsnorm_linear_post."
+    )
+    model_group.add_argument(
+        "--rmsnorm_linear_pre_init",
+        type=str,
+        default="default",
+        choices=["default", "identity"],
+        help="Initialization for the linear matrix used in rmsnorm_linear_pre."
+    )
+    model_group.add_argument(
+        "--rmsnorm_linear_pre_divisor_mode",
+        type=str,
+        default="default",
+        choices=["default", "constant", "learnable"],
+        help="Divisor mode for the normalization step in rmsnorm_linear_pre."
+    )
 
     ## Layernorm
     model_group.add_argument('--bias', default=False, action=argparse.BooleanOptionalAction, help="only used for layernorm variation option")
@@ -650,9 +703,17 @@ def parse_args():
     model_group.add_argument("--krmsnorm_recompute_percentage", type=float, default=None, help="percentage needed within the total RMS to not trigger recompute")
 
     ## HyperSphereNorm
-    model_group.add_argument("--hsnorm_gain", default=False, action=argparse.BooleanOptionalAction)
     model_group.add_argument("--hsnorm_radius", type=float, default=None)
-    model_group.add_argument("--hsnorm_radius_learning", default=False, action=argparse.BooleanOptionalAction)
+    model_group.add_argument(
+        "--hsnorm_radius_mode",
+        type=str,
+        default="fixed",
+        choices=["dynamic", "fixed", "learned_param"],
+        help=(
+            "Select how HyperSphereNorm determines its target radius: dynamically via sqrt(feature dim), "
+            "a fixed constant, or a learned parameter."
+        ),
+    )
 
     activation_variations = [
             "celu",


### PR DESCRIPTION
## Summary
- add an RMSNormPreGain module that applies gain before RMS scaling and register it for selection
- expose the new variant through CLI choices and include it in the norm sweep exploration coverage
- create an attention/peri/output normalization sweep exercising combinations of norm variants and initialization settings

## Testing
- python -m compileall variations/norm_variations.py train_args.py

------
https://chatgpt.com/codex/tasks/task_e_68dec33419148326a11406c5ca30caed