### PR TITLE
Add no-diagonal causal mask variation for attention variants

### DIFF
--- a/explorations/no_diag_mask_inf.yaml
+++ b/explorations/no_diag_mask_inf.yaml
@@ -1,0 +1,151 @@
+# no_diag_mask_inf.yaml
+# Compares baseline vs use_no_diag_mask for infinite attention.
+# Note: relu2max does not get along with peri_ln, so relu2max runs use pre_ln
+# while softmax runs use peri_ln. Each softmax/relu2max baseline is paired
+# with a matching use_no_diag_mask run (tokens cannot attend to themselves).
+---
+
+named_static_groups:
+  # QK Norm
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  # Norm Type - peri_ln works with softmax but not relu2max
+  - named_group: "peri_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [true]
+    use_post_ln: [false]
+
+  # Norm Type - pre_ln for relu2max (relu2max doesn't get along with peri_ln)
+  - named_group: "pre_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [false]
+    use_post_ln: [false]
+
+  # Position Embeddings
+  - named_group: "rotary"
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+  # Embedding Norm
+  - named_group: "rmsnorm_wte"
+    norm_variant_wte: ["rmsnorm"]
+
+  # MLP Activation
+  - named_group: "squared_relu"
+    activation_variant: ["squared_relu"]
+
+  # Relu2Max
+  - named_group: "relu2max"
+    softmax_variant_attn: ["relu2max"]
+
+  # Softmax
+  - named_group: "softmax"
+    softmax_variant_attn: ["softmax"]
+
+  # Infinite Attention
+  - named_group: "infinite"
+    attention_variant: ["infinite"]
+    use_concat_heads: [true]
+
+  # Head Dimension
+  - named_group: "hd_100"
+    n_qk_head_dim: [100]
+    n_v_head_dim: [100]
+
+  - named_group: "hd_150"
+    n_qk_head_dim: [150]
+    n_v_head_dim: [150]
+
+  - named_group: "hd_200"
+    n_qk_head_dim: [200]
+    n_v_head_dim: [200]
+
+  # MQA
+  - named_group: "mqa"
+    n_kv_group: [1]
+
+  # Baseline (standard causal mask, diagonal included)
+  - named_group: "baseline_mask"
+    use_no_diag_mask: [false]
+
+  # No-diagonal causal mask (tokens cannot attend to themselves)
+  - named_group: "no_diag_mask"
+    use_no_diag_mask: [true]
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [2500]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+  compile: [true]
+  log_rankme: [true]
+  log_areq: [true]
+
+parameter_groups:
+  # Softmax baseline (standard diagonal-inclusive causal mask) with peri_ln
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "softmax"
+      - "infinite"
+      - "mqa"
+      - "baseline_mask"
+    n_head:
+      range:
+        start: 1
+        end: 12
+        step: 1
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]
+
+  # Softmax with use_no_diag_mask enabled, with peri_ln
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "softmax"
+      - "infinite"
+      - "mqa"
+      - "no_diag_mask"
+    n_head:
+      range:
+        start: 1
+        end: 12
+        step: 1
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]
+
+  # Relu2max baseline (standard diagonal-inclusive causal mask) with pre_ln
+  # (peri_ln intentionally omitted: relu2max does not get along with peri_ln)
+  - named_group_static:
+      - "qk_norm"
+      - "pre_ln"
+      - "rotary"
+      - "relu2max"
+      - "infinite"
+      - "mqa"
+      - "baseline_mask"
+    n_head:
+      range:
+        start: 1
+        end: 12
+        step: 1
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]
+
+  # Relu2max with use_no_diag_mask enabled, with pre_ln
+  # (peri_ln intentionally omitted: relu2max does not get along with peri_ln)
+  - named_group_static:
+      - "qk_norm"
+      - "pre_ln"
+      - "rotary"
+      - "relu2max"
+      - "infinite"
+      - "mqa"
+      - "no_diag_mask"
+    n_head:
+      range:
+        start: 1
+        end: 12
+        step: 1
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -176,6 +176,7 @@ class GPTConfig:
 
     # Attention Options
     attention_variant: str = "causal"
+    use_no_diag_mask: bool = False
     attn_cproj_scale: float = 1.0
     attn_post_act_l2_norm: bool = False
 

--- a/train_args.py
+++ b/train_args.py
@@ -903,6 +903,8 @@ def parse_args():
         help="Which attention variant to use for the Transformer blocks."
     )
 
+    model_group.add_argument("--use_no_diag_mask", default=False, action=argparse.BooleanOptionalAction, help="Exclude the diagonal from the causal attention mask (tokens cannot attend to themselves)")
+
     ## MLA Variations
     # ── inside   model_group = parser.add_argument_group('model_group')  … ──
     model_group.add_argument(

--- a/variations/attention_variations.py
+++ b/variations/attention_variations.py
@@ -229,6 +229,12 @@ class CausalSelfAttention(nn.Module):
         if self.disable_flash_attention:
             self.flash = False
 
+        # No-diagonal causal mask
+        self.use_no_diag_mask = config.use_no_diag_mask
+        if self.use_no_diag_mask:
+            self.flash = False
+            print("flash attention removed due to no-diagonal mask")
+
         # Softmax Variant Selection
         self.softmax_variant_attn = config.softmax_variant_attn
         if self.softmax_variant_attn == "softmax":
@@ -248,12 +254,16 @@ class CausalSelfAttention(nn.Module):
         if (not self.flash) and (not self.use_flex_attn):
             print("WARNING: using slow attention. Flash Attention requires PyTorch >= 2.0")
             # causal mask to ensure that attention is only applied to the left in the input sequence
-            self.register_buffer("bias", torch.tril(torch.ones(config.block_size, config.block_size))
+            tril_diag = -1 if self.use_no_diag_mask else 0
+            self.register_buffer("bias", torch.tril(torch.ones(config.block_size, config.block_size), diagonal=tril_diag)
                                         .view(1, 1, config.block_size, config.block_size))
 
     # Flex Attention Related
     def sliding_window_causal(self, b, h, q_idx, kv_idx):
-        causal_mask = q_idx >= kv_idx
+        if self.use_no_diag_mask:
+            causal_mask = q_idx > kv_idx
+        else:
+            causal_mask = q_idx >= kv_idx
         window_mask = q_idx - kv_idx <= self.window_size
         return causal_mask & window_mask
 
@@ -603,9 +613,13 @@ class EdgeLLMASICAttention(nn.Module):
             g0 = math.log2(L*L - L)
             self.qk_norm_factor = nn.Parameter(torch.tensor(g0))
 
+        # No-diagonal causal mask
+        self.use_no_diag_mask = config.use_no_diag_mask
+
         print("WARNING: using slow attention. Flash Attention requires PyTorch >= 2.0")
         # causal mask to ensure that attention is only applied to the left in the input sequence
-        self.register_buffer("bias", torch.tril(torch.ones(config.block_size, config.block_size))
+        tril_diag = -1 if self.use_no_diag_mask else 0
+        self.register_buffer("bias", torch.tril(torch.ones(config.block_size, config.block_size), diagonal=tril_diag)
                                     .view(1, 1, config.block_size, config.block_size))
 
     def _expand_kv(self, tensor: torch.Tensor) -> torch.Tensor:
@@ -1142,6 +1156,13 @@ class InfiniteHeadAttention(nn.Module):
             g0 = math.log2(L*L - L)
             self.qk_norm_factor = nn.Parameter(torch.tensor(g0))
 
+        # No-diagonal causal mask
+        self.use_no_diag_mask = config.use_no_diag_mask
+        if self.use_no_diag_mask:
+            if not self.disable_flash_attention:
+                print("flash attention removed due to no-diagonal mask")
+            self.disable_flash_attention = True
+
         # Softmax Variant Selection
         self.softmax_variant_attn = config.softmax_variant_attn
         if self.softmax_variant_attn != 'softmax':
@@ -1150,7 +1171,8 @@ class InfiniteHeadAttention(nn.Module):
                 print("flash attention removed due to softmax alternative")
             self.disable_flash_attention = True
 
-        self.register_buffer("bias", torch.tril(torch.ones(config.block_size, config.block_size))
+        tril_diag = -1 if self.use_no_diag_mask else 0
+        self.register_buffer("bias", torch.tril(torch.ones(config.block_size, config.block_size), diagonal=tril_diag)
                              .view(1, 1, config.block_size, config.block_size))
 
     def _maybe_print_attn_norm(self, name, weight, dim):
@@ -1375,10 +1397,14 @@ class MultiHeadLatentAttention(nn.Module):
         else:
             self.register_parameter("lobo_log", None)
 
+        # No-diagonal causal mask
+        self.use_no_diag_mask = config.use_no_diag_mask
+
         # Pre-build causal mask for the worst-case block_size
+        tril_diag = -1 if self.use_no_diag_mask else 0
         self.register_buffer(
             "causal_mask",
-            torch.tril(torch.ones(config.block_size, config.block_size)).view(1, 1, config.block_size, config.block_size),
+            torch.tril(torch.ones(config.block_size, config.block_size), diagonal=tril_diag).view(1, 1, config.block_size, config.block_size),
             persistent=False,
         )
 


### PR DESCRIPTION
Adds use_no_diag_mask config option that excludes the diagonal from the
causal attention mask, preventing tokens from attending to themselves.
Supported by CausalSelfAttention, EdgeLLMASICAttention,
InfiniteHeadAttention, and MultiHeadLatentAttention. Flash attention is
automatically disabled when this option is enabled.

https://claude.ai/code/session_01NC1GJ83BvSwmdi7nJEXEKp