### PR TITLE
Log tiktoken token totals during dataset preparation

### DIFF
--- a/data/template/prepare.py
+++ b/data/template/prepare.py
@@ -118,12 +118,16 @@ def main():
 
     # Tokenize data
     train_ids = tokenizer.tokenize(train_data)
+    if args.method == "tiktoken":
+        print(f"[tiktoken] Total train tokens: {tokenizer.last_token_count:,}")
     if args.method == "sinewave" and args.val_input is None:
         split_point = int(len(train_ids) * args.percentage_train)
         val_ids = train_ids[split_point:]
         train_ids = train_ids[:split_point]
     elif val_data is not None:
         val_ids = tokenizer.tokenize(val_data)
+        if args.method == "tiktoken":
+            print(f"[tiktoken] Total val tokens: {tokenizer.last_token_count:,}")
     else:
         val_ids = None
 

--- a/data/template/tokenizers.py
+++ b/data/template/tokenizers.py
@@ -121,6 +121,7 @@ class TiktokenTokenizer(Tokenizer):
     def __init__(self, args):
         super().__init__(args)
         self.tiktoken_encoding = args.tiktoken_encoding
+        self.last_token_count = 0
 
         # Load additional tokens if provided
         self.additional_tokens = {}
@@ -195,6 +196,8 @@ class TiktokenTokenizer(Tokenizer):
             "itos": {i: self.enc.decode([i]) for i in set(token_ids)}
         }
         self.finalize_meta(meta)
+
+        self.last_token_count = len(token_ids)
         return token_ids
 
     def detokenize(self, token_ids):


### PR DESCRIPTION
## Summary
- print the total number of tokens generated for train and validation splits when using the tiktoken tokenizer
- track the most recent token count inside `TiktokenTokenizer` so the preparation script can report totals

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4b906067c83268bfd888f99044959