### PR TITLE
Add common_group support to experiment runner

### DIFF
--- a/explorations/sample.yaml
+++ b/explorations/sample.yaml
@@ -7,6 +7,11 @@ parameter_groups:
   - use_rotary_embeddings: [false]
     use_abs_pos_embeddings: [true]
 
+# common_group: parameters applied to every run but omitted from run names
+common_group:
+  learning_rate: [0.0003]
+  weight_decay: [0.1]
+
 # base hyperparameters
 max_iters: [250]
 n_layer: [6]


### PR DESCRIPTION
## Summary
- add support for a `common_group` block in exploration configs and exclude those parameters from generated run names by default
- update the experiment runner CLI to optionally include the common parameters in names and propagate the metadata through execution
- document the new configuration section in the sample exploration file

## Testing
- python -m compileall optimization_and_search/run_experiments.py train.py

------
https://chatgpt.com/codex/tasks/task_e_68e2b1d848408326afb3ba7afa90e054