### PR TITLE
feat(attention): add exclusive self-attention option and ablation yaml

### DIFF
--- a/explorations/exclusive_self_attention_ablation.yaml
+++ b/explorations/exclusive_self_attention_ablation.yaml
@@ -1,0 +1,71 @@
+# XSA ablation based on default_inf.yaml
+---
+
+named_static_groups:
+  # QK Norm
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  # Norm Type
+  - named_group: "peri_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [true]
+    use_post_ln: [false]
+
+  # Position Embeddings
+  - named_group: "rotary"
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+  # Infinite attention setup
+  - named_group: "infinite"
+    attention_variant: ["infinite"]
+    use_concat_heads: [true]
+
+  # Causal attention setup
+  - named_group: "causal"
+    attention_variant: ["causal"]
+
+  # MQA
+  - named_group: "mqa"
+    n_kv_group: [1]
+
+  # Head Dimension
+  - named_group: "hd_100"
+    n_qk_head_dim: [100]
+    n_v_head_dim: [100]
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [2500]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+  compile: [true]
+  log_rankme: [true]
+  log_areq: [true]
+
+parameter_groups:
+  # Infinite attention: default vs XSA under both softmax variants
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "infinite"
+      - "mqa"
+      - "hd_100"
+    n_head: [8]
+    softmax_variant_attn: ["softmax", "relu2max"]
+    use_exclusive_self_attention: [false, true]
+
+  # Causal attention: default vs XSA under both softmax variants
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "causal"
+      - "mqa"
+      - "hd_100"
+    n_head: [8]
+    softmax_variant_attn: ["softmax", "relu2max"]
+    use_exclusive_self_attention: [false, true]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -176,6 +176,7 @@ class GPTConfig:
 
     # Attention Options
     attention_variant: str = "causal"
+    use_exclusive_self_attention: bool = False
     attn_cproj_scale: float = 1.0
     attn_post_act_l2_norm: bool = False
 

--- a/train_args.py
+++ b/train_args.py
@@ -945,6 +945,8 @@ def parse_args():
     model_group.add_argument('--n_qk_head_dim', default=None, type=int)
     model_group.add_argument('--n_v_head_dim', default=None, type=int)
     model_group.add_argument('--n_cproj', default=None, type=int)
+    model_group.add_argument("--use_exclusive_self_attention", type=bool, default=False, action=argparse.BooleanOptionalAction,
+                             help="project attention output to be orthogonal to each token's self value vector (XSA)")
     model_group.add_argument('--attn_cproj_scale', default=1.0, type=float,
                              help="Scale attention outputs before c_proj (Infinite Attention)")
     model_group.add_argument('--attn_post_act_l2_norm', default=False, action=argparse.BooleanOptionalAction,

--- a/variations/attention_variations.py
+++ b/variations/attention_variations.py
@@ -39,6 +39,13 @@ def _compute_kv_group_distribution(n_head: int, n_kv_group: int):
         )
 
     return group_sizes, head_to_group
+
+
+def apply_exclusive_self_attention(y: torch.Tensor, v_self: torch.Tensor) -> torch.Tensor:
+    """Remove components of attention output along the token's self value direction."""
+    v_self_norm = v_self / v_self.norm(dim=-1, keepdim=True).clamp_min(1e-6)
+    return y - (y * v_self_norm).sum(dim=-1, keepdim=True) * v_self_norm
+
 # Mamba related imports
 # if torch.cuda.is_available():
 #     from causal_conv1d import causal_conv1d_fn, causal_conv1d_update
@@ -150,6 +157,7 @@ class CausalSelfAttention(nn.Module):
         self.use_qk_norm = config.use_qk_norm
         self.use_qk_norm_scale = config.use_qk_norm_scale
         self.use_v_norm = config.use_v_norm
+        self.use_exclusive_self_attention = config.use_exclusive_self_attention
 
         # Flash Lobo
         self.use_flash_lobo = config.use_flash_lobo
@@ -375,9 +383,15 @@ class CausalSelfAttention(nn.Module):
                 dropout_p=self.dropout if self.training else 0,
                 is_causal=True,
             )
+            if self.use_exclusive_self_attention:
+                y = apply_exclusive_self_attention(y, v_attn)
         elif self.use_flex_attn and self.window_size is not None:
             block_mask = self.get_block_mask(T, x.device)
-            y = torch.nn.attention.flex_attention.flex_attention(q, k, v, block_mask=block_mask)
+            k_attn = self._expand_kv(k)
+            v_attn = self._expand_kv(v)
+            y = torch.nn.attention.flex_attention.flex_attention(q, k_attn, v_attn, block_mask=block_mask)
+            if self.use_exclusive_self_attention:
+                y = apply_exclusive_self_attention(y, v_attn)
         else:
             if self.quantization_attn_dict["quantize_attn_act_qk_mult_q_input"]:
                 num_bits = self.quantization_attn_dict["quantize_attn_act_qk_mult_q_input_bits"]
@@ -442,6 +456,8 @@ class CausalSelfAttention(nn.Module):
 
             v_attn = self._expand_kv(v)
             y = att @ v_attn # (B, nh, T, T) x (B, nh, T, hs) -> (B, nh, T, hs)
+            if self.use_exclusive_self_attention:
+                y = apply_exclusive_self_attention(y, v_attn)
 
         if self.quantization_attn_dict["quantize_attn_act_pv_mult_output"]:
             num_bits = self.quantization_attn_dict["quantize_attn_act_pv_mult_output_bits"]
@@ -566,6 +582,7 @@ class EdgeLLMASICAttention(nn.Module):
         self.use_qk_norm = config.use_qk_norm
         self.use_qk_norm_scale = config.use_qk_norm_scale
         self.use_v_norm = config.use_v_norm
+        self.use_exclusive_self_attention = config.use_exclusive_self_attention
 
         # Using flex attention
         self.use_flex_attn = config.use_flex_attn
@@ -1029,6 +1046,7 @@ class InfiniteHeadAttention(nn.Module):
         self.use_qk_norm        = config.use_qk_norm
         self.use_qk_norm_scale  = config.use_qk_norm_scale
         self.use_v_norm         = config.use_v_norm
+        self.use_exclusive_self_attention = config.use_exclusive_self_attention
 
         # Flash Lobo
         self.use_flash_lobo          = config.use_flash_lobo
@@ -1241,6 +1259,8 @@ class InfiniteHeadAttention(nn.Module):
                 dropout_p=self.dropout if self.training else 0,
                 is_causal=True,
             )
+            if self.use_exclusive_self_attention:
+                y = apply_exclusive_self_attention(y, v_attn)
 
         else:
             # Manual implementation of attention
@@ -1270,6 +1290,8 @@ class InfiniteHeadAttention(nn.Module):
             att = self.attn_dropout(att)
 
             y = att @ v_attn # (B, nh, T, T) x (B, nh, T, hs) -> (B, nh, T, hs)
+            if self.use_exclusive_self_attention:
+                y = apply_exclusive_self_attention(y, v_attn)
 
         if self.post_act_l2_norm:
             y = y / y.norm(dim=-1, keepdim=True).clamp_min(1e-6)


### PR DESCRIPTION
### Motivation
- Provide a toggle to enable Exclusive Self Attention (XSA) so attention layers can be constrained to remove components aligned with each token's self value vector, improving context modeling.
- Ensure the XSA option works across the main attention execution paths (flash, manual, flex) and for both `causal` and `infinite` attention variants so it can be evaluated broadly.
- Add an experiments YAML to ablate XSA vs default attention under multiple softmax alternatives for reproducible comparisons.

### Description
- Added a config flag `use_exclusive_self_attention` in `gpt_conf.py` and a CLI flag `--use_exclusive_self_attention` in `train_args.py` to enable XSA at runtime.
- Implemented `apply_exclusive_self_attention(y, v_self)` in `variations/attention_variations.py` which normalizes `v_self` (stable with `clamp_min(1e-6)`) and subtracts the projection of `y` onto the self-value direction to produce the XSA output.
- Wired the XSA projection into the attention code paths (flash `scaled_dot_product_attention`, manual attention, and flex attention) for the `causal` variant and likewise for the `infinite` attention implementation so the option is effective regardless of backend path.
- Added `explorations/exclusive_self_attention_ablation.yaml` (based on `default_inf.yaml`) to run controlled ablations comparing `use_exclusive_self_attention: [false, true]` with `softmax` and `relu2max` softmax variants for both `causal` and `infinite` attention.

### Testing
- Compiled the updated modules with `python -m py_compile gpt_conf.py train_args.py variations/attention_variations.py` and it completed successfully.
- Added the new exploration YAML and confirmed it is present under `explorations/` for downstream automated experiment runs (no runtime training was executed in this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd48d076808326a3f90e63e6bb2e66)