### PR TITLE
feat(training): add validation passage colorization timeline and TUI viewer

### DIFF
--- a/colorize_dataset.py
+++ b/colorize_dataset.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 
 import argparse, io, pickle, math
 from pathlib import Path
-from typing import Callable, List, Sequence
+from typing import Any, Callable, List, Sequence
 
 import numpy as np
 import torch, torch.nn.functional as F
@@ -67,6 +67,30 @@ def _colour(ids: List[int], scalars: List[float], decode: Callable[[Sequence[int
             token = _escape_ws(token)
         out.append(token, style=f"bold #{r:02x}{g:02x}00")
     return out
+
+
+def build_colorized_token_rows(
+    ids: List[int],
+    scalars: List[float],
+    decode: Callable[[Sequence[int]], str],
+    escape_ws: bool = True,
+) -> List[dict[str, Any]]:
+    rows: List[dict[str, Any]] = []
+    vals = torch.tensor(scalars, dtype=torch.float32)
+    norm = (vals - vals.min()) / (vals.max() - vals.min() + 1e-6)
+    for tid, scalar, heat in zip(ids, scalars, norm.tolist()):
+        token = decode([tid])
+        if escape_ws:
+            token = _escape_ws(token)
+        rows.append(
+            {
+                "token_id": int(tid),
+                "token": token,
+                "scalar": float(scalar),
+                "heat": float(heat),
+            }
+        )
+    return rows
 
 # byte-fallback helpers -------------------------------------------------------
 

--- a/demos/linux_commands_colorized_tui_demo.sh
+++ b/demos/linux_commands_colorized_tui_demo.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# demos/linux_commands_colorized_tui_demo.sh
+#
+# End-to-end demo:
+# 1) Build a small segment of the linux-commands dataset
+# 2) Train briefly with validation-passage colorization enabled
+# 3) Launch the passage timeline TUI
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+DATASET="linux-commands"
+OUT_DIR="out/linux_commands_colorize_demo"
+YAML_FILE="${OUT_DIR}/highlighted_passage.yaml"
+
+pushd "data/${DATASET}" >/dev/null
+
+# Fetch english split if needed (creates input.txt)
+if [[ ! -f input.txt ]]; then
+  bash get_dataset.sh eng
+fi
+
+# Use only a small segment so the demo runs quickly
+head -n 1200 input.txt > demo_segment.txt
+
+# Tokenize the segment into train.bin/val.bin for this dataset
+python3 prepare.py \
+  -t demo_segment.txt \
+  --method tiktoken \
+  --train_output train.bin \
+  --val_output val.bin \
+  -p 0.9
+
+popd >/dev/null
+
+python3 train.py \
+  --dataset "${DATASET}" \
+  --out_dir "${OUT_DIR}" \
+  --device cpu \
+  --dtype float32 \
+  --n_layer 2 \
+  --n_head 2 \
+  --n_embd 128 \
+  --block_size 64 \
+  --batch_size 8 \
+  --max_iters 60 \
+  --eval_interval 20 \
+  --eval_iters 20 \
+  --log_interval 20 \
+  --no-compile \
+  --no-tensorboard_log \
+  --colorize_val_passage \
+  --colorize_val_tokens 80 \
+  --colorize_val_offset 0 \
+  --colorize_val_mode softmax \
+  --colorize_val_yaml highlighted_passage.yaml
+
+echo "Launching TUI viewer for ${YAML_FILE}"
+python3 view_colorized_passages.py --yaml_file "${YAML_FILE}"

--- a/tests/test_colorize_dataset_helpers.py
+++ b/tests/test_colorize_dataset_helpers.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from colorize_dataset import build_colorized_token_rows
+
+
+def test_build_colorized_token_rows_shape_and_fields():
+    ids = [1, 2, 3]
+    scalars = [0.2, 0.8, 0.5]
+
+    def decode_fn(values):
+        return f"T{values[0]}"
+
+    rows = build_colorized_token_rows(ids, scalars, decode_fn)
+
+    assert len(rows) == 3
+    assert rows[0]["token_id"] == 1
+    assert rows[0]["token"] == "T1"
+    assert abs(rows[1]["scalar"] - 0.8) < 1e-8
+    for row in rows:
+        assert 0.0 <= row["heat"] <= 1.0

--- a/train.py
+++ b/train.py
@@ -9,6 +9,7 @@ import pickle
 import shutil
 import sys
 import time
+import yaml
 from collections import deque
 from datetime import datetime, timedelta
 
@@ -84,6 +85,9 @@ from torch.utils.tensorboard import SummaryWriter
 from variations.model_variations import model_variation_dictionary
 
 from model import GPT, GPTConfig
+from colorize_dataset import _ansi as colorize_ansi
+from colorize_dataset import _colour as colorize_text
+from colorize_dataset import build_colorized_token_rows
 
 # Inference related imports
 import tiktoken
@@ -152,6 +156,8 @@ class Trainer:
             'min': 0.0,
             'abs_max': 0.0,
         }
+        self.colorized_passage_history = []
+        self.colorized_passage_yaml_path = None
 
         # whether to show all model stats
         self.compute_model_stats = self.args.compute_model_stats
@@ -174,6 +180,15 @@ class Trainer:
             sample_dir = os.path.dirname(self.args.sample_file)
             if sample_dir and not os.path.exists(sample_dir):
                 os.makedirs(sample_dir, exist_ok=True)
+
+        if getattr(self.args, "colorize_val_passage", False):
+            color_yaml = os.path.expanduser(self.args.colorize_val_yaml)
+            if not os.path.isabs(color_yaml):
+                color_yaml = os.path.join(self.args.out_dir, color_yaml)
+            color_yaml_dir = os.path.dirname(color_yaml)
+            if color_yaml_dir and not os.path.exists(color_yaml_dir):
+                os.makedirs(color_yaml_dir, exist_ok=True)
+            self.colorized_passage_yaml_path = color_yaml
 
         # calculation on end time via eval cycle
         self.eval_cycle_window = deque(maxlen=self.args.eval_cycle_window)
@@ -737,6 +752,73 @@ class Trainer:
                     self.writer.add_scalar(f"dataset_benchmarks/{mk}", mv, self.iter_num)
         except Exception as e:
             print(f"Error running dataset benchmarks: {e}")
+
+    def _get_colorize_val_data_and_decode(self, dataset_name=None):
+        if self.args.training_mode == 'multicontext':
+            target_dataset = dataset_name or self.args.multicontext_datasets[0]
+            val_data = self.val_data_dict[target_dataset]
+            decode_fn = self.decode_dict[target_dataset] if hasattr(self, 'decode_dict') else self.decode
+            return target_dataset, val_data, decode_fn
+        if self.args.training_mode == 'multidataset':
+            if dataset_name is None:
+                target_dataset = self.args.dataset_list[0]
+            else:
+                target_dataset = dataset_name
+            val_data = self.val_data_dict[target_dataset]
+            decode_fn = self.decode_dict[target_dataset] if hasattr(self, 'decode_dict') else self.decode
+            return target_dataset, val_data, decode_fn
+        return self.args.dataset, self.val_data, self.decode
+
+    @torch.no_grad()
+    def save_colorized_validation_passage(self, losses, dataset_name=None):
+        if not self.args.colorize_val_passage or self.colorized_passage_yaml_path is None:
+            return
+
+        target_dataset, val_data, decode_fn = self._get_colorize_val_data_and_decode(dataset_name)
+        if len(val_data) <= 2:
+            return
+
+        num_tokens = max(int(self.args.colorize_val_tokens), 1)
+        max_tokens = min(num_tokens, len(val_data) - 2)
+        if max_tokens <= 0:
+            return
+
+        block_size = self.args.block_size
+        max_start = max(0, len(val_data) - max_tokens - 1)
+        start = min(max(int(self.args.colorize_val_offset), 0), max_start)
+
+        ids = []
+        scalars = []
+        for relative_idx in range(max_tokens):
+            pos = start + relative_idx
+            ctx_start = max(0, pos - block_size + 1)
+            ctx = torch.from_numpy(val_data[ctx_start:pos + 1].astype(np.int64))[None, :].to(self.device)
+            with self.ctx:
+                logits, _ = self.model(ctx)
+            logits_last = logits[0, -1, :]
+            target_token = int(val_data[pos + 1])
+            if self.args.colorize_val_mode == "softmax":
+                scalar = float(F.softmax(logits_last, dim=-1)[target_token].item())
+            else:
+                scalar = float(logits_last[target_token].item())
+            ids.append(target_token)
+            scalars.append(scalar)
+
+        colorized_text = colorize_text(ids, scalars, decode_fn, escape_ws=True)
+        record = {
+            "iter_num": int(self.iter_num),
+            "dataset": target_dataset,
+            "val_loss": float(losses["val"]),
+            "offset": int(start),
+            "num_tokens": int(max_tokens),
+            "mode": self.args.colorize_val_mode,
+            "ansi": colorize_ansi(colorized_text),
+            "tokens": build_colorized_token_rows(ids, scalars, decode_fn, escape_ws=True),
+        }
+        self.colorized_passage_history.append(record)
+
+        with open(self.colorized_passage_yaml_path, "w", encoding="utf-8") as fout:
+            yaml.safe_dump(self.colorized_passage_history, fout, sort_keys=False, allow_unicode=True)
 
     def load_data(self):
         def _dataset_bin_dtype(dataset_name):
@@ -1873,6 +1955,8 @@ class Trainer:
             with open(self.args.out_dir + "/nan_iter_num.txt", 'w') as file:
                 print("Exiting with nan")
                 file.write(str(self.iter_num))
+
+        self.save_colorized_validation_passage(losses, current_dataset)
 
         if (not self.args.never_save_checkpoint and
             self.args.save_major_ckpt_interval is not None):

--- a/train_args.py
+++ b/train_args.py
@@ -233,6 +233,11 @@ def parse_args():
     training_group.add_argument('--sample_only', default=False, action=argparse.BooleanOptionalAction, help="Run only the sampling process and exit")
     training_group.add_argument('--dataset_benchmarks', default=False, action=argparse.BooleanOptionalAction, help="Run dataset benchmark metrics on a random slice after each validation")
     training_group.add_argument('--sample_metrics', default=False, action=argparse.BooleanOptionalAction, help="Display sample metrics like spelling correctness during sampling")
+    training_group.add_argument('--colorize_val_passage', default=False, action=argparse.BooleanOptionalAction, help="At each validation interval, colorize a validation passage and append it to a YAML timeline.")
+    training_group.add_argument('--colorize_val_tokens', default=128, type=int, help="Number of target tokens to colorize during validation passage dumps.")
+    training_group.add_argument('--colorize_val_offset', default=0, type=int, help="Start offset into val.bin for validation passage colorization.")
+    training_group.add_argument('--colorize_val_mode', choices=['softmax', 'minmax'], default='softmax', help="Scoring mode for validation passage colorization.")
+    training_group.add_argument('--colorize_val_yaml', default='highlighted_passage.yaml', type=str, help="Path (or filename under out_dir) for saving colorized validation passages as YAML.")
 
     # Checkpoint args
     training_group.add_argument('--save_major_ckpt_interval', default=None, type=int, help="Interval for saving major checkpoints.")

--- a/view_colorized_passages.py
+++ b/view_colorized_passages.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""TUI viewer for highlighted_passage.yaml timelines.
+
+Use Left/Right arrows (or h/l) to move between snapshots created during
+training via --colorize_val_passage.
+"""
+
+import argparse
+from pathlib import Path
+
+import yaml
+from rich.panel import Panel
+from rich.text import Text
+from textual.app import App, ComposeResult
+from textual.widgets import Footer, Header, Static
+
+
+class PassageViewer(App):
+    BINDINGS = [
+        ("left", "prev", "Prev"),
+        ("right", "next", "Next"),
+        ("h", "prev", "Prev"),
+        ("l", "next", "Next"),
+        ("q", "quit", "Quit"),
+    ]
+
+    def __init__(self, records):
+        super().__init__()
+        self.records = records
+        self.index = 0
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        yield Static(id="passage")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self._render_current()
+
+    def action_prev(self) -> None:
+        if self.index > 0:
+            self.index -= 1
+            self._render_current()
+
+    def action_next(self) -> None:
+        if self.index < len(self.records) - 1:
+            self.index += 1
+            self._render_current()
+
+    def _render_current(self) -> None:
+        record = self.records[self.index]
+        ansi = record.get("ansi", "")
+        passage_text = Text.from_ansi(ansi)
+        title = (
+            f"{self.index + 1}/{len(self.records)}  "
+            f"iter={record.get('iter_num')}  dataset={record.get('dataset')}  "
+            f"val_loss={record.get('val_loss'):.6f}"
+        )
+        self.query_one("#passage", Static).update(Panel(passage_text, title=title))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="View colorized validation passages over time")
+    parser.add_argument("--yaml_file", default="highlighted_passage.yaml")
+    args = parser.parse_args()
+
+    yaml_path = Path(args.yaml_file)
+    if not yaml_path.exists():
+        raise FileNotFoundError(f"YAML file not found: {yaml_path}")
+
+    records = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or []
+    if not isinstance(records, list) or len(records) == 0:
+        raise ValueError(f"No records found in {yaml_path}")
+
+    PassageViewer(records).run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide an opt-in way to dump a colorized view of a validation passage at every validation interval so users can visualise how token-level model confidence/heatmaps evolve over training.
- Persist colorized snapshots to a simple YAML timeline so external tools (and a TUI) can replay progression over time.
- Reuse the existing colour rendering utilities and add a structured token-row serializer suitable for YAML and downstream inspection.

### Description
- Added new training CLI options in `train_args.py`: `--colorize_val_passage`, `--colorize_val_tokens`, `--colorize_val_offset`, `--colorize_val_mode` (choices `softmax`/`minmax`), and `--colorize_val_yaml` (default `highlighted_passage.yaml`).
- Added `build_colorized_token_rows(...)` to `colorize_dataset.py` to produce YAML-friendly token records with `token_id`, `token`, `scalar`, and normalized `heat` fields.
- Extended `train.py` to optionally compute a colorized passage from `val.bin` at each validation interval, serialize an ANSI-rendered passage plus token rows and metadata into a timeline list, and write that list to the configured YAML file under `out_dir` by default.
- Added a small Textual TUI `view_colorized_passages.py` that loads the YAML timeline and lets users navigate snapshots with left/right (or `h`/`l`) keys; it renders the stored ANSI to reproduce colored passages.
- Added a focused unit test `tests/test_colorize_dataset_helpers.py` that verifies the shape and fields produced by `build_colorized_token_rows`.

### Testing
- Compiled the modified modules: `python -m py_compile train.py train_args.py colorize_dataset.py view_colorized_passages.py tests/test_colorize_dataset_helpers.py` (succeeded).
- Ran the new test with `pytest -q tests/test_colorize_dataset_helpers.py`, but collection failed in this environment due to a missing system dependency (`numpy`) so the test could not be executed here (test file itself is present and imports corrected for repo-relative import).
- Basic smoke checks: the new TUI script parses YAML and renders stored ANSI; model-time integration path exercised via `py_compile` (no runtime model execution was performed in CI due to environment constraints).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08cffd2a48326afa53a02fcadc336)