### PR TITLE
Gemma 270M: add attention blending (softmax/RELU variants), EN→ES finetune recipes, plotting and benchmarking scripts

### DIFF
--- a/huggingface_model/gemma/270M/README.md
+++ b/huggingface_model/gemma/270M/README.md
@@ -7,6 +7,14 @@ experimenting with LM head acceleration using Johnson-Lindenstrauss (JL) project
 
 `finetune.py` now supports the exact experiment structure below.
 
+If you want a single runnable walkthrough, use:
+
+```bash
+bash huggingface_model/gemma/270M/demo_gradual_blend_en_es.sh
+```
+
+That demo runs the gradual blend path and prints commented commands for the two baselines.
+
 ### A) Gradual blend recipe (Softmax → ReLUMax/ReLU2Max + output norm blending)
 
 1. obtain checkpoint

--- a/huggingface_model/gemma/270M/README.md
+++ b/huggingface_model/gemma/270M/README.md
@@ -3,6 +3,132 @@
 This folder includes scripts for training Gemma 270M from scratch, fine-tuning, and
 experimenting with LM head acceleration using Johnson-Lindenstrauss (JL) projection.
 
+## Experiment sequence (English → Spanish)
+
+`finetune.py` now supports the exact experiment structure below.
+
+### A) Gradual blend recipe (Softmax → ReLUMax/ReLU2Max + output norm blending)
+
+1. obtain checkpoint
+2. optional fine-tune with standard softmax
+3. gradual fine-tune with alpha schedule:
+   - attention: `alpha * softmax + (1-alpha) * relu_variant`
+   - output norms (post-attn + post-ffn): `alpha * output_norm + (1-alpha) * raw`
+   - alpha decreases from 1 → 0 and is clamped at 0, with optional `post_zero_steps`
+
+Example:
+
+```bash
+# Stage 1: stabilize on Softmax first
+python huggingface_model/gemma/270M/finetune.py \
+  --model_name google/gemma-3-270m \
+  --dataset_config en-es \
+  --source_lang en \
+  --target_lang es \
+  --source_lang_name English \
+  --target_lang_name Spanish \
+  --dataset_split "train[:10%]" \
+  --output_dir ./runs/gemma270_softmax_stage1 \
+  --total_iterations 20000 \
+  --sample_frequency 1000 \
+  --attention_mode softmax
+
+# Stage 2: switch activation and continue from Stage 1 checkpoint
+python huggingface_model/gemma/270M/finetune.py \
+  --model_name ./runs/gemma270_softmax_stage1 \
+  --dataset_config en-es \
+  --source_lang en \
+  --target_lang es \
+  --source_lang_name English \
+  --target_lang_name Spanish \
+  --dataset_split "train[:10%]" \
+  --output_dir ./runs/gemma270_relu2max_stage2 \
+  --total_iterations 10000 \
+  --sample_frequency 1000 \
+  --attention_mode gradual_blend \
+  --attention_activation relu2max \
+  --activation_divisor 256.0 \
+  --alpha_start 1.0 \
+  --alpha_end 0.0 \
+  --post_zero_steps 1000 \
+  --blend_output_norm
+```
+
+For `relumax`, only change:
+
+```bash
+--attention_activation relumax --activation_divisor 256.0
+```
+
+### B) Baseline recipe (Softmax only)
+
+1. obtain checkpoint
+2. fine-tune with standard softmax
+
+```bash
+python huggingface_model/gemma/270M/finetune.py \
+  --model_name google/gemma-3-270m \
+  --dataset_config en-es \
+  --output_dir ./runs/gemma270_softmax_only \
+  --total_iterations 20000 \
+  --sample_frequency 1000 \
+  --attention_mode softmax
+```
+
+### C) Sum baseline (Softmax + ReLU variant scores)
+
+1. obtain checkpoint
+2. fine-tune with summed attention probabilities/scores
+
+```bash
+python huggingface_model/gemma/270M/finetune.py \
+  --model_name google/gemma-3-270m \
+  --dataset_config en-es \
+  --output_dir ./runs/gemma270_sum_relu2max \
+  --total_iterations 20000 \
+  --sample_frequency 1000 \
+  --attention_mode sum \
+  --attention_activation relu2max \
+  --activation_divisor 256.0
+```
+
+### Important implementation note
+
+The activation swap is implemented by monkey-patching `torch.nn.functional.softmax`
+during training, so this is intended as a practical experiment path and not a
+production-safe kernel-level replacement.
+
+After each run, the script prints **multi-shot translation outputs for 3 fixed EN→ES
+test sentences** (`--print_multishot_after_train` defaults to true).
+
+## Plot validation loss per iteration (Softmax vs ReLUMax vs ReLU2Max)
+
+After running three stage-2 experiments (one each for softmax / relumax / relu2max),
+you can plot validation-loss curves from each run's `trainer_state.json`:
+
+```bash
+python huggingface_model/gemma/270M/plot_validation_loss.py \
+  --run "softmax=./runs/gemma270_softmax_stage2" \
+  --run "relumax=./runs/gemma270_relumax_stage2" \
+  --run "relu2max=./runs/gemma270_relu2max_stage2" \
+  --title "Gemma 270M EN→ES: validation loss per iteration" \
+  --output ./runs/gemma270_en_es_val_loss.png
+```
+
+## Benchmark EN→ES translation quality
+
+You can run a quick benchmark on a held-out slice with exact-match plus BLEU/chrF
+(if `sacrebleu` is installed):
+
+```bash
+python huggingface_model/gemma/270M/benchmark_en_es_translation.py \
+  --model_name ./runs/gemma270_relu2max_stage2 \
+  --dataset_config en-es \
+  --dataset_split "train[10%:11%]" \
+  --num_samples 200 \
+  --max_new_tokens 64
+```
+
 ## Loading a pre-trained checkpoint
 
 Use the Hugging Face model hub (or a local checkpoint directory) as the `model_name`:

--- a/huggingface_model/gemma/270M/benchmark_en_es_translation.py
+++ b/huggingface_model/gemma/270M/benchmark_en_es_translation.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+Benchmark EN->ES translation checkpoints with simple generation metrics.
+"""
+
+import argparse
+from statistics import mean
+
+import torch
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+def maybe_compute_sacrebleu(predictions, references):
+    try:
+        import sacrebleu
+    except Exception:
+        return None
+
+    bleu = sacrebleu.corpus_bleu(predictions, [references]).score
+    chrf = sacrebleu.corpus_chrf(predictions, [references]).score
+    return {"bleu": bleu, "chrf": chrf}
+
+
+def exact_match_rate(predictions, references):
+    matches = [int(p.strip().lower() == r.strip().lower()) for p, r in zip(predictions, references)]
+    return mean(matches) if matches else 0.0
+
+
+def main(args):
+    print(f"Loading dataset: {args.dataset_name} ({args.dataset_config}) split={args.dataset_split}")
+    dataset = load_dataset(args.dataset_name, args.dataset_config, split=args.dataset_split)
+    dataset = dataset.select(range(min(len(dataset), args.num_samples)))
+
+    print(f"Loading model/tokenizer from: {args.model_name}")
+    tokenizer = AutoTokenizer.from_pretrained(args.model_name)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    model = AutoModelForCausalLM.from_pretrained(args.model_name, attn_implementation="eager")
+    model.eval()
+    device = args.device if args.device else ("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+
+    predictions, references = [], []
+    for i, row in enumerate(dataset):
+        src = row["translation"][args.source_lang]
+        tgt = row["translation"][args.target_lang]
+        prompt = (
+            f"Translate {args.source_lang_name} to {args.target_lang_name}:\n"
+            f"{args.source_lang_name}: {src}\n"
+            f"{args.target_lang_name}: "
+        )
+        inputs = tokenizer(prompt, return_tensors="pt").to(device)
+        with torch.no_grad():
+            out = model.generate(
+                **inputs,
+                max_new_tokens=args.max_new_tokens,
+                do_sample=False,
+                pad_token_id=tokenizer.eos_token_id,
+            )
+        decoded = tokenizer.decode(out[0], skip_special_tokens=True)
+        pred = decoded.replace(prompt, "").strip().split("\n")[0]
+
+        predictions.append(pred)
+        references.append(tgt)
+
+        if i < args.print_examples:
+            print(f"\n[{i}]")
+            print(f"SRC: {src}")
+            print(f"REF: {tgt}")
+            print(f"PRD: {pred}")
+
+    metrics = {"exact_match": exact_match_rate(predictions, references)}
+    sacrebleu_metrics = maybe_compute_sacrebleu(predictions, references)
+    if sacrebleu_metrics:
+        metrics.update(sacrebleu_metrics)
+    else:
+        print("sacrebleu not installed; skipping BLEU/chrF.")
+
+    print("\n=== Benchmark results ===")
+    for k, v in metrics.items():
+        print(f"{k}: {v:.4f}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Benchmark EN->ES translation with Gemma checkpoints.")
+    parser.add_argument("--model_name", type=str, required=True, help="Checkpoint path or HF model id.")
+    parser.add_argument("--dataset_name", type=str, default="Helsinki-NLP/opus-100")
+    parser.add_argument("--dataset_config", type=str, default="en-es")
+    parser.add_argument("--dataset_split", type=str, default="train[10%:11%]")
+    parser.add_argument("--source_lang", type=str, default="en")
+    parser.add_argument("--target_lang", type=str, default="es")
+    parser.add_argument("--source_lang_name", type=str, default="English")
+    parser.add_argument("--target_lang_name", type=str, default="Spanish")
+    parser.add_argument("--num_samples", type=int, default=200)
+    parser.add_argument("--max_new_tokens", type=int, default=64)
+    parser.add_argument("--print_examples", type=int, default=3)
+    parser.add_argument("--device", type=str, default=None)
+    main(parser.parse_args())

--- a/huggingface_model/gemma/270M/demo_gradual_blend_en_es.sh
+++ b/huggingface_model/gemma/270M/demo_gradual_blend_en_es.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Demo: EN->ES gradual blend fine-tuning for Gemma 270M
+#
+# This script shows the full staged flow:
+#   1) obtain / choose a checkpoint
+#   2) optional Softmax warmup stage
+#   3) gradual blend stage with alpha annealing
+#
+# It also includes commented alternatives for:
+#   - pure Softmax baseline
+#   - summed scores baseline (Softmax + ReLU variant)
+#
+# Usage:
+#   bash huggingface_model/gemma/270M/demo_gradual_blend_en_es.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+cd "${REPO_ROOT}"
+
+# ----------------------------
+# Common configuration
+# ----------------------------
+BASE_MODEL="${BASE_MODEL:-google/gemma-3-270m}"
+DATASET_NAME="${DATASET_NAME:-Helsinki-NLP/opus-100}"
+DATASET_CONFIG="${DATASET_CONFIG:-en-es}"
+DATASET_SPLIT="${DATASET_SPLIT:-train[:10%]}"
+SOURCE_LANG="${SOURCE_LANG:-en}"
+TARGET_LANG="${TARGET_LANG:-es}"
+SOURCE_LANG_NAME="${SOURCE_LANG_NAME:-English}"
+TARGET_LANG_NAME="${TARGET_LANG_NAME:-Spanish}"
+
+# Training controls (override through env vars if desired)
+WARMUP_STEPS="${WARMUP_STEPS:-2000}"
+GRADUAL_STEPS="${GRADUAL_STEPS:-4000}"
+POST_ZERO_STEPS="${POST_ZERO_STEPS:-500}"
+SAMPLE_FREQ="${SAMPLE_FREQ:-500}"
+
+# ReLU branch options for gradual/sum variants
+ATTN_ACTIVATION="${ATTN_ACTIVATION:-relu2max}"   # relumax | relu2max
+ACTIVATION_DIVISOR="${ACTIVATION_DIVISOR:-256.0}"
+
+# Output directories
+RUN_ROOT="${RUN_ROOT:-./runs/gemma270_demo_en_es}"
+SOFTMAX_STAGE_DIR="${SOFTMAX_STAGE_DIR:-${RUN_ROOT}/stage1_softmax}"
+GRADUAL_STAGE_DIR="${GRADUAL_STAGE_DIR:-${RUN_ROOT}/stage2_gradual_${ATTN_ACTIVATION}}"
+SUM_BASELINE_DIR="${SUM_BASELINE_DIR:-${RUN_ROOT}/baseline_sum_${ATTN_ACTIVATION}}"
+SOFTMAX_BASELINE_DIR="${SOFTMAX_BASELINE_DIR:-${RUN_ROOT}/baseline_softmax}"
+
+mkdir -p "${RUN_ROOT}"
+
+echo "== Stage 1 (optional): Softmax warmup from ${BASE_MODEL} =="
+python huggingface_model/gemma/270M/finetune.py \
+  --model_name "${BASE_MODEL}" \
+  --dataset_name "${DATASET_NAME}" \
+  --dataset_config "${DATASET_CONFIG}" \
+  --dataset_split "${DATASET_SPLIT}" \
+  --source_lang "${SOURCE_LANG}" \
+  --target_lang "${TARGET_LANG}" \
+  --source_lang_name "${SOURCE_LANG_NAME}" \
+  --target_lang_name "${TARGET_LANG_NAME}" \
+  --output_dir "${SOFTMAX_STAGE_DIR}" \
+  --total_iterations "${WARMUP_STEPS}" \
+  --sample_frequency "${SAMPLE_FREQ}" \
+  --attention_mode softmax
+
+echo "== Stage 2: Gradual blend from Softmax checkpoint =="
+python huggingface_model/gemma/270M/finetune.py \
+  --model_name "${SOFTMAX_STAGE_DIR}" \
+  --dataset_name "${DATASET_NAME}" \
+  --dataset_config "${DATASET_CONFIG}" \
+  --dataset_split "${DATASET_SPLIT}" \
+  --source_lang "${SOURCE_LANG}" \
+  --target_lang "${TARGET_LANG}" \
+  --source_lang_name "${SOURCE_LANG_NAME}" \
+  --target_lang_name "${TARGET_LANG_NAME}" \
+  --output_dir "${GRADUAL_STAGE_DIR}" \
+  --total_iterations "${GRADUAL_STEPS}" \
+  --sample_frequency "${SAMPLE_FREQ}" \
+  --attention_mode gradual_blend \
+  --attention_activation "${ATTN_ACTIVATION}" \
+  --activation_divisor "${ACTIVATION_DIVISOR}" \
+  --alpha_start 1.0 \
+  --alpha_end 0.0 \
+  --post_zero_steps "${POST_ZERO_STEPS}" \
+  --blend_output_norm
+
+echo "== Done. Final gradual checkpoint: ${GRADUAL_STAGE_DIR} =="
+
+cat <<'EOF'
+
+Other options (copy/paste if needed):
+
+1) Softmax-only baseline
+python huggingface_model/gemma/270M/finetune.py \
+  --model_name google/gemma-3-270m \
+  --dataset_config en-es \
+  --output_dir ./runs/gemma270_demo_en_es/baseline_softmax \
+  --total_iterations 4000 \
+  --sample_frequency 500 \
+  --attention_mode softmax
+
+2) Sum baseline (Softmax + relu variant)
+python huggingface_model/gemma/270M/finetune.py \
+  --model_name google/gemma-3-270m \
+  --dataset_config en-es \
+  --output_dir ./runs/gemma270_demo_en_es/baseline_sum_relu2max \
+  --total_iterations 4000 \
+  --sample_frequency 500 \
+  --attention_mode sum \
+  --attention_activation relu2max \
+  --activation_divisor 256.0
+
+3) Plot validation loss curves
+python huggingface_model/gemma/270M/plot_validation_loss.py \
+  --run "gradual=./runs/gemma270_demo_en_es/stage2_gradual_relu2max" \
+  --run "softmax=./runs/gemma270_demo_en_es/baseline_softmax" \
+  --run "sum=./runs/gemma270_demo_en_es/baseline_sum_relu2max" \
+  --output ./runs/gemma270_demo_en_es/val_loss_compare.png
+
+4) Benchmark EN->ES translation
+python huggingface_model/gemma/270M/benchmark_en_es_translation.py \
+  --model_name ./runs/gemma270_demo_en_es/stage2_gradual_relu2max \
+  --dataset_config en-es \
+  --dataset_split "train[10%:11%]" \
+  --num_samples 200
+
+EOF

--- a/huggingface_model/gemma/270M/finetune.py
+++ b/huggingface_model/gemma/270M/finetune.py
@@ -5,6 +5,8 @@ os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 
 import torch
 import argparse
+import torch.nn.functional as F
+from typing import Callable
 from datasets import load_dataset
 from transformers import (
     AutoTokenizer,
@@ -15,13 +17,54 @@ from transformers import (
     TrainerCallback
 )
 
-# --- Custom Callback for Generating Sample Outputs ---
+
+def _relu_variant(inputs: torch.Tensor, activation: str, divisor: float) -> torch.Tensor:
+    if divisor <= 0:
+        raise ValueError("--activation_divisor must be > 0.")
+    if activation == "relumax":
+        return torch.relu(inputs) / divisor
+    if activation == "relu2max":
+        return torch.relu(inputs).pow(2) / divisor
+    raise ValueError(f"Unsupported activation '{activation}'")
+
+
+class BlendController:
+    def __init__(self, alpha_start: float, alpha_end: float, anneal_steps: int, post_zero_steps: int):
+        self.alpha_start = alpha_start
+        self.alpha_end = alpha_end
+        self.anneal_steps = max(1, anneal_steps)
+        self.post_zero_steps = max(0, post_zero_steps)
+        self.alpha = alpha_start
+
+    def update(self, step: int):
+        progress = min(step, self.anneal_steps) / float(self.anneal_steps)
+        self.alpha = self.alpha_start + (self.alpha_end - self.alpha_start) * progress
+        self.alpha = max(self.alpha, 0.0)  # clamp; cannot go below zero
+
+
+class AlphaScheduleCallback(TrainerCallback):
+    def __init__(self, blend_controller: BlendController, log_every: int = 100):
+        self.blend_controller = blend_controller
+        self.log_every = max(1, log_every)
+
+    def on_step_begin(self, args, state, control, **kwargs):
+        self.blend_controller.update(state.global_step)
+        if state.global_step % self.log_every == 0 and state.is_world_process_zero:
+            print(f"[alpha schedule] step={state.global_step} alpha={self.blend_controller.alpha:.6f}")
+
+
 class SampleOutputCallback(TrainerCallback):
     """A callback that generates a sample translation periodically."""
-    def __init__(self, tokenizer, test_sentence="The sun is shining today."):
+    def __init__(self, tokenizer, source_lang="English", target_lang="Spanish", test_sentence="The sun is shining today."):
         self.tokenizer = tokenizer
+        self.source_lang = source_lang
+        self.target_lang = target_lang
         self.test_sentence = test_sentence
-        self.prompt = f"Translate English to Chinese:\nEnglish: {self.test_sentence}\nChinese: "
+        self.prompt = (
+            f"Translate {self.source_lang} to {self.target_lang}:\n"
+            f"{self.source_lang}: {self.test_sentence}\n"
+            f"{self.target_lang}: "
+        )
 
     def on_log(self, args, state, control, **kwargs):
         # This callback is triggered every `logging_steps`.
@@ -37,24 +80,95 @@ class SampleOutputCallback(TrainerCallback):
             
             # Clean and print the generated text
             generated_text = decoded_output.replace(self.prompt, "").strip()
-            print(f"English: {self.test_sentence}")
-            print(f"Generated Chinese: {generated_text}")
+            print(f"{self.source_lang}: {self.test_sentence}")
+            print(f"Generated {self.target_lang}: {generated_text}")
             print("---------------------------------------\n")
 
-# --- Main Script ---
-def main(args):
-    # 1. Load the dataset
-    print("Loading the dataset...")
-    # Using a larger portion for more meaningful training
-    dataset = load_dataset("Helsinki-NLP/opus-100", "en-zh", split="train[:10%]")
+def _build_attention_softmax(
+    args,
+    blend_controller: BlendController,
+    original_softmax: Callable,
+):
+    def _replacement(x, dim=None, _stacklevel=3, dtype=None):
+        dim = -1 if dim is None else dim
+        x_in = x.to(dtype) if dtype is not None else x
+        softmax_scores = original_softmax(x_in, dim=dim, _stacklevel=_stacklevel, dtype=dtype)
 
-    # Split the dataset
+        if args.attention_mode == "softmax":
+            return softmax_scores
+
+        relu_scores = _relu_variant(x_in, args.attention_activation, args.activation_divisor)
+
+        if args.attention_mode == "sum":
+            return softmax_scores + relu_scores
+
+        if args.attention_mode == "gradual_blend":
+            alpha = blend_controller.alpha
+            return alpha * softmax_scores + (1.0 - alpha) * relu_scores
+
+        raise ValueError(f"Unsupported --attention_mode: {args.attention_mode}")
+
+    return _replacement
+
+
+def _patch_output_norms(model, blend_controller: BlendController, enable_norm_blend: bool):
+    if not enable_norm_blend:
+        return []
+
+    patched = []
+    target_fragments = ("post_attention_layernorm", "post_feedforward_layernorm")
+    for name, module in model.named_modules():
+        if not any(fragment in name for fragment in target_fragments):
+            continue
+        original_forward = module.forward
+
+        def wrapped_forward(hidden_states, *f_args, __orig=original_forward, **f_kwargs):
+            normalized = __orig(hidden_states, *f_args, **f_kwargs)
+            alpha = blend_controller.alpha
+            return alpha * normalized + (1.0 - alpha) * hidden_states
+
+        module.forward = wrapped_forward
+        patched.append((name, module, original_forward))
+
+    return patched
+
+
+def _restore_output_norms(patched_norms):
+    for _, module, original_forward in patched_norms:
+        module.forward = original_forward
+
+
+def _print_multishot_examples(model, tokenizer, args):
+    prompts_en = [
+        "The weather is perfect for a walk in the park.",
+        "Please summarize the main argument in this paragraph.",
+        "I forgot my charger at home, so my laptop battery is low.",
+    ]
+    print("\n=== Multi-shot EN->ES examples ===")
+    for idx, sentence in enumerate(prompts_en, start=1):
+        prompt = (
+            f"Translate {args.source_lang_name} to {args.target_lang_name}:\n"
+            f"{args.source_lang_name}: {sentence}\n"
+            f"{args.target_lang_name}: "
+        )
+        inputs = tokenizer(prompt, return_tensors="pt").to(model.device)
+        outputs = model.generate(**inputs, max_new_tokens=64, do_sample=False, pad_token_id=tokenizer.eos_token_id)
+        decoded_output = tokenizer.decode(outputs[0], skip_special_tokens=True)
+        generated = decoded_output.replace(prompt, "").strip().split("\n")[0]
+        print(f"[{idx}] EN: {sentence}")
+        print(f"    ES: {generated}")
+
+        
+
+def main(args):
+    print("Loading the dataset...")
+    dataset = load_dataset(args.dataset_name, args.dataset_config, split=args.dataset_split)
     train_test_split = dataset.train_test_split(test_size=0.1)
     train_dataset = train_test_split["train"]
     eval_dataset = train_test_split["test"]
 
     # 2. Load the tokenizer and model
-    model_name = "google/gemma-3-270m"
+    model_name = args.model_name
     print(f"Loading tokenizer and model for {model_name}...")
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     model = AutoModelForCausalLM.from_pretrained(model_name, attn_implementation="eager") # "eager" is the recommended setting for Gemma 270M
@@ -65,7 +179,14 @@ def main(args):
 
     # 3. Preprocess the data
     def preprocess_function(examples):
-        texts = [f"Translate English to Chinese:\nEnglish: {ex['en']}\nChinese: {ex['zh']}" for ex in examples["translation"]]
+        texts = [
+            (
+                f"Translate {args.source_lang_name} to {args.target_lang_name}:\n"
+                f"{args.source_lang_name}: {ex[args.source_lang]}\n"
+                f"{args.target_lang_name}: {ex[args.target_lang]}"
+            )
+            for ex in examples["translation"]
+        ]
         return tokenizer(texts, truncation=True, max_length=128, padding="max_length")
 
     print("Tokenizing the dataset...")
@@ -74,7 +195,7 @@ def main(args):
 
     # 4. Define training arguments from command-line args
     training_args = TrainingArguments(
-        output_dir="./gemma-3-270m-opus-100-en-zh-causal",
+        output_dir=args.output_dir,
         # Control training with steps instead of epochs
         max_steps=args.total_iterations,
         # Set strategies to 'steps' to use the step-based arguments
@@ -97,8 +218,21 @@ def main(args):
     # 5. Create data collator
     data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
 
-    # Instantiate the custom callback
-    sample_callback = SampleOutputCallback(tokenizer=tokenizer)
+    blend_controller = BlendController(
+        alpha_start=args.alpha_start,
+        alpha_end=args.alpha_end,
+        anneal_steps=max(1, args.total_iterations - args.post_zero_steps),
+        post_zero_steps=args.post_zero_steps,
+    )
+
+    sample_callback = SampleOutputCallback(
+        tokenizer=tokenizer,
+        source_lang=args.source_lang_name,
+        target_lang=args.target_lang_name,
+    )
+    callbacks = [sample_callback]
+    if args.attention_mode == "gradual_blend":
+        callbacks.append(AlphaScheduleCallback(blend_controller, log_every=args.sample_frequency))
 
     # 6. Initialize the Trainer
     trainer = Trainer(
@@ -108,20 +242,88 @@ def main(args):
         eval_dataset=tokenized_eval_dataset,
         tokenizer=tokenizer,
         data_collator=data_collator,
-        callbacks=[sample_callback] # Add the callback here
+        callbacks=callbacks
     )
 
     # 7. Start training
     print("Starting the training process...")
-    trainer.train()
+    original_softmax = F.softmax
+    replacement_softmax = _build_attention_softmax(args, blend_controller, original_softmax)
+    F.softmax = replacement_softmax
+    patched_norms = _patch_output_norms(
+        model=model,
+        blend_controller=blend_controller,
+        enable_norm_blend=args.blend_output_norm and args.attention_mode == "gradual_blend",
+    )
+    try:
+        trainer.train()
+    finally:
+        F.softmax = original_softmax
+        _restore_output_norms(patched_norms)
 
     # Save the final model state
     trainer.save_model()
     print("Training complete! Final model saved.")
+    if args.print_multishot_after_train:
+        _print_multishot_examples(model, tokenizer, args)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Fine-tune a Gemma model for translation.")
+    parser.add_argument(
+        "--dataset_name",
+        type=str,
+        default="Helsinki-NLP/opus-100",
+        help="HF datasets repository id."
+    )
+    parser.add_argument(
+        "--dataset_config",
+        type=str,
+        default="en-es",
+        help="HF dataset config name (e.g. 'en-es')."
+    )
+    parser.add_argument(
+        "--source_lang",
+        type=str,
+        default="en",
+        help="Source language key inside examples['translation']."
+    )
+    parser.add_argument(
+        "--target_lang",
+        type=str,
+        default="es",
+        help="Target language key inside examples['translation']."
+    )
+    parser.add_argument(
+        "--source_lang_name",
+        type=str,
+        default="English",
+        help="Human-friendly source language label used in prompts."
+    )
+    parser.add_argument(
+        "--target_lang_name",
+        type=str,
+        default="Spanish",
+        help="Human-friendly target language label used in prompts."
+    )
+    parser.add_argument(
+        "--model_name",
+        type=str,
+        default="google/gemma-3-270m",
+        help="HF model id or local checkpoint path."
+    )
+    parser.add_argument(
+        "--dataset_split",
+        type=str,
+        default="train[:10%]",
+        help="Datasets split string passed to load_dataset for OPUS-100."
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default="./gemma-3-270m-opus-100-en-es-causal",
+        help="Directory to save checkpoints and final model."
+    )
     parser.add_argument(
         "--total_iterations",
         type=int,
@@ -134,6 +336,45 @@ if __name__ == "__main__":
         default=1000,
         help="How often (in steps) to save, evaluate, and generate a sample output."
     )
+    parser.add_argument(
+        "--attention_activation",
+        type=str,
+        default="relumax",
+        choices=["relumax", "relu2max"],
+        help="Non-softmax branch used in attention_mode=sum or gradual_blend."
+    )
+    parser.add_argument(
+        "--activation_divisor",
+        type=float,
+        default=256.0,
+        help="Divisor applied for relumax/relu2max activation variants."
+    )
+    parser.add_argument(
+        "--attention_mode",
+        type=str,
+        default="softmax",
+        choices=["softmax", "sum", "gradual_blend"],
+        help="softmax baseline, sum baseline (softmax + relu*), or alpha-annealed blend."
+    )
+    parser.add_argument("--alpha_start", type=float, default=1.0, help="Initial alpha for gradual_blend.")
+    parser.add_argument("--alpha_end", type=float, default=0.0, help="Final alpha for gradual_blend.")
+    parser.add_argument(
+        "--post_zero_steps",
+        type=int,
+        default=0,
+        help="Optional additional steps after alpha reaches 0 (uses clamped alpha=0).",
+    )
+    parser.add_argument(
+        "--blend_output_norm",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="For gradual_blend: blend post-attn/post-ffn output norms with raw residual path.",
+    )
+    parser.add_argument(
+        "--print_multishot_after_train",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Print 3 fixed EN->ES translation outputs after training.",
+    )
     parsed_args = parser.parse_args()
     main(parsed_args)
-

--- a/huggingface_model/gemma/270M/plot_validation_loss.py
+++ b/huggingface_model/gemma/270M/plot_validation_loss.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Plot validation loss vs global step from one or more Hugging Face Trainer runs.
+
+Each run directory should contain `trainer_state.json` (saved by Trainer checkpoints).
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+
+def load_eval_curve(run_dir: Path):
+    state_path = run_dir / "trainer_state.json"
+    if not state_path.exists():
+        raise FileNotFoundError(f"Missing {state_path}")
+
+    with state_path.open("r", encoding="utf-8") as f:
+        state = json.load(f)
+
+    eval_records = [
+        entry for entry in state.get("log_history", [])
+        if "eval_loss" in entry and "step" in entry
+    ]
+    steps = [record["step"] for record in eval_records]
+    losses = [record["eval_loss"] for record in eval_records]
+    return steps, losses
+
+
+def parse_run(value: str):
+    if "=" in value:
+        label, path = value.split("=", 1)
+    else:
+        path = value
+        label = Path(path).name
+    return label, Path(path)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Plot validation loss curves for Gemma finetuning runs.")
+    parser.add_argument(
+        "--run",
+        action="append",
+        required=True,
+        help="Run spec in format LABEL=PATH (or just PATH). Repeat for multiple runs.",
+    )
+    parser.add_argument("--title", type=str, default="Validation loss per iteration")
+    parser.add_argument("--output", type=str, default="validation_loss_comparison.png")
+    args = parser.parse_args()
+
+    plt.figure(figsize=(9, 5))
+    for run_spec in args.run:
+        label, run_dir = parse_run(run_spec)
+        steps, losses = load_eval_curve(run_dir)
+        plt.plot(steps, losses, marker="o", linewidth=1.5, markersize=3, label=label)
+
+    plt.title(args.title)
+    plt.xlabel("Global step")
+    plt.ylabel("Validation loss")
+    plt.grid(alpha=0.3)
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(args.output, dpi=150)
+    print(f"Saved plot to: {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide experimental support for replacing or blending the attention softmax with ReLU-based variants and to run controlled EN→ES translation finetuning experiments. 
- Add utilities to benchmark generation quality and visualize validation loss across different attention variants.

### Description
- Extend `finetune.py` with new CLI options (`--attention_mode`, `--attention_activation`, `--activation_divisor`, `--alpha_start`, `--alpha_end`, `--post_zero_steps`, `--blend_output_norm`, language/dataset options) and implement `BlendController`, `AlphaScheduleCallback`, and an expanded `SampleOutputCallback` for multi-language prompts. 
- Implement ReLU-based attention alternatives (`relumax` and `relu2max`) and support three attention modes: `softmax`, `sum` (softmax + relu variant), and `gradual_blend` (alpha-annealed mix), by monkey-patching `torch.nn.functional.softmax` during training and restoring it afterward. 
- Add output-norm blending by wrapping layernorm forwards for targeted modules when enabled, and print multi-shot EN→ES examples after training via `_print_multishot_examples`. 
- Add `benchmark_en_es_translation.py` to run simple exact-match/BLEU/chrF benchmarks for EN→ES on a dataset slice and `plot_validation_loss.py` to plot validation loss vs global step from `trainer_state.json`. 
- Update the README `huggingface_model/gemma/270M/README.md` with an experiment sequence (Gradual blend, Baseline, Sum baseline), example commands, and notes about the softmax monkey-patch being experimental.

### Testing
- Performed smoke checks by invoking the CLI help for `finetune.py`, `benchmark_en_es_translation.py`, and `plot_validation_loss.py`, and confirmed they import and display usage successfully. 
- Verified that `finetune.py` installs and restores the original `F.softmax` and that the new callbacks initialize without runtime errors in a dry import/run; no unit tests were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddd9292d788326a593feaae2330c66)