### PR TITLE
Run scale-up before embedding normalization

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -366,6 +366,8 @@ class GPTConfig:
     # Layernorm Alternatives and Options
     norm_variant_attn: str = "rmsnorm"
     norm_variant_output: str = "rmsnorm"
+    norm_variant_wte: str | None = None
+    norm_variant_abs: str | None = None
     bias: bool = False # True: bias in Linears and LayerNorms, like GPT-2. False: a bit better and faster
     prmsnorm_pct: float = 0.0625
     krmsnorm_num: float = 10


### PR DESCRIPTION
## Summary
- instantiate the optional post-token embedding normalization without cloning config
- apply the factorized `scale_up` projection before optional post-embedding normalization in both embedding paths

## Testing
- python -m compileall model.py gpt_conf.py

------
https://chatgpt.com/codex/tasks/task_e_68e1ba84fdf483269b22cb73c87474f1