### PR TITLE
Add Gemma 270M latin/punctuation/other manual LM-head router eval for OPUS en-es

### DIFF
--- a/huggingface_model/gemma/270M/README.md
+++ b/huggingface_model/gemma/270M/README.md
@@ -64,3 +64,35 @@ python huggingface_model/gemma/270M/jl_head_eval.py \
   --annotate_stats true \
   --output_dir jl_eval_outputs
 ```
+
+## Latin/punctuation/other manual router (OPUS-100 en-es)
+
+`latin_punct_router_eval.py` builds three token groups from the Gemma vocabulary:
+
+1. Tokens whose decoded UTF text contains at least one Latin-script codepoint.
+2. Tokens that are punctuation-only (Unicode punctuation plus common English/Spanish punctuation symbols).
+3. Everything else (including byte/special tokens).
+
+It then:
+
+- prints a raw-count and percentage table for all three groups,
+- computes one average LM-head vector per group,
+- L2-normalizes those three vectors into unit routing prototypes,
+- routes each decoding step by dot product of final-layer hidden state with the 3 prototypes,
+- and performs next-token scoring only within the routed token subset.
+
+Example:
+
+```bash
+python huggingface_model/gemma/270M/latin_punct_router_eval.py \
+  --model_name google/gemma-3-270m \
+  --split "train[:1%]" \
+  --max_samples 100 \
+  --max_target_tokens 64 \
+  --device cuda
+```
+
+Notes:
+
+- Evaluation is teacher-forced next-token prediction over OPUS-100 `en-es` translation targets.
+- The script uses cosine-style scoring (unit-normalized hidden state and LM-head rows) for both routing and routed token selection.

--- a/huggingface_model/gemma/270M/README.md
+++ b/huggingface_model/gemma/270M/README.md
@@ -89,6 +89,8 @@ python huggingface_model/gemma/270M/latin_punct_router_eval.py \
   --split "train[:1%]" \
   --max_samples 100 \
   --max_target_tokens 64 \
+  --route_mode three_way \
+  --byte_fallback \
   --device cuda
 ```
 
@@ -96,3 +98,14 @@ Notes:
 
 - Evaluation is teacher-forced next-token prediction over OPUS-100 `en-es` translation targets.
 - The script uses cosine-style scoring (unit-normalized hidden state and LM-head rows) for both routing and routed token selection.
+
+
+Alternative 2-way routing (latin+punct vs other):
+
+```bash
+python huggingface_model/gemma/270M/latin_punct_router_eval.py \
+  --route_mode latin_punct_vs_other \
+  --byte_fallback
+```
+
+Use `--no-byte_fallback` to disable unioning byte tokens into non-`other` candidate sets.

--- a/huggingface_model/gemma/270M/latin_punct_router_eval.py
+++ b/huggingface_model/gemma/270M/latin_punct_router_eval.py
@@ -1,0 +1,223 @@
+"""Build a 3-way manual LM-head router for Gemma 270M and evaluate on OPUS-100 en-es.
+
+Groups:
+1) Tokens containing Latin script characters.
+2) Punctuation-only tokens (Unicode punctuation / common ES-EN punctuation symbols).
+3) Everything else (including byte/special tokens).
+"""
+from __future__ import annotations
+
+import argparse
+import unicodedata
+from dataclasses import dataclass
+from typing import Dict, List, Sequence
+
+import torch
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+COMMON_ES_EN_PUNCT = {
+    ".", ",", "!", "?", ":", ";", "'", '"', "-", "—", "–", "(", ")", "[", "]", "{", "}",
+    "¡", "¿", "…", "«", "»", "‹", "›", "`", "´", "/", "\\", "|", "@", "#", "&", "*", "%",
+    "_",
+}
+
+
+@dataclass
+class EvalStats:
+    total_target_tokens: int = 0
+    top1_correct: int = 0
+    route_latin: int = 0
+    route_punct: int = 0
+    route_other: int = 0
+
+
+def _normalize_rows(x: torch.Tensor) -> torch.Tensor:
+    return torch.nn.functional.normalize(x, dim=-1)
+
+
+def _is_latin_char(ch: str) -> bool:
+    if not ch:
+        return False
+    try:
+        name = unicodedata.name(ch)
+    except ValueError:
+        return False
+    return "LATIN" in name
+
+
+def _is_common_punctuation(ch: str) -> bool:
+    if ch in COMMON_ES_EN_PUNCT:
+        return True
+    cat = unicodedata.category(ch)
+    return cat.startswith("P")
+
+
+def _is_punctuation_only_text(text: str) -> bool:
+    meaningful = [c for c in text if not c.isspace()]
+    if not meaningful:
+        return False
+    return all(_is_common_punctuation(c) for c in meaningful)
+
+
+def _build_token_groups(tokenizer: AutoTokenizer, vocab_size: int) -> Dict[str, List[int]]:
+    groups = {"latin": [], "punct": [], "other": []}
+    for token_id in range(vocab_size):
+        decoded = tokenizer.decode([token_id], skip_special_tokens=False)
+        if any(_is_latin_char(c) for c in decoded):
+            groups["latin"].append(token_id)
+        elif _is_punctuation_only_text(decoded):
+            groups["punct"].append(token_id)
+        else:
+            groups["other"].append(token_id)
+    return groups
+
+
+def _print_group_table(groups: Dict[str, Sequence[int]], vocab_size: int) -> None:
+    headers = ["Group", "Raw token count", "% of vocab"]
+    rows = []
+    for key in ("latin", "punct", "other"):
+        count = len(groups[key])
+        pct = 100.0 * count / vocab_size
+        rows.append((key, count, f"{pct:.2f}%"))
+
+    widths = [max(len(str(h)), max(len(str(r[i])) for r in rows)) for i, h in enumerate(headers)]
+    line = "+" + "+".join("-" * (w + 2) for w in widths) + "+"
+    print("\nToken routing groups for vocabulary")
+    print(line)
+    print("| " + " | ".join(str(h).ljust(widths[i]) for i, h in enumerate(headers)) + " |")
+    print(line)
+    for row in rows:
+        print("| " + " | ".join(str(row[i]).ljust(widths[i]) for i in range(len(headers))) + " |")
+    print(line)
+
+
+def _compute_group_prototypes(
+    lm_head_weight: torch.Tensor,
+    groups: Dict[str, Sequence[int]],
+    device: torch.device,
+) -> Dict[str, torch.Tensor]:
+    out = {}
+    for key in ("latin", "punct", "other"):
+        ids = torch.tensor(groups[key], dtype=torch.long, device=lm_head_weight.device)
+        avg = lm_head_weight.index_select(0, ids).mean(dim=0)
+        out[key] = torch.nn.functional.normalize(avg, dim=0).to(device)
+    return out
+
+
+def _router_scores(hidden_last: torch.Tensor, prototypes: Dict[str, torch.Tensor]) -> torch.Tensor:
+    mat = torch.stack([prototypes["latin"], prototypes["punct"], prototypes["other"]], dim=0)
+    return torch.matmul(hidden_last, mat.T)
+
+
+def _evaluate_router(
+    model: AutoModelForCausalLM,
+    tokenizer: AutoTokenizer,
+    groups: Dict[str, Sequence[int]],
+    prototypes: Dict[str, torch.Tensor],
+    split: str,
+    max_samples: int,
+    max_target_tokens: int,
+    device: torch.device,
+) -> EvalStats:
+    stats = EvalStats()
+    ds = load_dataset("Helsinki-NLP/opus-100", "en-es", split=split)
+    lm_head_weight = _normalize_rows(model.lm_head.weight.detach())
+
+    group_names = ["latin", "punct", "other"]
+    group_ids = {
+        k: torch.tensor(v, dtype=torch.long, device=device)
+        for k, v in groups.items()
+    }
+
+    for ex in ds.select(range(min(max_samples, len(ds)))):
+        en = ex["translation"]["en"]
+        es = ex["translation"]["es"]
+        prompt = f"Translate English to Spanish:\nEnglish: {en}\nSpanish:"
+
+        prompt_ids = tokenizer(prompt, add_special_tokens=True, return_tensors="pt").input_ids.to(device)
+        target_ids = tokenizer(es, add_special_tokens=False, return_tensors="pt").input_ids.to(device)
+        if target_ids.numel() == 0:
+            continue
+
+        steps = min(max_target_tokens, target_ids.size(1))
+        running = prompt_ids
+
+        for idx in range(steps):
+            with torch.no_grad():
+                out = model(running, output_hidden_states=True, use_cache=False)
+            hidden_last = out.hidden_states[-1][:, -1, :]  # post-final layernorm state
+            route = _router_scores(hidden_last, prototypes).argmax(dim=-1).item()
+            chosen = group_names[route]
+            if chosen == "latin":
+                stats.route_latin += 1
+            elif chosen == "punct":
+                stats.route_punct += 1
+            else:
+                stats.route_other += 1
+
+            candidate_ids = group_ids[chosen]
+            candidate_weight = lm_head_weight.index_select(0, candidate_ids)
+            logits = torch.matmul(torch.nn.functional.normalize(hidden_last, dim=-1), candidate_weight.T)
+            pred_local = torch.argmax(logits, dim=-1)
+            pred_id = candidate_ids[pred_local].item()
+            gold_id = target_ids[0, idx].item()
+
+            stats.total_target_tokens += 1
+            if pred_id == gold_id:
+                stats.top1_correct += 1
+
+            next_gold = target_ids[:, idx : idx + 1]
+            running = torch.cat([running, next_gold], dim=1)
+
+    return stats
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manual 3-way Gemma 270M token router eval (OPUS-100 en-es).")
+    parser.add_argument("--model_name", type=str, default="google/gemma-3-270m")
+    parser.add_argument("--split", type=str, default="train[:1%]")
+    parser.add_argument("--max_samples", type=int, default=100)
+    parser.add_argument("--max_target_tokens", type=int, default=64)
+    parser.add_argument("--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu")
+    args = parser.parse_args()
+
+    device = torch.device(args.device)
+    tokenizer = AutoTokenizer.from_pretrained(args.model_name)
+    model = AutoModelForCausalLM.from_pretrained(args.model_name, attn_implementation="eager")
+    model.to(device)
+    model.eval()
+
+    vocab_size = tokenizer.vocab_size
+    groups = _build_token_groups(tokenizer, vocab_size)
+    _print_group_table(groups, vocab_size)
+
+    prototypes = _compute_group_prototypes(model.lm_head.weight.detach(), groups, device)
+    stats = _evaluate_router(
+        model=model,
+        tokenizer=tokenizer,
+        groups=groups,
+        prototypes=prototypes,
+        split=args.split,
+        max_samples=args.max_samples,
+        max_target_tokens=args.max_target_tokens,
+        device=device,
+    )
+
+    acc = 100.0 * stats.top1_correct / max(1, stats.total_target_tokens)
+    total_routes = max(1, stats.route_latin + stats.route_punct + stats.route_other)
+    print("\nRouter evaluation (teacher-forced next-token prediction)")
+    print(f"- Evaluated tokens: {stats.total_target_tokens}")
+    print(f"- Top-1 accuracy with routed LM head: {acc:.2f}%")
+    print(
+        "- Route distribution: latin={:.2f}% punct={:.2f}% other={:.2f}%".format(
+            100.0 * stats.route_latin / total_routes,
+            100.0 * stats.route_punct / total_routes,
+            100.0 * stats.route_other / total_routes,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/huggingface_model/gemma/270M/latin_punct_router_eval.py
+++ b/huggingface_model/gemma/270M/latin_punct_router_eval.py
@@ -1,15 +1,21 @@
-"""Build a 3-way manual LM-head router for Gemma 270M and evaluate on OPUS-100 en-es.
+"""Build a manual LM-head router for Gemma 270M and evaluate on OPUS-100 en-es.
 
-Groups:
-1) Tokens containing Latin script characters.
-2) Punctuation-only tokens (Unicode punctuation / common ES-EN punctuation symbols).
-3) Everything else (including byte/special tokens).
+Base groups:
+1) latin: tokens containing Latin-script characters.
+2) punct: punctuation-only tokens (Unicode punctuation + common ES/EN punctuation).
+3) other: everything else (including byte/special tokens).
+
+Routing modes:
+- three_way: latin vs punct vs other.
+- latin_punct_vs_other: (latin U punct) vs other.
 """
 from __future__ import annotations
 
 import argparse
+import re
 import unicodedata
-from dataclasses import dataclass
+from collections import defaultdict
+from dataclasses import dataclass, field
 from typing import Dict, List, Sequence
 
 import torch
@@ -22,15 +28,14 @@ COMMON_ES_EN_PUNCT = {
     "¡", "¿", "…", "«", "»", "‹", "›", "`", "´", "/", "\\", "|", "@", "#", "&", "*", "%",
     "_",
 }
+BYTE_TOKEN_RE = re.compile(r"^<0x[0-9A-Fa-f]{2}>$")
 
 
 @dataclass
 class EvalStats:
     total_target_tokens: int = 0
     top1_correct: int = 0
-    route_latin: int = 0
-    route_punct: int = 0
-    route_other: int = 0
+    route_counts: Dict[str, int] = field(default_factory=lambda: defaultdict(int))
 
 
 def _normalize_rows(x: torch.Tensor) -> torch.Tensor:
@@ -50,8 +55,7 @@ def _is_latin_char(ch: str) -> bool:
 def _is_common_punctuation(ch: str) -> bool:
     if ch in COMMON_ES_EN_PUNCT:
         return True
-    cat = unicodedata.category(ch)
-    return cat.startswith("P")
+    return unicodedata.category(ch).startswith("P")
 
 
 def _is_punctuation_only_text(text: str) -> bool:
@@ -62,9 +66,13 @@ def _is_punctuation_only_text(text: str) -> bool:
 
 
 def _build_token_groups(tokenizer: AutoTokenizer, vocab_size: int) -> Dict[str, List[int]]:
-    groups = {"latin": [], "punct": [], "other": []}
-    for token_id in range(vocab_size):
+    groups = {"latin": [], "punct": [], "other": [], "byte": []}
+    raw_tokens = tokenizer.convert_ids_to_tokens(list(range(vocab_size)))
+
+    for token_id, raw_token in enumerate(raw_tokens):
         decoded = tokenizer.decode([token_id], skip_special_tokens=False)
+        if BYTE_TOKEN_RE.match(raw_token or ""):
+            groups["byte"].append(token_id)
         if any(_is_latin_char(c) for c in decoded):
             groups["latin"].append(token_id)
         elif _is_punctuation_only_text(decoded):
@@ -77,8 +85,9 @@ def _build_token_groups(tokenizer: AutoTokenizer, vocab_size: int) -> Dict[str, 
 def _print_group_table(groups: Dict[str, Sequence[int]], vocab_size: int) -> None:
     headers = ["Group", "Raw token count", "% of vocab"]
     rows = []
-    for key in ("latin", "punct", "other"):
-        count = len(groups[key])
+    for key in ("latin", "punct", "other", "byte (subset of other)"):
+        src_key = "byte" if key.startswith("byte") else key
+        count = len(groups[src_key])
         pct = 100.0 * count / vocab_size
         rows.append((key, count, f"{pct:.2f}%"))
 
@@ -95,40 +104,61 @@ def _print_group_table(groups: Dict[str, Sequence[int]], vocab_size: int) -> Non
 
 def _compute_group_prototypes(
     lm_head_weight: torch.Tensor,
-    groups: Dict[str, Sequence[int]],
+    route_groups: Dict[str, Sequence[int]],
     device: torch.device,
 ) -> Dict[str, torch.Tensor]:
     out = {}
-    for key in ("latin", "punct", "other"):
-        ids = torch.tensor(groups[key], dtype=torch.long, device=lm_head_weight.device)
+    for key, id_list in route_groups.items():
+        if not id_list:
+            raise ValueError(f"Routing group '{key}' is empty; cannot compute average prototype.")
+        ids = torch.tensor(id_list, dtype=torch.long, device=lm_head_weight.device)
         avg = lm_head_weight.index_select(0, ids).mean(dim=0)
         out[key] = torch.nn.functional.normalize(avg, dim=0).to(device)
     return out
 
 
-def _router_scores(hidden_last: torch.Tensor, prototypes: Dict[str, torch.Tensor]) -> torch.Tensor:
-    mat = torch.stack([prototypes["latin"], prototypes["punct"], prototypes["other"]], dim=0)
+def _router_scores(hidden_last: torch.Tensor, prototypes: Dict[str, torch.Tensor], ordered_names: Sequence[str]) -> torch.Tensor:
+    mat = torch.stack([prototypes[name] for name in ordered_names], dim=0)
     return torch.matmul(hidden_last, mat.T)
+
+
+def _build_route_groups(base_groups: Dict[str, Sequence[int]], route_mode: str) -> Dict[str, List[int]]:
+    if route_mode == "three_way":
+        return {
+            "latin": list(base_groups["latin"]),
+            "punct": list(base_groups["punct"]),
+            "other": list(base_groups["other"]),
+        }
+    if route_mode == "latin_punct_vs_other":
+        latin_punct = sorted(set(base_groups["latin"]) | set(base_groups["punct"]))
+        return {
+            "latin_punct": latin_punct,
+            "other": list(base_groups["other"]),
+        }
+    raise ValueError(f"Unknown route_mode: {route_mode}")
 
 
 def _evaluate_router(
     model: AutoModelForCausalLM,
     tokenizer: AutoTokenizer,
-    groups: Dict[str, Sequence[int]],
+    route_groups: Dict[str, Sequence[int]],
+    byte_ids: Sequence[int],
     prototypes: Dict[str, torch.Tensor],
     split: str,
     max_samples: int,
     max_target_tokens: int,
     device: torch.device,
+    byte_fallback: bool,
 ) -> EvalStats:
     stats = EvalStats()
     ds = load_dataset("Helsinki-NLP/opus-100", "en-es", split=split)
     lm_head_weight = _normalize_rows(model.lm_head.weight.detach())
 
-    group_names = ["latin", "punct", "other"]
+    route_names = list(route_groups.keys())
+    byte_set = set(byte_ids)
     group_ids = {
         k: torch.tensor(v, dtype=torch.long, device=device)
-        for k, v in groups.items()
+        for k, v in route_groups.items()
     }
 
     for ex in ds.select(range(min(max_samples, len(ds)))):
@@ -148,16 +178,17 @@ def _evaluate_router(
             with torch.no_grad():
                 out = model(running, output_hidden_states=True, use_cache=False)
             hidden_last = out.hidden_states[-1][:, -1, :]  # post-final layernorm state
-            route = _router_scores(hidden_last, prototypes).argmax(dim=-1).item()
-            chosen = group_names[route]
-            if chosen == "latin":
-                stats.route_latin += 1
-            elif chosen == "punct":
-                stats.route_punct += 1
-            else:
-                stats.route_other += 1
+            route = _router_scores(hidden_last, prototypes, route_names).argmax(dim=-1).item()
+            chosen = route_names[route]
+            stats.route_counts[chosen] += 1
 
-            candidate_ids = group_ids[chosen]
+            candidate_ids_list = list(route_groups[chosen])
+            if byte_fallback and chosen != "other":
+                candidate_ids_list = sorted(set(candidate_ids_list) | byte_set)
+            if not candidate_ids_list:
+                candidate_ids_list = list(byte_set)
+            candidate_ids = torch.tensor(candidate_ids_list, dtype=torch.long, device=device)
+
             candidate_weight = lm_head_weight.index_select(0, candidate_ids)
             logits = torch.matmul(torch.nn.functional.normalize(hidden_last, dim=-1), candidate_weight.T)
             pred_local = torch.argmax(logits, dim=-1)
@@ -175,11 +206,24 @@ def _evaluate_router(
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Manual 3-way Gemma 270M token router eval (OPUS-100 en-es).")
+    parser = argparse.ArgumentParser(description="Manual Gemma 270M token router eval (OPUS-100 en-es).")
     parser.add_argument("--model_name", type=str, default="google/gemma-3-270m")
     parser.add_argument("--split", type=str, default="train[:1%]")
     parser.add_argument("--max_samples", type=int, default=100)
     parser.add_argument("--max_target_tokens", type=int, default=64)
+    parser.add_argument(
+        "--route_mode",
+        type=str,
+        default="three_way",
+        choices=["three_way", "latin_punct_vs_other"],
+        help="Routing mode: 3-way (latin/punct/other) or 2-way ((latin+punct)/other).",
+    )
+    parser.add_argument(
+        "--byte_fallback",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Include byte tokens in non-other candidate sets as fallback.",
+    )
     parser.add_argument("--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu")
     args = parser.parse_args()
 
@@ -190,33 +234,35 @@ def main() -> None:
     model.eval()
 
     vocab_size = tokenizer.vocab_size
-    groups = _build_token_groups(tokenizer, vocab_size)
-    _print_group_table(groups, vocab_size)
+    base_groups = _build_token_groups(tokenizer, vocab_size)
+    _print_group_table(base_groups, vocab_size)
 
-    prototypes = _compute_group_prototypes(model.lm_head.weight.detach(), groups, device)
+    route_groups = _build_route_groups(base_groups, args.route_mode)
+    prototypes = _compute_group_prototypes(model.lm_head.weight.detach(), route_groups, device)
     stats = _evaluate_router(
         model=model,
         tokenizer=tokenizer,
-        groups=groups,
+        route_groups=route_groups,
+        byte_ids=base_groups["byte"],
         prototypes=prototypes,
         split=args.split,
         max_samples=args.max_samples,
         max_target_tokens=args.max_target_tokens,
         device=device,
+        byte_fallback=args.byte_fallback,
     )
 
     acc = 100.0 * stats.top1_correct / max(1, stats.total_target_tokens)
-    total_routes = max(1, stats.route_latin + stats.route_punct + stats.route_other)
     print("\nRouter evaluation (teacher-forced next-token prediction)")
+    print(f"- Routing mode: {args.route_mode}")
+    print(f"- Byte fallback: {args.byte_fallback}")
     print(f"- Evaluated tokens: {stats.total_target_tokens}")
     print(f"- Top-1 accuracy with routed LM head: {acc:.2f}%")
-    print(
-        "- Route distribution: latin={:.2f}% punct={:.2f}% other={:.2f}%".format(
-            100.0 * stats.route_latin / total_routes,
-            100.0 * stats.route_punct / total_routes,
-            100.0 * stats.route_other / total_routes,
-        )
+    route_total = max(1, sum(stats.route_counts.values()))
+    route_summary = " ".join(
+        f"{name}={100.0 * count / route_total:.2f}%" for name, count in stats.route_counts.items()
     )
+    print(f"- Route distribution: {route_summary}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Provide a simple, manual 3-way LM-head routing experiment for Gemma 270M that separates tokens into Latin-script-containing, punctuation-only, and everything-else groups to study routing efficacy for English→Spanish translation.
- Allow fast, teacher-forced next-token evaluation on OPUS-100 `en-es` using group-wise LM-head scoring instead of scoring the full vocabulary.
- Offer a reproducible script to generate group counts, percentage breakdowns, and prototype vectors derived from the model LM head for routing research and ablation.

### Description
- Add `huggingface_model/gemma/270M/latin_punct_router_eval.py` which builds three token groups by decoding each vocabulary id and testing characters for Latin script or punctuation, then assigns the remainder to `other`.
- Compute one average LM-head vector per group from `model.lm_head.weight`, L2-normalize these averages into routing prototypes, and route per-step by dot product between the final-layer hidden state and the three prototypes.
- Restrict next-token scoring to the selected group by computing cosine-style logits with the normalized hidden state and the LM-head rows for only the routed subset, and perform teacher-forced evaluation on OPUS-100 `en-es` targets.
- Update `huggingface_model/gemma/270M/README.md` to document usage, behavior, and an example CLI invocation for the new script.

### Testing
- Successfully compiled the new script with `python -m compileall huggingface_model/gemma/270M/latin_punct_router_eval.py`.
- Attempted to run `python huggingface_model/gemma/270M/latin_punct_router_eval.py --help`, which failed in the current environment with `ModuleNotFoundError: No module named 'torch'` (environment dependency issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dde6d8097c8326a309a205860229d9)