### PR TITLE
Ensure print_model_stats_table creates output directories

### DIFF
--- a/train.py
+++ b/train.py
@@ -143,6 +143,11 @@ class Trainer:
         self.stats_device = torch.device("cuda") if stats_dev_flag == "gpu" else torch.device("cpu")
 
         self.stats_csv_path = getattr(self.args, "print_model_stats_table", None)
+        if self.stats_csv_path:
+            self.stats_csv_path = os.path.expanduser(self.stats_csv_path)
+            stats_dir = os.path.dirname(self.stats_csv_path)
+            if stats_dir and not os.path.exists(stats_dir):
+                os.makedirs(stats_dir, exist_ok=True)
 
         # calculation on end time via eval cycle
         self.eval_cycle_window = deque(maxlen=self.args.eval_cycle_window)


### PR DESCRIPTION
## Summary
- expand the configured model stats CSV path to allow home-directory shortcuts
- automatically create the parent directory for the model stats CSV if it does not exist

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2eb0f77788326b33cdef4f0b0b156