### PR TITLE
Add optional ResiDual dual residual support

### DIFF
--- a/explorations/residual_dual_comparison.yaml
+++ b/explorations/residual_dual_comparison.yaml
@@ -1,0 +1,30 @@
+# residual_dual_comparison.yaml
+---
+# Shared configuration for both runs
+max_iters: [10000]
+eval_interval: [1000]
+dataset: ["minipile"]
+block_size: [512]
+n_layer: [12]
+n_head: [12]
+n_embd: [768]
+batch_size: ["64"]
+device: ["cuda"]
+dtype: ["bfloat16"]
+compile: [true]
+use_rotary_embeddings: [true]
+use_abs_pos_embeddings: [false]
+use_qk_norm: [true]
+use_qk_norm_scale: [true]
+
+# Compare default Pre-LN against ResiDual dual residual configuration
+parameter_groups:
+  - run_name: ["preln_baseline"]
+    use_pre_ln: [true]
+    use_post_ln: [false]
+    use_dual_residual: [false]
+  - run_name: ["residual_dual"]
+    use_pre_ln: [true]
+    use_post_ln: [true]
+    use_dual_residual: [true]
+    dual_residual_norm_variant: ["rmsnorm"]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -144,6 +144,10 @@ class GPTConfig:
     window_size: int = None
     use_flex_attn: bool = None
 
+    # Dual residual (ResiDual) options
+    use_dual_residual: bool = False
+    dual_residual_norm_variant: str | None = None
+
     gate: bool = False
     use_moe: bool = False
     moe_layer_freq: int = 2

--- a/train_args.py
+++ b/train_args.py
@@ -469,6 +469,10 @@ def parse_args():
     model_group.add_argument('--use_peri_ln_mlp', default=None, action=argparse.BooleanOptionalAction, help="override peri-LN for MLP block")
     model_group.add_argument('--use_post_ln_attn', default=None, action=argparse.BooleanOptionalAction, help="override post-LN for attention block")
     model_group.add_argument('--use_post_ln_mlp', default=None, action=argparse.BooleanOptionalAction, help="override post-LN for MLP block")
+    model_group.add_argument('--use_dual_residual', default=False, action=argparse.BooleanOptionalAction,
+                             help="Enable ResiDual-style dual residual stream that combines pre- and post-layer normalized activations")
+    model_group.add_argument('--dual_residual_norm_variant', type=str, default=None,
+                             help="Normalization variant for the dual residual stream (defaults to norm_variant_output when omitted)")
     model_group.add_argument('--window_size', default=None, type=int, help="Sliding window size, note this cannot be greater than block size")
     model_group.add_argument('--gate', default=False, action=argparse.BooleanOptionalAction, help="option for gated attention see https://arxiv.org/abs/2306.12929")
     model_group.add_argument('--use_moe', default=False,  action=argparse.BooleanOptionalAction, help="option for Mixture of Experts (MoE) architecture")


### PR DESCRIPTION
## Summary
- add configuration fields and CLI flags to toggle a ResiDual-style dual residual stream
- update GPT forward paths to maintain a secondary residual accumulator and fuse it after the final layer norm when enabled
- provide an exploration YAML that compares the default Pre-LN baseline against the new dual residual option

## Testing
- python -m py_compile model.py gpt_conf.py train_args.py

------
https://chatgpt.com/codex/tasks/task_e_68e5f22252b0832681fe1dd4c28a74af