### PR TITLE
Add named parameter group support for experiment sweeps

### DIFF
--- a/explorations/sample.yaml
+++ b/explorations/sample.yaml
@@ -1,49 +1,79 @@
-# sample.yaml
+# sample.yaml demonstrating named parameter group configurations
 ---
+
+named_static_groups:
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+  - named_group: "rotary"
+    named_group_settings:
+      use_rotary_embeddings: [true]
+      use_abs_pos_embeddings: [false]
+  - named_group: "abs"
+    named_group_settings:
+      use_rotary_embeddings: [false]
+      use_abs_pos_embeddings: [true]
+  - named_group: "rmsnorm_all"
+    named_group_settings:
+      norm_variant_attn: ["rmsnorm"]
+      norm_variant_output: ["rmsnorm"]
+  - named_group: "rmsnorm_attn_hsnorm_out"
+    named_group_settings:
+      norm_variant_attn: ["rmsnorm"]
+      norm_variant_output: ["hyperspherenorm"]
+  - named_group: "speed_optimal"
+    named_group_settings:
+      compile: [true]
+      use_gradient_checkpointing: [false]
+  - named_group: "memory_optimal"
+    named_group_settings:
+      compile: [false]
+      use_gradient_checkpointing: [true]
+  - named_group: "shared_training_defaults"
+    named_group_settings:
+      dropout: [0.0]
+      gradient_accumulation_steps: [1]
+
+named_variation_groups:
+  - named_group: "layer_batch_variations"
+    named_group_settings:
+      block_size: [256]
+    parameter_groups:
+      - n_layer: [2, 3]
+        batch_size: [32]
+      - n_layer: [4]
+        batch_size: [64]
+  - named_group: "embedding_head_variations"
+    parameter_groups:
+      - n_embd: 256
+        n_head: 4
+      - n_embd: 320
+        n_head: 5
+  - named_group: "positional_embeddings"
+    named_group_alternates: ["rotary", "abs"]
+  - named_group: "memory_vs_speed"
+    named_group_alternates: ["speed_optimal", "memory_optimal"]
+
 # parameter_groups: define sets of overrides to apply on top of base params
 parameter_groups:
-  - use_rotary_embeddings: [true]
-    use_abs_pos_embeddings: [true]
-  - use_rotary_embeddings: [false]
-    use_abs_pos_embeddings: [true]
+  - use_post_ln: [true, false]
+    named_group_static: ["qk_norm", "shared_training_defaults"]
+    named_group_variations:
+      - "layer_batch_variations"
+      - "embedding_head_variations"
+      - "positional_embeddings"
+      - "memory_vs_speed"
+    named_group_alternates: ["rmsnorm_all", "rmsnorm_attn_hsnorm_out"]
 
 # common_group: parameters applied to every run but omitted from run names
 common_group:
+  dataset: ["shakespeare_char"]
+  max_iters: [750]
   learning_rate: [0.0003]
   weight_decay: [0.1]
 
 # base hyperparameters
-max_iters: [250]
-n_layer: [6]
-n_head: [6]
-n_embd: [384]
-block_size: [256]
-device: ["cuda"]
-dtype: ["bfloat16"]
-dataset: ["shakespeare_char"]
-
-# ranged sweep
-seed:
-  range:
-    start: 100
-    end: 102
-    step: 1
-
-# conditional options
-consmax_initial_beta:
-  conditions:
-    - ["softmax_variant_attn", "consmax"]
-  options: ["2.5", "5.0", "10.0"]
-
-softmax_variant_attn:
-  - softmax
-  - polymax
-  - consmax
-
-# boolean flags
-compile: [true]
-use_post_ln: [true, false]
-
-# tensorboard run name
-tensorboard_run_name: ["full_feature_demo"]
+device: ["cpu"]
+dtype: ["float32"]
+tensorboard_run_name: ["named_group_demo"]
 

--- a/optimization_and_search/run_experiments.py
+++ b/optimization_and_search/run_experiments.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from itertools import product
 import argparse
 import os
+from copy import deepcopy
 
 import yaml
 from rich import print
@@ -71,6 +72,14 @@ def parse_args() -> argparse.Namespace:
             "common parameters are omitted to keep names short."
         ),
     )
+    parser.add_argument(
+        '--expand_named_groups_in_names', action='store_true',
+        help=(
+            "Include explicit parameter values contributed by named groups in run "
+            "names. By default named groups are abbreviated using their group names "
+            "to keep run identifiers shorter."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -124,6 +133,240 @@ def _substitute_run_name(obj, run_name: str):
     return obj
 
 
+def _ensure_list(value):
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _merge_parameter_groups(existing, new):
+    existing_list = []
+    if existing is not None:
+        existing_list = existing if isinstance(existing, list) else [existing]
+    new_list = []
+    if new is not None:
+        new_list = new if isinstance(new, list) else [new]
+
+    if not existing_list:
+        return [deepcopy(g) for g in new_list]
+    if not new_list:
+        return [deepcopy(g) for g in existing_list]
+
+    combined = []
+    for existing_group in existing_list:
+        group_copy = deepcopy(existing_group)
+        nested_existing = group_copy.get('parameter_groups')
+        group_copy['parameter_groups'] = _merge_parameter_groups(nested_existing, new_list)
+        combined.append(group_copy)
+    return combined
+
+
+def _merge_named_metadata(dest: dict, src: dict) -> None:
+    if '_named_group_fragments' in src:
+        dest.setdefault('_named_group_fragments', [])
+        dest['_named_group_fragments'].extend(src['_named_group_fragments'])
+    if '_named_group_param_keys' in src:
+        dest.setdefault('_named_group_param_keys', {})
+        for key, group in src['_named_group_param_keys'].items():
+            dest['_named_group_param_keys'].setdefault(key, group)
+
+
+def _merge_config_dicts(base: dict, addition: dict) -> dict:
+    result = {k: deepcopy(v) for k, v in base.items()}
+    for key, value in addition.items():
+        if key == '_named_group_fragments' or key == '_named_group_param_keys':
+            result.setdefault(key, []) if key == '_named_group_fragments' else result.setdefault(key, {})
+            _merge_named_metadata(result, {key: deepcopy(value)})
+            continue
+        if key == 'parameter_groups':
+            merged = _merge_parameter_groups(result.get(key), value)
+            if merged == []:
+                result.pop(key, None)
+            else:
+                result[key] = merged
+            continue
+        if key in result and result[key] != value:
+            raise ValueError(
+                f"Conflicting values for parameter '{key}' when merging named groups: "
+                f"{result[key]!r} vs {value!r}"
+            )
+        result[key] = deepcopy(value)
+    return result
+
+
+def _collect_param_keys(cfg: dict) -> set[str]:
+    keys: set[str] = set()
+    for key in cfg:
+        if key in {'parameter_groups', '_named_group_fragments', '_named_group_param_keys'}:
+            continue
+        if key.startswith('_'):
+            continue
+        keys.add(key)
+    return keys
+
+
+class NamedGroupRegistry:
+    def __init__(self, static_groups: dict[str, dict], variation_groups: dict[str, dict]):
+        self.static_groups = static_groups
+        self.variation_groups = variation_groups
+
+    @classmethod
+    def from_config(cls, cfg: dict) -> tuple['NamedGroupRegistry', dict]:
+        cfg = dict(cfg)
+        raw_static = cfg.pop('named_static_groups', [])
+        raw_variation = cfg.pop('named_variation_groups', [])
+
+        static_groups: dict[str, dict] = {}
+        for entry in _ensure_list(raw_static):
+            if not isinstance(entry, dict):
+                raise TypeError("Entries in 'named_static_groups' must be mappings")
+            name = entry.get('named_group')
+            if not name:
+                raise ValueError("Each named static group must include 'named_group'")
+            if name in static_groups:
+                raise ValueError(f"Duplicate named static group '{name}'")
+            body = {k: deepcopy(v) for k, v in entry.items() if k != 'named_group'}
+            static_groups[name] = body
+
+        variation_groups: dict[str, dict] = {}
+        for entry in _ensure_list(raw_variation):
+            if not isinstance(entry, dict):
+                raise TypeError("Entries in 'named_variation_groups' must be mappings")
+            name = entry.get('named_group')
+            if not name:
+                raise ValueError("Each named variation group must include 'named_group'")
+            if name in variation_groups:
+                raise ValueError(f"Duplicate named variation group '{name}'")
+            body = {k: deepcopy(v) for k, v in entry.items() if k != 'named_group'}
+            variation_groups[name] = body
+
+        return cls(static_groups, variation_groups), cfg
+
+    def resolve_static(self, name: str, visited_static: set[str] | None, visited_variation: set[str] | None):
+        if name not in self.static_groups:
+            raise KeyError(f"Unknown static named group '{name}'")
+        visited_static = set(visited_static or set())
+        if name in visited_static:
+            raise ValueError(f"Circular dependency detected in static named groups involving '{name}'")
+        visited_static.add(name)
+        body = deepcopy(self.static_groups[name])
+        resolved = expand_named_config(body, self, visited_static, visited_variation)
+        if len(resolved) != 1:
+            raise ValueError(
+                f"Static named group '{name}' expanded to {len(resolved)} configurations; expected exactly one"
+            )
+        for cfg in resolved:
+            fragments = cfg.get('_named_group_fragments', [])
+            fragments.append(name)
+            cfg['_named_group_fragments'] = fragments
+            keys = _collect_param_keys(cfg)
+            key_map = cfg.get('_named_group_param_keys', {})
+            for key in keys:
+                key_map.setdefault(key, name)
+            cfg['_named_group_param_keys'] = key_map
+        return resolved
+
+    def resolve_variation(self, name: str, visited_static: set[str] | None, visited_variation: set[str] | None):
+        if name not in self.variation_groups:
+            raise KeyError(f"Unknown variation named group '{name}'")
+        visited_variation = set(visited_variation or set())
+        if name in visited_variation:
+            raise ValueError(
+                f"Circular dependency detected in variation named groups involving '{name}'"
+            )
+        visited_variation.add(name)
+        body = deepcopy(self.variation_groups[name])
+        return expand_named_config(body, self, visited_static, visited_variation)
+
+    def resolve(self, name: str, visited_static: set[str] | None, visited_variation: set[str] | None):
+        if name in self.static_groups:
+            return self.resolve_static(name, visited_static, visited_variation)
+        if name in self.variation_groups:
+            return self.resolve_variation(name, visited_static, visited_variation)
+        raise KeyError(f"Unknown named group '{name}'")
+
+
+def expand_named_config(
+    cfg: dict,
+    registry: NamedGroupRegistry,
+    visited_static: set[str] | None = None,
+    visited_variation: set[str] | None = None,
+):
+    base = {k: deepcopy(v) for k, v in cfg.items()}
+    fragments = base.pop('_named_group_fragments', [])
+    param_key_map = base.pop('_named_group_param_keys', {})
+
+    settings = base.pop('named_group_settings', None)
+    if settings is not None:
+        if not isinstance(settings, dict):
+            raise TypeError("'named_group_settings' must be a mapping")
+        base = _merge_config_dicts(base, settings)
+
+    alternate_names = _ensure_list(base.pop('named_group_alternates', []))
+    static_names = _ensure_list(base.pop('named_group_static', []))
+    variation_names = _ensure_list(base.pop('named_group_variations', []))
+
+    if alternate_names:
+        expanded = []
+        for name in alternate_names:
+            resolved_list = registry.resolve(name, visited_static, visited_variation)
+            if not resolved_list:
+                resolved_list = [{}]
+            for resolved in resolved_list:
+                merged = _merge_config_dicts(base, resolved)
+                if static_names:
+                    merged['named_group_static'] = list(static_names) + _ensure_list(merged.get('named_group_static', []))
+                if variation_names:
+                    merged['named_group_variations'] = list(variation_names) + _ensure_list(merged.get('named_group_variations', []))
+                _merge_named_metadata(merged, {'_named_group_fragments': fragments})
+                _merge_named_metadata(merged, {'_named_group_param_keys': param_key_map})
+                expanded.extend(expand_named_config(merged, registry, visited_static, visited_variation))
+        return expanded
+
+    cfg_list: list[tuple[dict, list[str], dict]] = [(base, fragments, param_key_map)]
+
+    for name in static_names:
+        resolved_list = registry.resolve_static(name, visited_static, visited_variation)
+        new_list: list[tuple[dict, list[str], dict]] = []
+        for current_cfg, current_frags, current_map in cfg_list:
+            for resolved in resolved_list:
+                merged = _merge_config_dicts(current_cfg, resolved)
+                fragments_copy = list(current_frags)
+                fragments_copy.extend(resolved.get('_named_group_fragments', []))
+                param_map = dict(current_map)
+                for key, group_name in resolved.get('_named_group_param_keys', {}).items():
+                    param_map.setdefault(key, group_name)
+                new_list.append((merged, fragments_copy, param_map))
+        cfg_list = new_list
+
+    for name in variation_names:
+        resolved_list = registry.resolve_variation(name, visited_static, visited_variation)
+        if not resolved_list:
+            resolved_list = [{}]
+        new_list = []
+        for current_cfg, current_frags, current_map in cfg_list:
+            for resolved in resolved_list:
+                merged = _merge_config_dicts(current_cfg, resolved)
+                fragments_copy = list(current_frags)
+                fragments_copy.extend(resolved.get('_named_group_fragments', []))
+                param_map = dict(current_map)
+                for key, group_name in resolved.get('_named_group_param_keys', {}).items():
+                    param_map.setdefault(key, group_name)
+                new_list.append((merged, fragments_copy, param_map))
+        cfg_list = new_list
+
+    final = []
+    for current_cfg, current_frags, current_map in cfg_list:
+        if current_frags:
+            current_cfg['_named_group_fragments'] = current_frags
+        if current_map:
+            current_cfg['_named_group_param_keys'] = current_map
+        final.append(current_cfg)
+    return final
+
+
 def _extract_common_group(cfg: dict) -> tuple[dict, set[str]]:
     """Extract shared parameters defined under ``common_group``.
 
@@ -165,7 +408,8 @@ def generate_combinations(config: dict):
     ``common_group`` block.
     """
 
-    cfg = dict(config)
+    registry, cfg = NamedGroupRegistry.from_config(config)
+    cfg = dict(cfg)
     common_values, common_keys = _extract_common_group(cfg)
 
     def _expand_base_and_conditionals(cfg: dict):
@@ -217,23 +461,36 @@ def generate_combinations(config: dict):
         return valid
 
     def recurse(cfg: dict):
-        groups = cfg.get('parameter_groups')
-        if groups:
-            # Coerce to list to handle both single dict and list-of-dicts
-            groups_list = groups if isinstance(groups, list) else [groups]
-            base_cfg = {k: v for k, v in cfg.items() if k != 'parameter_groups'}
-            for grp in groups_list:
-                merged = {**base_cfg, **grp}
-                yield from recurse(merged)
-            return
+        expanded_cfgs = expand_named_config(cfg, registry)
+        for expanded in expanded_cfgs:
+            metadata = {
+                key: deepcopy(expanded[key])
+                for key in ('_named_group_fragments', '_named_group_param_keys')
+                if key in expanded
+            }
+            expanded_clean = {
+                k: v for k, v in expanded.items() if k not in metadata
+            }
 
-        base, conditionals = _expand_base_and_conditionals(cfg)
-        keys = list(base)
-        # itertools.product with zero iterables yields one empty tuple, which is what we want
-        for combo in product(*(base[k] for k in keys)):
-            combo_dict = dict(zip(keys, combo))
-            for final in _apply_conditionals(combo_dict, conditionals):
-                yield final
+            groups = expanded_clean.get('parameter_groups')
+            if groups:
+                groups_list = groups if isinstance(groups, list) else [groups]
+                base_cfg = {k: v for k, v in expanded_clean.items() if k != 'parameter_groups'}
+                for key, value in metadata.items():
+                    base_cfg[key] = deepcopy(value)
+                for grp in groups_list:
+                    merged = _merge_config_dicts(base_cfg, grp)
+                    yield from recurse(merged)
+                continue
+
+            base, conditionals = _expand_base_and_conditionals(expanded_clean)
+            keys = list(base)
+            for combo in product(*(base[k] for k in keys)):
+                combo_dict = dict(zip(keys, combo))
+                for key, value in metadata.items():
+                    combo_dict[key] = deepcopy(value)
+                for final in _apply_conditionals(combo_dict, conditionals):
+                    yield final
 
     for combo in recurse(cfg):
         merged = dict(common_values)
@@ -251,16 +508,28 @@ def format_run_name(
     base: str,
     prefix: str,
     exclude_keys: set[str] | None = None,
+    named_fragments: list[str] | None = None,
+    named_param_keys: dict[str, str] | None = None,
+    expand_named_group_values: bool = False,
 ) -> str:
     """Create a unique run name from parameter values."""
 
-    exclude_keys = exclude_keys or set()
-    parts = [
-        str(v)
-        for k, v in combo.items()
-        if k not in exclude_keys
-        and not (isinstance(v, str) and RUN_NAME_VAR in v)
-    ]
+    exclude_keys = set(exclude_keys or set())
+    if not expand_named_group_values and named_param_keys:
+        exclude_keys.update(named_param_keys.keys())
+
+    parts: list[str] = []
+    if not expand_named_group_values and named_fragments:
+        parts.extend(list(dict.fromkeys(named_fragments)))
+
+    for k, v in combo.items():
+        if k in exclude_keys:
+            continue
+        if k.startswith('_'):
+            continue
+        if isinstance(v, str) and RUN_NAME_VAR in v:
+            continue
+        parts.append(str(v))
 
     base_name = f"{prefix}{base}"
     return f"{base_name}-{'-'.join(parts)}" if parts else base_name
@@ -319,6 +588,8 @@ def build_command(combo: dict) -> list[str]:
     """
     cmd = ['python3', 'train.py']
     for k, v in combo.items():
+        if k.startswith('_'):
+            continue
         if isinstance(v, bool):
             cmd.append(f"--{'' if v else 'no-'}{k}")
         elif isinstance(v, list):
@@ -338,8 +609,18 @@ def run_experiment(
     """
     Execute one experiment combo: skip if done, run train.py, record metrics.
     """
+    named_fragments = combo.pop('_named_group_fragments', [])
+    named_param_keys = combo.pop('_named_group_param_keys', {})
     exclude = set() if args.include_common_group_in_name else common_keys
-    run_name = format_run_name(combo, base, args.prefix, exclude)
+    run_name = format_run_name(
+        combo,
+        base,
+        args.prefix,
+        exclude,
+        named_fragments=named_fragments,
+        named_param_keys=named_param_keys,
+        expand_named_group_values=args.expand_named_groups_in_names,
+    )
     log_file = LOG_DIR / f"{base}.yaml"
     if run_name in completed_runs(log_file):
         print(f"[yellow]Skipping already-run:[/] {run_name}")
@@ -360,6 +641,8 @@ def run_experiment(
     console = Console()
     table = Table("Parameters", show_header=False)
     for k, v in combo.items():
+        if k.startswith('_'):
+            continue
         table.add_row(k, str(v))
     console.print(table)
 


### PR DESCRIPTION
## Summary
- add reusable named static and variation group handling to the experiment runner with metadata-driven run naming
- add a flag to toggle named-group abbreviation in run identifiers and skip helper metadata in CLI invocations
- refresh `explorations/sample.yaml` to exercise named group settings and alternates on the shakespeare_char dataset

## Testing
- python -m compileall optimization_and_search/run_experiments.py
- python - <<'PY'
from optimization_and_search.run_experiments import load_configurations, generate_combinations, format_run_name

configs = load_configurations('explorations/sample.yaml', 'yaml')
print(f"Loaded {len(configs)} config document(s)")
for idx, cfg in enumerate(configs):
    combos = list(generate_combinations(cfg))
    print(f"Config {idx} combos: {len(combos)}")
    for i, (combo, common_keys) in enumerate(combos[:3]):
        named_fragments = combo.get('_named_group_fragments', [])
        named_param_keys = combo.get('_named_group_param_keys', {})
        combo_copy = {k: v for k, v in combo.items()}
        name_abbrev = format_run_name(
            combo_copy,
            base=f"sample_{idx}",
            prefix='',
            exclude_keys=common_keys,
            named_fragments=named_fragments,
            named_param_keys=named_param_keys,
            expand_named_group_values=False,
        )
        combo_copy = {k: v for k, v in combo.items()}
        name_full = format_run_name(
            combo_copy,
            base=f"sample_{idx}",
            prefix='',
            exclude_keys=common_keys,
            named_fragments=named_fragments,
            named_param_keys=named_param_keys,
            expand_named_group_values=True,
        )
        print(f"  Combo {i} abbrev: {name_abbrev}")
        print(f"  Combo {i} full  : {name_full}")
    print()
PY

------
https://chatgpt.com/codex/tasks/task_e_68e306ecb3a48326a0fc0bb92b50180e