### PR TITLE
Add SwiGLU two-gate pre-activation variant and minipile equal-params exploration

### DIFF
--- a/explorations/mlp_equal_params_vs_swiglu_minipile.yaml
+++ b/explorations/mlp_equal_params_vs_swiglu_minipile.yaml
@@ -1,0 +1,108 @@
+# Compare regular SwiGLU against equal-parameter MLP activation variants on minipile.
+# Parameter-matching rationale (ignoring biases):
+# - regular SwiGLU params per block: 3 * n_embd * mlp_size
+# - plain MLP params per block:     2 * n_embd * mlp_size
+# With n_embd=512 and regular SwiGLU mlp_size=2048, matching MLP mlp_size is 3072.
+---
+
+named_static_groups:
+  # QK Norm
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  # Norm Type
+  - named_group: "peri_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [true]
+    use_post_ln: [false]
+
+  # Position Embeddings
+  - named_group: "rotary"
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+  # Relu2Max + Infinite Attention + MQA (mirrors default_inf.yaml setup)
+  - named_group: "relu2max"
+    softmax_variant_attn: ["relu2max"]
+
+  - named_group: "infinite"
+    attention_variant: ["infinite"]
+    use_concat_heads: [true]
+
+  - named_group: "mqa"
+    n_kv_group: [1]
+
+  # Model size controls (held fixed for this exploration)
+  - named_group: "hd_150"
+    n_qk_head_dim: [150]
+    n_v_head_dim: [150]
+
+  - named_group: "n_head_6"
+    n_head: [6]
+
+  # Baselines
+  - named_group: "regular_swiglu"
+    mlp_variant: ["swiglu"]
+    activation_variant: ["silu"]
+    mlp_size: [2048]
+
+  - named_group: "regular_swiglu_2gate_pre_act"
+    mlp_variant: ["swiglu_2gate_pre_act"]
+    activation_variant: ["silu"]
+    # 4*n_embd*mlp_size ~= 3*n_embd*2048 -> mlp_size ~= 1536 for similar projection count.
+    mlp_size: [1536]
+
+  # Equal-parameter plain MLP variants
+  - named_group: "equal_param_mlp_squared_relu"
+    mlp_variant: ["mlp"]
+    activation_variant: ["squared_relu"]
+    mlp_size: [3072]
+
+  - named_group: "equal_param_mlp_gelu"
+    mlp_variant: ["mlp"]
+    activation_variant: ["gelu"]
+    mlp_size: [3072]
+
+  - named_group: "equal_param_mlp_mish"
+    mlp_variant: ["mlp"]
+    activation_variant: ["mish"]
+    mlp_size: [3072]
+
+  - named_group: "equal_param_mlp_silu"
+    mlp_variant: ["mlp"]
+    activation_variant: ["silu"]
+    mlp_size: [3072]
+
+  - named_group: "equal_param_mlp_identity"
+    mlp_variant: ["mlp"]
+    activation_variant: ["identity"]
+    mlp_size: [3072]
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [2500]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+  compile: [true]
+  log_rankme: [true]
+  log_areq: [true]
+
+parameter_groups:
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "relu2max"
+      - "infinite"
+      - "mqa"
+      - "hd_150"
+      - "n_head_6"
+    named_group_alternates:
+      - "regular_swiglu"
+      - "regular_swiglu_2gate_pre_act"
+      - "equal_param_mlp_squared_relu"
+      - "equal_param_mlp_gelu"
+      - "equal_param_mlp_mish"
+      - "equal_param_mlp_silu"
+      - "equal_param_mlp_identity"

--- a/train_args.py
+++ b/train_args.py
@@ -661,6 +661,7 @@ def parse_args():
             "edgellm_asic_mlp",
             "kan",
             "swiglu",
+            "swiglu_2gate_pre_act",
             "dual_path",
             "dual_path_swiglu",
             "identity",

--- a/variations/mlp_variations.py
+++ b/variations/mlp_variations.py
@@ -656,6 +656,154 @@ class Swiglu(nn.Module):
             x = fake_quantize_act(self, "mlp_act_output", x, num_bits, quant_method, iter_num)
         return x
 
+class SwiGLUTwoGatesPreAct(nn.Module):
+    """SwiGLU variant with two gates applied before the non-linearity."""
+    def __init__(self, config):
+        super().__init__()
+
+        self.full_quant_iteration = config.full_quant_iteration
+        self.eval_interval = config.eval_interval
+
+        self.start_quant_level = config.start_quant_level
+        self.quant_scheduler = config.quant_scheduler
+        self.mlp_down_projs = config.mlp_down_projs
+
+        self.activation_variant = activation_dictionary[config.activation_variant](config=config)
+
+        self.l2_norm_mlp_up = config.l2_norm_mlp_up
+        self.l2_norm_mlp_down = config.l2_norm_mlp_down
+        self.l2_norm_mlp_up_dim = config.l2_norm_mlp_up_dim
+        self.l2_norm_mlp_down_dim = config.l2_norm_mlp_down_dim
+
+        if config.learn_mlp_x_offset:
+            self.activation_x_offset = nn.Parameter(torch.tensor(config.mlp_x_offset))
+        else:
+            self.register_buffer("activation_x_offset", torch.tensor(config.mlp_x_offset))
+
+        if config.learn_mlp_y_offset:
+            self.activation_y_offset = nn.Parameter(torch.tensor(config.mlp_y_offset))
+        else:
+            self.register_buffer("activation_y_offset", torch.tensor(config.mlp_y_offset))
+
+        self.linear_variant_mlp_up = linear_dictionary[set_variant(config.linear_variant_mlp_up, config.linear_variant_mlp)]
+        self.linear_variant_mlp_down = linear_dictionary[set_variant(config.linear_variant_mlp_down, config.linear_variant_mlp)]
+
+        self.quantization_mlp_dict = {}
+        self.quantization_mlp_dict["activations_quant_method"] = config.activations_quant_method
+
+        for arg, val in vars(config).items():
+            if arg.startswith("quantize_") and "mlp_act" in arg and arg.endswith("_bits"):
+                self.quantization_mlp_dict[arg] = set_variant(val, config.quantize_mlp_act_bits)
+            elif arg.startswith("quantize_") and "mlp_act" in arg:
+                self.quantization_mlp_dict[arg] = set_variant(val, config.quantize_mlp_act)
+                if config.store_activations and arg != "quantize_mlp_act" and self.quantization_mlp_dict[arg]:
+                    create_activation_buffers(self, arg)
+            elif arg.startswith("quantize_") and "linear_mlp" in arg and arg.endswith("_bits"):
+                self.quantization_mlp_dict[arg] = set_variant(val, config.quantize_linear_bits)
+            elif arg.startswith("quantize_") and "linear_mlp" in arg and arg.endswith("_method"):
+                self.quantization_mlp_dict[arg] = set_variant(val, config.quantize_linear_method)
+
+        if config.mlp_size is not None:
+            mlp_expansion_size = config.mlp_size
+        else:
+            mlp_expansion_size = config.mlp_expansion_factor * config.n_embd
+
+        use_up_bias = config.mlp_up_bias if config.mlp_up_bias is not None else config.bias
+        use_down_bias = config.mlp_down_bias if config.mlp_down_bias is not None else config.bias
+
+        self.c_fc_main = self.linear_variant_mlp_up(
+            config.n_embd,
+            mlp_expansion_size,
+            config,
+            self.quantization_mlp_dict["quantize_linear_mlp_up_method"],
+            self.quantization_mlp_dict["quantize_linear_mlp_up_bits"],
+            bias=use_up_bias
+        )
+        self.c_fc_gate1 = self.linear_variant_mlp_up(
+            config.n_embd,
+            mlp_expansion_size,
+            config,
+            self.quantization_mlp_dict["quantize_linear_mlp_up_method"],
+            self.quantization_mlp_dict["quantize_linear_mlp_up_bits"],
+            bias=use_up_bias
+        )
+        self.c_fc_gate2 = self.linear_variant_mlp_up(
+            config.n_embd,
+            mlp_expansion_size,
+            config,
+            self.quantization_mlp_dict["quantize_linear_mlp_up_method"],
+            self.quantization_mlp_dict["quantize_linear_mlp_up_bits"],
+            bias=use_up_bias
+        )
+
+        self.c_fc_out = self.linear_variant_mlp_down(
+            mlp_expansion_size,
+            config.n_embd * self.mlp_down_projs,
+            config,
+            self.quantization_mlp_dict["quantize_linear_mlp_down_method"],
+            self.quantization_mlp_dict["quantize_linear_mlp_down_bits"],
+            bias=use_down_bias,
+        )
+
+        self.post_act_l2_norm = config.mlp_post_act_l2_norm
+        self.cproj_scale = config.mlp_cproj_scale
+        self.dropout = nn.Dropout(config.dropout)
+
+    def _up_project(self, x, layer):
+        if self.l2_norm_mlp_up:
+            up_dim = 1 if self.l2_norm_mlp_up_dim == 'embed' else 0
+            weight = F.normalize(layer.weight, p=2, dim=up_dim)
+            return F.linear(x, weight, layer.bias)
+        return layer(x)
+
+    def forward(self, x, iter_num=None):
+        if self.quantization_mlp_dict["quantize_mlp_act_input"]:
+            num_bits = self.quantization_mlp_dict["quantize_mlp_act_input_bits"]
+            quant_method = self.quantization_mlp_dict["activations_quant_method"]
+            x = fake_quantize_act(self, "mlp_act_input", x, num_bits, quant_method, iter_num)
+
+        x_main = self._up_project(x, self.c_fc_main)
+        if self.quantization_mlp_dict["quantize_mlp_act_activation_input"]:
+            num_bits = self.quantization_mlp_dict["quantize_mlp_act_activation_input_bits"]
+            quant_method = self.quantization_mlp_dict["activations_quant_method"]
+            x_main = fake_quantize_act(self, "mlp_act_activation_input", x_main, num_bits, quant_method, iter_num)
+
+        gate1 = self._up_project(x, self.c_fc_gate1)
+        gate2 = self._up_project(x, self.c_fc_gate2)
+
+        x_out = (x_main * gate1) * gate2
+        x_out = self.activation_variant(x_out - self.activation_x_offset) - self.activation_y_offset
+
+        if self.quantization_mlp_dict["quantize_mlp_act_activation_output"]:
+            num_bits = self.quantization_mlp_dict["quantize_mlp_act_activation_output_bits"]
+            quant_method = self.quantization_mlp_dict["activations_quant_method"]
+            x_out = fake_quantize_act(self, "mlp_act_activation_output", x_out, num_bits, quant_method, iter_num)
+
+        if self.post_act_l2_norm:
+            x_out = x_out / x_out.norm(dim=-1, keepdim=True).clamp_min(1e-6)
+        if self.cproj_scale is not None and self.cproj_scale != 1.0:
+            x_out = x_out / self.cproj_scale
+
+        if self.l2_norm_mlp_down:
+            down_dim = 0 if self.l2_norm_mlp_down_dim == 'embed' else 1
+            weight = F.normalize(self.c_fc_out.weight, p=2, dim=down_dim)
+            x = F.linear(x_out, weight, self.c_fc_out.bias)
+        else:
+            x = self.c_fc_out(x_out)
+
+        if self.mlp_down_projs > 1:
+            batch_size, seq_len, _ = x.shape
+            x = x.view(batch_size, seq_len, self.mlp_down_projs, -1)
+            x = x.sum(dim=2)
+
+        x = self.dropout(x)
+
+        if self.quantization_mlp_dict["quantize_mlp_act_output"]:
+            num_bits = self.quantization_mlp_dict["quantize_mlp_act_output_bits"]
+            quant_method = self.quantization_mlp_dict["activations_quant_method"]
+            x = fake_quantize_act(self, "mlp_act_output", x, num_bits, quant_method, iter_num)
+        return x
+
 class DualPathSwiglu(nn.Module):
     def __init__(self, config):
         super().__init__()
@@ -887,6 +1035,7 @@ mlp_dictionary = {
     "mlp": OriginalMLP,
     "edgellm_asic_mlp": EdgeLLMASICMLP,
     "swiglu": Swiglu,
+    "swiglu_2gate_pre_act": SwiGLUTwoGatesPreAct,
     "identity": MLP_Identity,
     "kan": KanMLP,
     "dual_path": DualPathMLP,
@@ -899,4 +1048,3 @@ def get_mlp_instance(config):
     if mlp_class is None:
         raise ValueError(f"Unsupported MLP variant: {mlp_type}")
     return mlp_class(config)
-


### PR DESCRIPTION
### Motivation
- Provide an MLP variant that applies two multiplicative gates before the activation to explore whether extra gating before non-linearity improves performance versus standard SwiGLU and plain MLPs. 
- Enable experiments comparing equal-parameter setups across activations on `minipile` using `default_inf.yaml`-style configuration choices.

### Description
- Added `SwiGLUTwoGatesPreAct` to `variations/mlp_variations.py`, which computes `x_main = W_main x`, `gate1 = W_g1 x`, `gate2 = W_g2 x`, then `x_out = activation((x_main * gate1) * gate2)` and follows existing down-projection, L2-normalization, scaling, dropout, and quantization hooks. 
- Registered the variant in the MLP factory (`mlp_dictionary`) and exposed it in CLI choices by adding `swiglu_2gate_pre_act` to `--mlp_variant` in `train_args.py`. 
- Added a new exploration YAML at `explorations/mlp_equal_params_vs_swiglu_minipile.yaml` that compares: regular SwiGLU, the new two-gate pre-act SwiGLU, and equal-parameter plain MLP variants using `squared_relu`, `gelu`, `mish`, `silu`, and `identity`, with manual `mlp_size` settings to approximate parameter matching. 

### Testing
- Ran `python -m py_compile variations/mlp_variations.py train_args.py` and it completed successfully. 
- Parsed the new YAML with `yaml.safe_load` in a small Python snippet and it loaded successfully (returned top-level keys).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f5dcce6c8326a899c6c1b56251bc)