### PR TITLE
feat(gemma-270m): add vocab angle component analysis script

### DIFF
--- a/huggingface_model/gemma/270M/README.md
+++ b/huggingface_model/gemma/270M/README.md
@@ -135,9 +135,15 @@ Outputs:
 * `digit_<d>_relative_angles.png` one plot per digit, showing baseline vs all
   quantized curves against all other digits.
 * `digit_token_ids.csv` for the resolved token IDs.
+* `tsne_structure_all_modes.png` for approximate global structure view.
+* `distortion_<token>.png` signed angular distortion per token vs fp32 baseline.
+* `relative_angles_selector.html` interactive Plotly page with token dropdown and
+  per-quantization disorder labels indicating rank-order changes vs fp32.
 
 Demo:
 
 ```bash
 bash ./demo_digit_quant_angles.sh
+bash ./demo_weekday_quant_angles.sh
+bash ./demo_month_quant_angles.sh
 ```

--- a/huggingface_model/gemma/270M/README.md
+++ b/huggingface_model/gemma/270M/README.md
@@ -119,3 +119,25 @@ python huggingface_model/gemma/270M/vocab_angle_explorer_app.py \
   --port 8050 \
   --output-dir ./gemma_angle_explorer_exports
 ```
+
+## Digit-only quantization angle comparison
+
+`digit_quant_angle_comparison.py` compares pairwise angles for digits `0-9`
+under full precision (`fp32`) and symmetric quantization modes:
+
+* int8, int7, int6, int5, int4, int3
+* ternary
+* binary
+
+Outputs:
+
+* `angles_<mode>.csv` angle matrix for each mode.
+* `digit_<d>_relative_angles.png` one plot per digit, showing baseline vs all
+  quantized curves against all other digits.
+* `digit_token_ids.csv` for the resolved token IDs.
+
+Demo:
+
+```bash
+bash huggingface_model/gemma/270M/demo_digit_quant_angles.sh
+```

--- a/huggingface_model/gemma/270M/README.md
+++ b/huggingface_model/gemma/270M/README.md
@@ -83,10 +83,10 @@ Highlights:
 Demo scripts:
 
 ```bash
-bash huggingface_model/gemma/270M/demo_angle_dashboard_digits.sh
-bash huggingface_model/gemma/270M/demo_angle_dashboard_months.sh
-bash huggingface_model/gemma/270M/demo_angle_dashboard_weekdays.sh
-bash huggingface_model/gemma/270M/demo_islands_20deg.sh
+bash ./demo_angle_dashboard_digits.sh
+bash ./demo_angle_dashboard_months.sh
+bash ./demo_angle_dashboard_weekdays.sh
+bash ./demo_islands_20deg.sh
 ```
 
 ## Interactive webapp: angle-neighborhood explorer (Gemma + Gemma-IT)
@@ -112,7 +112,7 @@ Features:
 Run:
 
 ```bash
-python huggingface_model/gemma/270M/vocab_angle_explorer_app.py \
+python ./vocab_angle_explorer_app.py \
   --model-base google/gemma-3-270m \
   --model-it google/gemma-3-270m-it \
   --device cpu \
@@ -139,5 +139,5 @@ Outputs:
 Demo:
 
 ```bash
-bash huggingface_model/gemma/270M/demo_digit_quant_angles.sh
+bash ./demo_digit_quant_angles.sh
 ```

--- a/huggingface_model/gemma/270M/README.md
+++ b/huggingface_model/gemma/270M/README.md
@@ -88,3 +88,34 @@ bash huggingface_model/gemma/270M/demo_angle_dashboard_months.sh
 bash huggingface_model/gemma/270M/demo_angle_dashboard_weekdays.sh
 bash huggingface_model/gemma/270M/demo_islands_20deg.sh
 ```
+
+## Interactive webapp: angle-neighborhood explorer (Gemma + Gemma-IT)
+
+`vocab_angle_explorer_app.py` runs a local Dash webapp that compares:
+
+* `google/gemma-3-270m`
+* `google/gemma-3-270m-it`
+
+It visualizes, per selected token, how many vocab vectors fall within angle
+bins over a configurable range (defaults `10` to `90` degrees with 10-degree
+stack bins).
+
+Features:
+
+* Presets: `digits` (default), `weekdays`, `months`, `alphabet`, `all`
+* Regex token filter
+* Sort mode: alphabetical, highest→lowest, lowest→highest
+* Stacked histogram in both models
+* Click a token bar, then export a CSV listing all tokens with:
+  token id, degree separation, dot product, normalized dot product
+
+Run:
+
+```bash
+python huggingface_model/gemma/270M/vocab_angle_explorer_app.py \
+  --model-base google/gemma-3-270m \
+  --model-it google/gemma-3-270m-it \
+  --device cpu \
+  --port 8050 \
+  --output-dir ./gemma_angle_explorer_exports
+```

--- a/huggingface_model/gemma/270M/README.md
+++ b/huggingface_model/gemma/270M/README.md
@@ -64,3 +64,27 @@ python huggingface_model/gemma/270M/jl_head_eval.py \
   --annotate_stats true \
   --output_dir jl_eval_outputs
 ```
+
+## Token-angle dashboard + island exports
+
+`vocab_angle_token_dashboard.py` adds an interactive Plotly dashboard for selected
+tokens and exports connected-component island files for the full vocab graph at a
+chosen angle threshold.
+
+Highlights:
+
+* `--tokens`: comma-separated tokens to inspect (e.g., digits, months, weekdays).
+* `selected_token_dashboard.html`: interactive histogram + token-id scatter of
+  selected-token angles to the rest of the vocab.
+* `selected_token_reports/*.csv`: per-selected-token nearest-angle lists.
+* `islands/*.txt`: one uniquely named file per connected island (`uuid` suffix),
+  with token id, token string, and graph degree.
+
+Demo scripts:
+
+```bash
+bash huggingface_model/gemma/270M/demo_angle_dashboard_digits.sh
+bash huggingface_model/gemma/270M/demo_angle_dashboard_months.sh
+bash huggingface_model/gemma/270M/demo_angle_dashboard_weekdays.sh
+bash huggingface_model/gemma/270M/demo_islands_20deg.sh
+```

--- a/huggingface_model/gemma/270M/demo_angle_dashboard_digits.sh
+++ b/huggingface_model/gemma/270M/demo_angle_dashboard_digits.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python huggingface_model/gemma/270M/vocab_angle_token_dashboard.py \
+  --model google/gemma-3-270m \
+  --tokens '0,1,2,3,4,5,6,7,8,9' \
+  --angle-threshold-deg 70 \
+  --chunk-size 512 \
+  --device cpu \
+  --output-dir ./gemma_angle_dashboard_digits

--- a/huggingface_model/gemma/270M/demo_angle_dashboard_digits.sh
+++ b/huggingface_model/gemma/270M/demo_angle_dashboard_digits.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-python huggingface_model/gemma/270M/vocab_angle_token_dashboard.py \
+python ./vocab_angle_token_dashboard.py \
   --model google/gemma-3-270m \
   --tokens '0,1,2,3,4,5,6,7,8,9' \
   --angle-threshold-deg 70 \

--- a/huggingface_model/gemma/270M/demo_angle_dashboard_months.sh
+++ b/huggingface_model/gemma/270M/demo_angle_dashboard_months.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-python huggingface_model/gemma/270M/vocab_angle_token_dashboard.py \
+python ./vocab_angle_token_dashboard.py \
   --model google/gemma-3-270m \
   --tokens 'January,February,March,April,May,June,July,August,September,October,November,December' \
   --angle-threshold-deg 70 \

--- a/huggingface_model/gemma/270M/demo_angle_dashboard_months.sh
+++ b/huggingface_model/gemma/270M/demo_angle_dashboard_months.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python huggingface_model/gemma/270M/vocab_angle_token_dashboard.py \
+  --model google/gemma-3-270m \
+  --tokens 'January,February,March,April,May,June,July,August,September,October,November,December' \
+  --angle-threshold-deg 70 \
+  --chunk-size 512 \
+  --device cpu \
+  --output-dir ./gemma_angle_dashboard_months

--- a/huggingface_model/gemma/270M/demo_angle_dashboard_weekdays.sh
+++ b/huggingface_model/gemma/270M/demo_angle_dashboard_weekdays.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python huggingface_model/gemma/270M/vocab_angle_token_dashboard.py \
+  --model google/gemma-3-270m \
+  --tokens 'Monday,Tuesday,Wednesday,Thursday,Friday,Saturday,Sunday' \
+  --angle-threshold-deg 70 \
+  --chunk-size 512 \
+  --device cpu \
+  --output-dir ./gemma_angle_dashboard_weekdays

--- a/huggingface_model/gemma/270M/demo_angle_dashboard_weekdays.sh
+++ b/huggingface_model/gemma/270M/demo_angle_dashboard_weekdays.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-python huggingface_model/gemma/270M/vocab_angle_token_dashboard.py \
+python ./vocab_angle_token_dashboard.py \
   --model google/gemma-3-270m \
   --tokens 'Monday,Tuesday,Wednesday,Thursday,Friday,Saturday,Sunday' \
   --angle-threshold-deg 70 \

--- a/huggingface_model/gemma/270M/demo_digit_quant_angles.sh
+++ b/huggingface_model/gemma/270M/demo_digit_quant_angles.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-python huggingface_model/gemma/270M/digit_quant_angle_comparison.py \
+python ./digit_quant_angle_comparison.py \
   --model google/gemma-3-270m \
   --embedding-source input \
   --device cpu \

--- a/huggingface_model/gemma/270M/demo_digit_quant_angles.sh
+++ b/huggingface_model/gemma/270M/demo_digit_quant_angles.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python huggingface_model/gemma/270M/digit_quant_angle_comparison.py \
+  --model google/gemma-3-270m \
+  --embedding-source input \
+  --device cpu \
+  --output-dir ./gemma_digit_quant_angles

--- a/huggingface_model/gemma/270M/demo_islands_20deg.sh
+++ b/huggingface_model/gemma/270M/demo_islands_20deg.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python huggingface_model/gemma/270M/vocab_angle_token_dashboard.py \
+  --model google/gemma-3-270m \
+  --tokens '0,1,2,3,4,5,6,7,8,9' \
+  --angle-threshold-deg 20 \
+  --chunk-size 512 \
+  --device cpu \
+  --min-island-size 2 \
+  --output-dir ./gemma_islands_20deg

--- a/huggingface_model/gemma/270M/demo_islands_20deg.sh
+++ b/huggingface_model/gemma/270M/demo_islands_20deg.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-python huggingface_model/gemma/270M/vocab_angle_token_dashboard.py \
+python ./vocab_angle_token_dashboard.py \
   --model google/gemma-3-270m \
   --tokens '0,1,2,3,4,5,6,7,8,9' \
   --angle-threshold-deg 20 \

--- a/huggingface_model/gemma/270M/demo_month_quant_angles.sh
+++ b/huggingface_model/gemma/270M/demo_month_quant_angles.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python ./month_quant_angle_comparison.py \
+  --model google/gemma-3-270m \
+  --embedding-source input \
+  --device cpu \
+  --output-dir ./gemma_month_quant_angles

--- a/huggingface_model/gemma/270M/demo_weekday_quant_angles.sh
+++ b/huggingface_model/gemma/270M/demo_weekday_quant_angles.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python ./weekday_quant_angle_comparison.py \
+  --model google/gemma-3-270m \
+  --embedding-source input \
+  --device cpu \
+  --output-dir ./gemma_weekday_quant_angles

--- a/huggingface_model/gemma/270M/digit_quant_angle_comparison.py
+++ b/huggingface_model/gemma/270M/digit_quant_angle_comparison.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Compare pairwise digit-token angles before/after symmetric quantization."""
+from __future__ import annotations
+
+import argparse
+import math
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Digit angle comparison across quantization levels")
+    p.add_argument("--model", default="google/gemma-3-270m")
+    p.add_argument("--embedding-source", choices=["input", "lm_head"], default="input")
+    p.add_argument("--device", default="cpu")
+    p.add_argument("--output-dir", default="./gemma_digit_quant_angles")
+    return p.parse_args()
+
+
+def _resolve_digit_ids(tokenizer: AutoTokenizer) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for d in range(10):
+        text = str(d)
+        tid = tokenizer.convert_tokens_to_ids(text)
+        if tid is None or tid == tokenizer.unk_token_id:
+            ids = tokenizer(text, add_special_tokens=False)["input_ids"]
+            if not ids:
+                raise ValueError(f"Could not tokenize digit {text}")
+            tid = int(ids[0])
+        out[text] = int(tid)
+    return out
+
+
+def _symmetric_quantize(vecs: np.ndarray, mode: str) -> np.ndarray:
+    x = vecs.copy()
+    max_abs = np.max(np.abs(x), axis=1, keepdims=True)
+    max_abs[max_abs == 0] = 1.0
+
+    if mode == "binary":
+        q = np.where(x >= 0, 1.0, -1.0)
+        return q * max_abs
+    if mode == "ternary":
+        thr = 0.5 * max_abs
+        q = np.zeros_like(x)
+        q[x > thr] = 1.0
+        q[x < -thr] = -1.0
+        return q * max_abs
+
+    bits = int(mode)
+    qmax = (2 ** (bits - 1)) - 1
+    scale = max_abs / qmax
+    q = np.round(x / scale)
+    q = np.clip(q, -qmax, qmax)
+    return q * scale
+
+
+def _pairwise_angles(vecs: np.ndarray) -> np.ndarray:
+    n = vecs / np.clip(np.linalg.norm(vecs, axis=1, keepdims=True), 1e-12, None)
+    cos = np.clip(n @ n.T, -1.0, 1.0)
+    return np.degrees(np.arccos(cos))
+
+
+def _write_matrix_csv(path: Path, labels: list[str], matrix: np.ndarray) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        f.write("digit," + ",".join(labels) + "\n")
+        for i, d in enumerate(labels):
+            vals = ",".join(f"{matrix[i, j]:.6f}" for j in range(len(labels)))
+            f.write(f"{d},{vals}\n")
+
+
+def _plot_per_digit(output_dir: Path, digits: list[str], angles_by_mode: dict[str, np.ndarray]) -> None:
+    modes = list(angles_by_mode.keys())
+    x = np.arange(len(digits))
+    for i, d in enumerate(digits):
+        plt.figure(figsize=(11, 5))
+        for mode in modes:
+            y = angles_by_mode[mode][i]
+            plt.plot(x, y, marker="o", label=mode)
+        plt.xticks(x, digits)
+        plt.title(f"Digit {d}: relative angles to digits 0-9")
+        plt.xlabel("Other digit")
+        plt.ylabel("Angle (degrees)")
+        plt.grid(alpha=0.3)
+        plt.legend(ncol=3, fontsize=8)
+        plt.tight_layout()
+        plt.savefig(output_dir / f"digit_{d}_relative_angles.png", dpi=180)
+        plt.close()
+
+
+def main() -> None:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    model = AutoModelForCausalLM.from_pretrained(args.model, attn_implementation="eager")
+
+    emb = model.get_input_embeddings().weight.detach() if args.embedding_source == "input" else model.lm_head.weight.detach()
+    emb = emb.to(args.device, dtype=torch.float32)
+
+    digit_ids = _resolve_digit_ids(tokenizer)
+    digits = [str(i) for i in range(10)]
+    id_list = [digit_ids[d] for d in digits]
+
+    vecs = emb[id_list].cpu().numpy()
+    quant_modes = ["fp32", "8", "7", "6", "5", "4", "3", "ternary", "binary"]
+
+    angles_by_mode: dict[str, np.ndarray] = {}
+    for mode in quant_modes:
+        qvecs = vecs if mode == "fp32" else _symmetric_quantize(vecs, mode)
+        angles = _pairwise_angles(qvecs)
+        angles_by_mode[mode] = angles
+        _write_matrix_csv(output_dir / f"angles_{mode}.csv", digits, angles)
+
+    with (output_dir / "digit_token_ids.csv").open("w", encoding="utf-8") as f:
+        f.write("digit,token_id,token\n")
+        for d in digits:
+            tid = digit_ids[d]
+            tok = tokenizer.convert_ids_to_tokens(tid)
+            f.write(f"{d},{tid},{tok}\n")
+
+    _plot_per_digit(output_dir, digits, angles_by_mode)
+
+    with (output_dir / "summary.txt").open("w", encoding="utf-8") as f:
+        f.write(f"model={args.model}\n")
+        f.write(f"embedding_source={args.embedding_source}\n")
+        f.write(f"quant_modes={','.join(quant_modes)}\n")
+        f.write("outputs=angles_*.csv,digit_*_relative_angles.png,digit_token_ids.csv\n")
+
+    print(f"Done. Wrote outputs to {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/huggingface_model/gemma/270M/month_quant_angle_comparison.py
+++ b/huggingface_model/gemma/270M/month_quant_angle_comparison.py
@@ -8,17 +8,17 @@ from token_quant_angle_comparison import run_analysis
 
 
 def parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(description="Digit quantization angle comparison")
+    p = argparse.ArgumentParser(description="Month quantization angle comparison")
     p.add_argument("--model", default="google/gemma-3-270m")
     p.add_argument("--embedding-source", choices=["input", "lm_head"], default="input")
     p.add_argument("--device", default="cpu")
-    p.add_argument("--output-dir", default="./gemma_digit_quant_angles")
+    p.add_argument("--output-dir", default="./gemma_month_quant_angles")
     return p.parse_args()
 
 
 def main() -> None:
     a = parse_args()
-    run_analysis("digits", a.model, a.embedding_source, a.device, Path(a.output_dir))
+    run_analysis("months", a.model, a.embedding_source, a.device, Path(a.output_dir))
 
 
 if __name__ == "__main__":

--- a/huggingface_model/gemma/270M/token_quant_angle_comparison.py
+++ b/huggingface_model/gemma/270M/token_quant_angle_comparison.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import plotly.graph_objects as go
+import torch
+from sklearn.manifold import TSNE
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+PRESETS = {
+    "digits": [str(i) for i in range(10)],
+    "weekdays": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"],
+    "months": [
+        "January", "February", "March", "April", "May", "June",
+        "July", "August", "September", "October", "November", "December",
+    ],
+}
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Quantization angle analysis for token sets")
+    p.add_argument("--model", default="google/gemma-3-270m")
+    p.add_argument("--embedding-source", choices=["input", "lm_head"], default="input")
+    p.add_argument("--device", default="cpu")
+    p.add_argument("--preset", choices=["digits", "weekdays", "months"], default="digits")
+    p.add_argument("--output-dir", default="./gemma_token_quant_angles")
+    return p.parse_args()
+
+
+def _resolve_ids(tokenizer: AutoTokenizer, tokens: list[str]) -> list[int]:
+    out = []
+    for t in tokens:
+        tid = tokenizer.convert_tokens_to_ids(t)
+        if tid is None or tid == tokenizer.unk_token_id:
+            ids = tokenizer(t, add_special_tokens=False)["input_ids"]
+            if not ids:
+                raise ValueError(f"Could not tokenize token {t}")
+            tid = int(ids[0])
+        out.append(int(tid))
+    return out
+
+
+def _symmetric_quantize(vecs: np.ndarray, mode: str) -> np.ndarray:
+    x = vecs.copy()
+    max_abs = np.max(np.abs(x), axis=1, keepdims=True)
+    max_abs[max_abs == 0] = 1.0
+    if mode == "binary":
+        return np.where(x >= 0, 1.0, -1.0) * max_abs
+    if mode == "ternary":
+        thr = 0.5 * max_abs
+        q = np.zeros_like(x)
+        q[x > thr] = 1.0
+        q[x < -thr] = -1.0
+        return q * max_abs
+    bits = int(mode)
+    qmax = (2 ** (bits - 1)) - 1
+    scale = max_abs / qmax
+    q = np.round(x / scale)
+    q = np.clip(q, -qmax, qmax)
+    return q * scale
+
+
+def _angles(vecs: np.ndarray) -> np.ndarray:
+    n = vecs / np.clip(np.linalg.norm(vecs, axis=1, keepdims=True), 1e-12, None)
+    cos = np.clip(n @ n.T, -1.0, 1.0)
+    return np.degrees(np.arccos(cos))
+
+
+def _write_csv(path: Path, labels: list[str], matrix: np.ndarray) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        f.write("token," + ",".join(labels) + "\n")
+        for i, tok in enumerate(labels):
+            f.write(tok + "," + ",".join(f"{matrix[i, j]:.6f}" for j in range(len(labels))) + "\n")
+
+
+def _plot_tsne(out: Path, labels: list[str], vecs_by_mode: dict[str, np.ndarray]) -> None:
+    plt.figure(figsize=(11, 7))
+    for mode, vecs in vecs_by_mode.items():
+        tsne = TSNE(n_components=2, random_state=42, init="random", perplexity=max(2, min(5, len(labels)-1)))
+        pts = tsne.fit_transform(vecs)
+        plt.scatter(pts[:, 0], pts[:, 1], s=20, label=mode, alpha=0.7)
+    plt.title("t-SNE approximate structure across quantization modes")
+    plt.legend(ncol=3, fontsize=8)
+    plt.tight_layout()
+    plt.savefig(out / "tsne_structure_all_modes.png", dpi=180)
+    plt.close()
+
+
+def _plot_distortion_per_token(out: Path, labels: list[str], baseline: np.ndarray, angles_by_mode: dict[str, np.ndarray]) -> None:
+    x = np.arange(len(labels))
+    for i, tok in enumerate(labels):
+        plt.figure(figsize=(11, 5))
+        for mode, mat in angles_by_mode.items():
+            if mode == "fp32":
+                continue
+            delta = mat[i] - baseline[i]
+            plt.plot(x, delta, marker="o", label=mode)
+        plt.axhline(0.0, linestyle="--", color="black", linewidth=1)
+        plt.xticks(x, labels, rotation=45)
+        plt.ylabel("Angular distortion (deg, signed)")
+        plt.xlabel("Other token")
+        plt.title(f"Angular distortion direction/magnitude for {tok}")
+        plt.grid(alpha=0.3)
+        plt.legend(ncol=3, fontsize=8)
+        plt.tight_layout()
+        plt.savefig(out / f"distortion_{tok}.png", dpi=180)
+        plt.close()
+
+
+def _make_plotly_html(out: Path, labels: list[str], angles_by_mode: dict[str, np.ndarray]) -> None:
+    modes = list(angles_by_mode.keys())
+    baseline = angles_by_mode["fp32"]
+
+    fig = go.Figure()
+    for i, tok in enumerate(labels):
+        for mode in modes:
+            y = angles_by_mode[mode][i]
+            rank_base = np.argsort(baseline[i])
+            rank_cur = np.argsort(y)
+            disorder = (rank_cur != rank_base).sum()
+            name = f"{tok} | {mode} | disorder={int(disorder)}"
+            visible = i == 0
+            fig.add_trace(go.Scatter(x=labels, y=y, mode="lines+markers", name=name, visible=visible))
+
+    buttons = []
+    traces_per_token = len(modes)
+    for i, tok in enumerate(labels):
+        vis = [False] * (len(labels) * traces_per_token)
+        start = i * traces_per_token
+        for j in range(traces_per_token):
+            vis[start + j] = True
+        buttons.append(dict(label=tok, method="update", args=[{"visible": vis}, {"title": f"Relative angles for {tok}"}]))
+
+    fig.update_layout(
+        title=f"Relative angles for {labels[0]}",
+        xaxis_title="Other token",
+        yaxis_title="Angle (degrees)",
+        updatemenus=[dict(type="dropdown", buttons=buttons, x=1.02, y=1.0)],
+        margin=dict(l=40, r=220, t=60, b=120),
+    )
+    fig.write_html(str(out / "relative_angles_selector.html"), include_plotlyjs="cdn")
+
+
+def run_analysis(preset: str, model: str, embedding_source: str, device: str, output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    tokenizer = AutoTokenizer.from_pretrained(model)
+    m = AutoModelForCausalLM.from_pretrained(model, attn_implementation="eager")
+    emb = m.get_input_embeddings().weight.detach() if embedding_source == "input" else m.lm_head.weight.detach()
+    emb = emb.to(device, dtype=torch.float32)
+
+    labels = PRESETS[preset]
+    ids = _resolve_ids(tokenizer, labels)
+    vecs = emb[ids].cpu().numpy()
+
+    modes = ["fp32", "8", "7", "6", "5", "4", "3", "ternary", "binary"]
+    vecs_by_mode: dict[str, np.ndarray] = {}
+    angles_by_mode: dict[str, np.ndarray] = {}
+    for mode in modes:
+        q = vecs if mode == "fp32" else _symmetric_quantize(vecs, mode)
+        vecs_by_mode[mode] = q
+        ang = _angles(q)
+        angles_by_mode[mode] = ang
+        _write_csv(output_dir / f"angles_{mode}.csv", labels, ang)
+
+    with (output_dir / "token_ids.csv").open("w", encoding="utf-8") as f:
+        f.write("token,token_id,resolved_token\n")
+        for tok, tid in zip(labels, ids):
+            f.write(f"{tok},{tid},{tokenizer.convert_ids_to_tokens(tid)}\n")
+
+    _plot_tsne(output_dir, labels, vecs_by_mode)
+    _plot_distortion_per_token(output_dir, labels, angles_by_mode["fp32"], angles_by_mode)
+    _make_plotly_html(output_dir, labels, angles_by_mode)
+
+
+def main() -> None:
+    a = parse_args()
+    run_analysis(a.preset, a.model, a.embedding_source, a.device, Path(a.output_dir))
+
+
+if __name__ == "__main__":
+    main()

--- a/huggingface_model/gemma/270M/vocab_angle_explorer_app.py
+++ b/huggingface_model/gemma/270M/vocab_angle_explorer_app.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Dash webapp for Gemma vocab-angle neighborhood exploration."""
+from __future__ import annotations
+
+import argparse
+import math
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import dash
+from dash import Dash, Input, Output, State, dcc, html, no_update
+import numpy as np
+import plotly.graph_objects as go
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+PRESETS = {
+    "digits": [str(i) for i in range(10)],
+    "weekdays": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"],
+    "months": [
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
+    ],
+    "alphabet": list("abcdefghijklmnopqrstuvwxyz"),
+}
+
+
+@dataclass
+class ModelBundle:
+    name: str
+    tokenizer: AutoTokenizer
+    emb: torch.Tensor
+    emb_norm: torch.Tensor
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Gemma vocab-angle explorer webapp")
+    p.add_argument("--model-base", default="google/gemma-3-270m")
+    p.add_argument("--model-it", default="google/gemma-3-270m-it")
+    p.add_argument("--device", default="cpu")
+    p.add_argument("--dtype", choices=["float32", "float16", "bfloat16"], default="float32")
+    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument("--port", type=int, default=8050)
+    p.add_argument("--output-dir", default="./gemma_angle_explorer_exports")
+    p.add_argument("--max-selected-tokens", type=int, default=2000)
+    return p.parse_args()
+
+
+def _dtype(name: str) -> torch.dtype:
+    return {"float32": torch.float32, "float16": torch.float16, "bfloat16": torch.bfloat16}[name]
+
+
+def _load_bundle(model_name: str, device: str, dtype: torch.dtype) -> ModelBundle:
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(model_name, attn_implementation="eager")
+    emb = model.get_input_embeddings().weight.detach().to(device=device, dtype=dtype)
+    emb_norm = emb / emb.norm(dim=-1, keepdim=True).clamp_min(1e-12)
+    return ModelBundle(model_name, tokenizer, emb, emb_norm)
+
+
+def _resolve_token_id(tokenizer: AutoTokenizer, text: str) -> int | None:
+    tid = tokenizer.convert_tokens_to_ids(text)
+    if tid is not None and tid != tokenizer.unk_token_id:
+        return int(tid)
+    ids = tokenizer(text, add_special_tokens=False)["input_ids"]
+    if not ids:
+        return None
+    return int(ids[0])
+
+
+def _token_universe(bundle: ModelBundle) -> list[str]:
+    return [bundle.tokenizer.convert_ids_to_tokens(i) for i in range(bundle.emb.size(0))]
+
+
+def _apply_regex(tokens: Iterable[str], pattern: str) -> list[str]:
+    if not pattern.strip():
+        return list(tokens)
+    rgx = re.compile(pattern)
+    return [t for t in tokens if rgx.search(t)]
+
+
+def _get_selection(base_tokens: list[str], preset: str, regex: str, max_selected: int) -> list[str]:
+    if preset == "all":
+        selected = list(base_tokens)
+    else:
+        selected = PRESETS.get(preset, PRESETS["digits"])[:]
+    if regex.strip():
+        selected = _apply_regex(selected if preset != "all" else base_tokens, regex)
+    if len(selected) > max_selected:
+        selected = selected[:max_selected]
+    # preserve order + dedup
+    out: list[str] = []
+    seen = set()
+    for t in selected:
+        if t not in seen:
+            seen.add(t)
+            out.append(t)
+    return out
+
+
+def _stack_counts_for_model(
+    bundle: ModelBundle,
+    token_texts: list[str],
+    min_deg: float,
+    max_deg: float,
+    step_deg: float,
+) -> tuple[list[str], np.ndarray, list[str], list[int]]:
+    bins = np.arange(min_deg, max_deg + 1e-8, step_deg)
+    if bins.size < 2:
+        bins = np.array([min_deg, max_deg], dtype=np.float32)
+
+    labels = [f"({bins[i]:.0f},{bins[i+1]:.0f}]" for i in range(len(bins) - 1)]
+    token_ids: list[int] = []
+    resolved_texts: list[str] = []
+    for text in token_texts:
+        tid = _resolve_token_id(bundle.tokenizer, text)
+        if tid is None or tid >= bundle.emb.size(0):
+            continue
+        token_ids.append(tid)
+        resolved_texts.append(text)
+
+    if not token_ids:
+        return [], np.zeros((0, len(labels)), dtype=np.int64), labels, []
+
+    sel = bundle.emb_norm[token_ids]
+    sims = torch.matmul(sel, bundle.emb_norm.T).cpu().numpy()
+    sims = np.clip(sims, -1.0, 1.0)
+    angles = np.degrees(np.arccos(sims))
+    # exclude self match
+    for i, tid in enumerate(token_ids):
+        if 0 <= tid < angles.shape[1]:
+            angles[i, tid] = 180.0
+
+    counts = np.zeros((len(token_ids), len(labels)), dtype=np.int64)
+    for b in range(len(labels)):
+        lo, hi = bins[b], bins[b + 1]
+        counts[:, b] = ((angles > lo) & (angles <= hi)).sum(axis=1)
+
+    return resolved_texts, counts, labels, token_ids
+
+
+def _sorted_order(token_texts: list[str], total_counts: np.ndarray, mode: str) -> np.ndarray:
+    idx = np.arange(len(token_texts))
+    if mode == "alphabetical":
+        return np.array(sorted(idx, key=lambda i: token_texts[i].lower()))
+    if mode == "highest_to_lowest":
+        return np.argsort(-total_counts)
+    return np.argsort(total_counts)
+
+
+def _make_stack_figure(
+    title: str,
+    token_texts: list[str],
+    counts: np.ndarray,
+    labels: list[str],
+    order: np.ndarray,
+) -> go.Figure:
+    fig = go.Figure()
+    if len(token_texts) == 0:
+        fig.update_layout(title=title)
+        return fig
+
+    ordered_tokens = [token_texts[i] for i in order]
+    for b, lab in enumerate(labels):
+        y = counts[order, b]
+        fig.add_trace(go.Bar(x=ordered_tokens, y=y, name=lab, customdata=np.array(ordered_tokens)[:, None]))
+    fig.update_layout(
+        title=title,
+        barmode="stack",
+        xaxis_title="Token",
+        yaxis_title="Count of vocab vectors in angle range",
+        clickmode="event+select",
+        margin=dict(l=40, r=20, t=50, b=120),
+    )
+    return fig
+
+
+def _export_neighbors(
+    bundle: ModelBundle,
+    token_text: str,
+    output_dir: Path,
+) -> Path:
+    tid = _resolve_token_id(bundle.tokenizer, token_text)
+    if tid is None:
+        raise ValueError(f"Could not resolve token: {token_text}")
+
+    vec = bundle.emb[tid : tid + 1]
+    vec_n = bundle.emb_norm[tid : tid + 1]
+    dots = torch.matmul(vec, bundle.emb.T).squeeze(0).cpu().numpy()
+    ndots = torch.matmul(vec_n, bundle.emb_norm.T).squeeze(0).cpu().numpy()
+    ndots = np.clip(ndots, -1.0, 1.0)
+    deg = np.degrees(np.arccos(ndots))
+
+    out = output_dir / f"neighbors_{bundle.name.replace('/', '_')}_{tid}.csv"
+    with out.open("w", encoding="utf-8") as f:
+        f.write("token_id,token,degree_separation,dot_product,normalized_dot_product\n")
+        for i in range(bundle.emb.size(0)):
+            tok = bundle.tokenizer.convert_ids_to_tokens(i).replace("\n", "\\n")
+            f.write(f"{i},{tok},{float(deg[i]):.8f},{float(dots[i]):.8f},{float(ndots[i]):.8f}\n")
+    return out
+
+
+def main() -> None:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    dtype = _dtype(args.dtype)
+    base = _load_bundle(args.model_base, args.device, dtype)
+    it = _load_bundle(args.model_it, args.device, dtype)
+
+    base_tokens = _token_universe(base)
+
+    app: Dash = dash.Dash(__name__)
+    app.layout = html.Div(
+        [
+            html.H2("Gemma Vocab Angle Explorer"),
+            html.Div(
+                [
+                    html.Label("Preset"),
+                    dcc.Dropdown(
+                        id="preset",
+                        options=[
+                            {"label": "Digits", "value": "digits"},
+                            {"label": "Weekdays", "value": "weekdays"},
+                            {"label": "Months", "value": "months"},
+                            {"label": "Alphabet", "value": "alphabet"},
+                            {"label": "All", "value": "all"},
+                        ],
+                        value="digits",
+                        clearable=False,
+                    ),
+                    html.Label("Regex filter"),
+                    dcc.Input(id="regex", type="text", value="", style={"width": "100%"}),
+                    html.Label("Min degrees"),
+                    dcc.Input(id="min_deg", type="number", value=10, min=0, max=179, step=1),
+                    html.Label("Max degrees"),
+                    dcc.Input(id="max_deg", type="number", value=90, min=1, max=180, step=1),
+                    html.Label("Stack step (degrees)"),
+                    dcc.Input(id="step_deg", type="number", value=10, min=1, max=90, step=1),
+                    html.Label("Sort"),
+                    dcc.Dropdown(
+                        id="sort_mode",
+                        options=[
+                            {"label": "Alphabetical", "value": "alphabetical"},
+                            {"label": "Highest to lowest", "value": "highest_to_lowest"},
+                            {"label": "Lowest to highest", "value": "lowest_to_highest"},
+                        ],
+                        value="alphabetical",
+                        clearable=False,
+                    ),
+                ],
+                style={"maxWidth": "420px"},
+            ),
+            html.Hr(),
+            dcc.Graph(id="fig_base"),
+            dcc.Graph(id="fig_it"),
+            html.Div(id="clicked_token", style={"fontWeight": "bold"}),
+            html.Button("Export neighbors CSV for clicked token", id="export_btn", n_clicks=0),
+            html.Div(id="export_status"),
+            dcc.Store(id="click_store"),
+        ],
+        style={"padding": "12px"},
+    )
+
+    @app.callback(
+        Output("fig_base", "figure"),
+        Output("fig_it", "figure"),
+        Input("preset", "value"),
+        Input("regex", "value"),
+        Input("min_deg", "value"),
+        Input("max_deg", "value"),
+        Input("step_deg", "value"),
+        Input("sort_mode", "value"),
+    )
+    def update_figs(preset: str, regex: str, min_deg: float, max_deg: float, step_deg: float, sort_mode: str):
+        min_deg = float(min_deg or 10)
+        max_deg = float(max_deg or 90)
+        step_deg = max(1.0, float(step_deg or 10))
+        if min_deg >= max_deg:
+            max_deg = min_deg + 1
+
+        selected = _get_selection(base_tokens, preset, regex or "", args.max_selected_tokens)
+        t_base, c_base, labels_base, _ = _stack_counts_for_model(base, selected, min_deg, max_deg, step_deg)
+        t_it, c_it, labels_it, _ = _stack_counts_for_model(it, selected, min_deg, max_deg, step_deg)
+
+        totals = c_base.sum(axis=1) if c_base.size else np.array([])
+        order = _sorted_order(t_base, totals, sort_mode) if len(t_base) else np.array([], dtype=int)
+
+        fig_base = _make_stack_figure(f"{base.name} stacked histogram", t_base, c_base, labels_base, order)
+        fig_it = _make_stack_figure(f"{it.name} stacked histogram", t_it, c_it, labels_it, order if len(t_it) == len(t_base) else np.arange(len(t_it)))
+        return fig_base, fig_it
+
+    @app.callback(
+        Output("click_store", "data"),
+        Output("clicked_token", "children"),
+        Input("fig_base", "clickData"),
+        Input("fig_it", "clickData"),
+    )
+    def capture_click(base_click, it_click):
+        trigger = dash.callback_context.triggered_id
+        click = base_click if trigger == "fig_base" else it_click
+        if not click or not click.get("points"):
+            return no_update, no_update
+        token = click["points"][0]["x"]
+        model_key = "base" if trigger == "fig_base" else "it"
+        return {"token": token, "model": model_key}, f"Selected token: {token} (model={model_key})"
+
+    @app.callback(
+        Output("export_status", "children"),
+        Input("export_btn", "n_clicks"),
+        State("click_store", "data"),
+        prevent_initial_call=True,
+    )
+    def export_clicked(_n, click_data):
+        if not click_data:
+            return "Click a token bar first."
+        token = click_data["token"]
+        model_key = click_data["model"]
+        bundle = base if model_key == "base" else it
+        out = _export_neighbors(bundle, token, output_dir)
+        return f"Exported: {out}"
+
+    app.run(host=args.host, port=args.port, debug=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/huggingface_model/gemma/270M/vocab_angle_groups.py
+++ b/huggingface_model/gemma/270M/vocab_angle_groups.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import math
 import time
+import unicodedata
 from pathlib import Path
 
 import numpy as np
@@ -96,9 +97,20 @@ def _digit_token_map(tokenizer: AutoTokenizer, vocab_size: int) -> tuple[dict[st
     for idx in range(vocab_size):
         tok = tokenizer.convert_ids_to_tokens(idx)
         cleaned = tok.replace("▁", "").strip()
-        if len(cleaned) == 1 and cleaned.isdigit():
-            digit_map[cleaned].append(idx)
-            token_text[idx] = tok
+        if len(cleaned) != 1:
+            continue
+        if cleaned in digit_map:
+            digit_key = cleaned
+        else:
+            try:
+                numeric_value = unicodedata.digit(cleaned)
+                digit_key = str(int(numeric_value))
+            except (TypeError, ValueError):
+                continue
+            if digit_key not in digit_map:
+                continue
+        digit_map[digit_key].append(idx)
+        token_text[idx] = tok
     return digit_map, token_text
 
 

--- a/huggingface_model/gemma/270M/vocab_angle_groups.py
+++ b/huggingface_model/gemma/270M/vocab_angle_groups.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Analyze Gemma vocabulary embedding angle graph and connected groups.
+
+Builds an undirected graph over vocab tokens where an edge exists when the
+pairwise angle is <= threshold_degrees. Produces CSV summaries, plots, and a
+focused report for digit tokens 0-9.
+"""
+from __future__ import annotations
+
+import argparse
+import math
+from pathlib import Path
+
+import numpy as np
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Gemma vocab angle component analysis")
+    parser.add_argument("--model", default="google/gemma-3-270m", help="HF model name")
+    parser.add_argument(
+        "--embedding-source",
+        choices=["input", "lm_head"],
+        default="input",
+        help="Use model input embeddings or lm_head weights",
+    )
+    parser.add_argument(
+        "--angle-threshold-deg",
+        type=float,
+        default=70.0,
+        help="Create graph edge when pairwise angle <= this threshold",
+    )
+    parser.add_argument(
+        "--max-vocab",
+        type=int,
+        default=-1,
+        help="Limit vocab size for analysis (-1 for full vocab)",
+    )
+    parser.add_argument("--chunk-size", type=int, default=1024, help="Block size for similarity scan")
+    parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    parser.add_argument("--dtype", choices=["float32", "float16", "bfloat16"], default="float32")
+    parser.add_argument("--output-dir", default="./gemma_vocab_angle_groups")
+    parser.add_argument(
+        "--write-token-assignments",
+        action="store_true",
+        help="Write full token->component CSV (can be large)",
+    )
+    return parser.parse_args()
+
+
+def _torch_dtype(name: str) -> torch.dtype:
+    return {
+        "float32": torch.float32,
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+    }[name]
+
+
+def _decode_tokens(tokenizer: AutoTokenizer, vocab_size: int) -> list[str]:
+    tokens = [""] * vocab_size
+    for idx in range(vocab_size):
+        tokens[idx] = tokenizer.convert_ids_to_tokens(idx)
+    return tokens
+
+
+def _digit_token_map(tokens: list[str]) -> dict[str, list[int]]:
+    digit_map: dict[str, list[int]] = {str(d): [] for d in range(10)}
+    for idx, tok in enumerate(tokens):
+        cleaned = tok.replace("▁", "").strip()
+        if len(cleaned) == 1 and cleaned.isdigit():
+            digit_map[cleaned].append(idx)
+    return digit_map
+
+
+def _compute_edges(
+    emb: torch.Tensor,
+    cosine_threshold: float,
+    chunk_size: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    n = emb.size(0)
+    src_all: list[np.ndarray] = []
+    dst_all: list[np.ndarray] = []
+    degrees = np.zeros(n, dtype=np.int64)
+
+    for i0 in range(0, n, chunk_size):
+        i1 = min(i0 + chunk_size, n)
+        a = emb[i0:i1]
+        for j0 in range(i0, n, chunk_size):
+            j1 = min(j0 + chunk_size, n)
+            b = emb[j0:j1]
+            sims = torch.matmul(a, b.T)
+            mask = sims >= cosine_threshold
+            if i0 == j0:
+                tri = torch.triu(torch.ones_like(mask, dtype=torch.bool), diagonal=1)
+                mask = mask & tri
+
+            pairs = mask.nonzero(as_tuple=False)
+            if pairs.numel() == 0:
+                continue
+
+            src = (pairs[:, 0] + i0).cpu().numpy().astype(np.int32)
+            dst = (pairs[:, 1] + j0).cpu().numpy().astype(np.int32)
+            src_all.append(src)
+            dst_all.append(dst)
+            degrees += np.bincount(src, minlength=n)
+            degrees += np.bincount(dst, minlength=n)
+
+    if src_all:
+        src_cat = np.concatenate(src_all)
+        dst_cat = np.concatenate(dst_all)
+    else:
+        src_cat = np.empty((0,), dtype=np.int32)
+        dst_cat = np.empty((0,), dtype=np.int32)
+    return src_cat, dst_cat, degrees
+
+
+def _write_component_summary(
+    output_dir: Path,
+    component_ids: np.ndarray,
+    component_sizes: np.ndarray,
+) -> None:
+    counts = np.bincount(component_ids, minlength=component_sizes.shape[0])
+    ordered = np.argsort(counts)[::-1]
+    with (output_dir / "component_summary.csv").open("w", encoding="utf-8") as f:
+        f.write("component_id,size\n")
+        for cid in ordered:
+            f.write(f"{cid},{int(counts[cid])}\n")
+
+
+def _write_digit_reports(
+    output_dir: Path,
+    digit_map: dict[str, list[int]],
+    component_ids: np.ndarray,
+    component_sizes: np.ndarray,
+    degrees: np.ndarray,
+    tokens: list[str],
+) -> None:
+    rows: list[tuple[str, int, str, int, int, str]] = []
+    for d in range(10):
+        digit = str(d)
+        ids = digit_map[digit]
+        if not ids:
+            rows.append((digit, 0, "", -1, 0, ""))
+            continue
+        for token_id in ids:
+            comp = int(component_ids[token_id])
+            rows.append(
+                (
+                    digit,
+                    len(ids),
+                    tokens[token_id],
+                    comp,
+                    int(component_sizes[comp]),
+                    str(int(degrees[token_id])),
+                )
+            )
+
+    with (output_dir / "digit_report.csv").open("w", encoding="utf-8") as f:
+        f.write("digit,num_digit_tokens,token,component_id,component_size,degree\n")
+        for row in rows:
+            f.write(",".join(map(str, row)).replace("\n", " ") + "\n")
+
+    with (output_dir / "digit_report.md").open("w", encoding="utf-8") as f:
+        f.write("# Digit Token Report (0-9)\n\n")
+        f.write("| Digit | Num Digit Tokens | Token | Component ID | Component Size | Degree |\n")
+        f.write("|---|---:|---|---:|---:|---:|\n")
+        for row in rows:
+            f.write(
+                f"| {row[0]} | {row[1]} | `{row[2]}` | {row[3]} | {row[4]} | {row[5]} |\n"
+            )
+
+
+def _make_plots(output_dir: Path, component_sizes: np.ndarray, degrees: np.ndarray) -> None:
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print("matplotlib is not installed; skipping plot generation.")
+        return
+
+    sorted_sizes = np.sort(component_sizes)[::-1]
+
+    plt.figure(figsize=(10, 5))
+    top_n = min(30, len(sorted_sizes))
+    plt.bar(np.arange(top_n), sorted_sizes[:top_n])
+    plt.title("Top Connected Component Sizes")
+    plt.xlabel("Component Rank")
+    plt.ylabel("Size")
+    plt.tight_layout()
+    plt.savefig(output_dir / "component_sizes_top30.png", dpi=180)
+    plt.close()
+
+    plt.figure(figsize=(10, 5))
+    plt.hist(component_sizes, bins=50, log=True)
+    plt.title("Distribution of Connected Component Sizes")
+    plt.xlabel("Component Size")
+    plt.ylabel("Count (log scale)")
+    plt.tight_layout()
+    plt.savefig(output_dir / "component_size_hist.png", dpi=180)
+    plt.close()
+
+    plt.figure(figsize=(10, 5))
+    plt.hist(degrees, bins=60, log=True)
+    plt.title("Degree Distribution")
+    plt.xlabel("Node Degree")
+    plt.ylabel("Count (log scale)")
+    plt.tight_layout()
+    plt.savefig(output_dir / "degree_hist.png", dpi=180)
+    plt.close()
+
+
+def main() -> None:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    dtype = _torch_dtype(args.dtype)
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    model = AutoModelForCausalLM.from_pretrained(args.model, attn_implementation="eager")
+
+    if args.embedding_source == "input":
+        emb = model.get_input_embeddings().weight.detach()
+    else:
+        emb = model.lm_head.weight.detach()
+
+    if args.max_vocab > 0:
+        emb = emb[: args.max_vocab]
+
+    emb = emb.to(device=args.device, dtype=dtype)
+    emb = emb / emb.norm(dim=-1, keepdim=True).clamp_min(1e-12)
+
+    cosine_threshold = math.cos(math.radians(args.angle_threshold_deg))
+    src, dst, degrees = _compute_edges(emb, cosine_threshold=cosine_threshold, chunk_size=args.chunk_size)
+
+    n = emb.size(0)
+    if src.size == 0:
+        component_ids = np.arange(n, dtype=np.int32)
+        component_sizes = np.ones(n, dtype=np.int32)
+    else:
+        try:
+            from scipy.sparse import coo_matrix
+            from scipy.sparse.csgraph import connected_components
+
+            data = np.ones(src.shape[0] * 2, dtype=np.uint8)
+            row = np.concatenate([src, dst])
+            col = np.concatenate([dst, src])
+            graph = coo_matrix((data, (row, col)), shape=(n, n)).tocsr()
+            num_components, labels = connected_components(graph, directed=False, return_labels=True)
+            component_ids = labels.astype(np.int32)
+            component_sizes = np.bincount(component_ids, minlength=num_components).astype(np.int32)
+        except ImportError as err:
+            raise RuntimeError(
+                "scipy is required to compute connected components when edges are present. "
+                "Install scipy or rerun with a stricter angle threshold."
+            ) from err
+
+    tokens = _decode_tokens(tokenizer, n)
+    digit_map = _digit_token_map(tokens)
+
+    with (output_dir / "analysis_summary.txt").open("w", encoding="utf-8") as f:
+        f.write(f"model={args.model}\n")
+        f.write(f"embedding_source={args.embedding_source}\n")
+        f.write(f"vocab_size_analyzed={n}\n")
+        f.write(f"angle_threshold_deg={args.angle_threshold_deg}\n")
+        f.write(f"cosine_threshold={cosine_threshold:.8f}\n")
+        f.write(f"num_edges={int(src.size)}\n")
+        f.write(f"num_components={int(component_sizes.shape[0])}\n")
+        f.write(f"largest_component={int(component_sizes.max())}\n")
+        f.write(f"isolated_tokens={(degrees == 0).sum()}\n")
+
+    _write_component_summary(output_dir, component_ids, component_sizes)
+    _write_digit_reports(output_dir, digit_map, component_ids, component_sizes, degrees, tokens)
+
+    if args.write_token_assignments:
+        with (output_dir / "token_component_assignments.csv").open("w", encoding="utf-8") as f:
+            f.write("token_id,token,component_id,component_size,degree\n")
+            for token_id in range(n):
+                token = tokens[token_id].replace("\n", "\\n")
+                cid = int(component_ids[token_id])
+                f.write(f"{token_id},{token},{cid},{int(component_sizes[cid])},{int(degrees[token_id])}\n")
+
+    _make_plots(output_dir, component_sizes, degrees)
+    print(f"Done. Wrote outputs to {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/huggingface_model/gemma/270M/vocab_angle_groups.py
+++ b/huggingface_model/gemma/270M/vocab_angle_groups.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import math
+import time
 from pathlib import Path
 
 import numpy as np
@@ -37,8 +38,12 @@ def parse_args() -> argparse.Namespace:
         default=-1,
         help="Limit vocab size for analysis (-1 for full vocab)",
     )
-    parser.add_argument("--chunk-size", type=int, default=1024, help="Block size for similarity scan")
-    parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    parser.add_argument("--chunk-size", type=int, default=512, help="Block size for similarity scan")
+    parser.add_argument(
+        "--device",
+        default="cpu",
+        help="Computation device for similarity scan (default cpu to stay RAM-safe)",
+    )
     parser.add_argument("--dtype", choices=["float32", "float16", "bfloat16"], default="float32")
     parser.add_argument("--output-dir", default="./gemma_vocab_angle_groups")
     parser.add_argument(
@@ -49,6 +54,34 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+class UnionFind:
+    def __init__(self, n: int) -> None:
+        self.parent = np.arange(n, dtype=np.int32)
+        self.rank = np.zeros(n, dtype=np.int8)
+
+    def find(self, x: int) -> int:
+        parent = self.parent
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = int(parent[x])
+        return x
+
+    def union(self, a: int, b: int) -> None:
+        ra = self.find(a)
+        rb = self.find(b)
+        if ra == rb:
+            return
+        rank = self.rank
+        parent = self.parent
+        if rank[ra] < rank[rb]:
+            parent[ra] = rb
+        elif rank[ra] > rank[rb]:
+            parent[rb] = ra
+        else:
+            parent[rb] = ra
+            rank[ra] += 1
+
+
 def _torch_dtype(name: str) -> torch.dtype:
     return {
         "float32": torch.float32,
@@ -57,31 +90,50 @@ def _torch_dtype(name: str) -> torch.dtype:
     }[name]
 
 
-def _decode_tokens(tokenizer: AutoTokenizer, vocab_size: int) -> list[str]:
-    tokens = [""] * vocab_size
-    for idx in range(vocab_size):
-        tokens[idx] = tokenizer.convert_ids_to_tokens(idx)
-    return tokens
-
-
-def _digit_token_map(tokens: list[str]) -> dict[str, list[int]]:
+def _digit_token_map(tokenizer: AutoTokenizer, vocab_size: int) -> tuple[dict[str, list[int]], dict[int, str]]:
     digit_map: dict[str, list[int]] = {str(d): [] for d in range(10)}
-    for idx, tok in enumerate(tokens):
+    token_text: dict[int, str] = {}
+    for idx in range(vocab_size):
+        tok = tokenizer.convert_ids_to_tokens(idx)
         cleaned = tok.replace("▁", "").strip()
         if len(cleaned) == 1 and cleaned.isdigit():
             digit_map[cleaned].append(idx)
-    return digit_map
+            token_text[idx] = tok
+    return digit_map, token_text
+
+
+def _render_progress(
+    processed: int,
+    total: int,
+    start_time: float,
+    edges: int,
+) -> None:
+    elapsed = max(time.time() - start_time, 1e-6)
+    rate = processed / elapsed
+    remaining = total - processed
+    eta_sec = remaining / max(rate, 1e-9)
+    pct = (processed / max(total, 1)) * 100.0
+    print(
+        f"\rBlocks: {processed}/{total} ({pct:5.1f}%) | "
+        f"Edges: {edges:,} | ETA: {eta_sec:7.1f}s",
+        end="",
+        flush=True,
+    )
 
 
 def _compute_edges(
     emb: torch.Tensor,
     cosine_threshold: float,
     chunk_size: int,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+) -> tuple[UnionFind, np.ndarray, int]:
     n = emb.size(0)
-    src_all: list[np.ndarray] = []
-    dst_all: list[np.ndarray] = []
     degrees = np.zeros(n, dtype=np.int64)
+    uf = UnionFind(n)
+    edge_count = 0
+    num_blocks = math.ceil(n / chunk_size)
+    total_block_pairs = num_blocks * (num_blocks + 1) // 2
+    processed_pairs = 0
+    started = time.time()
 
     for i0 in range(0, n, chunk_size):
         i1 = min(i0 + chunk_size, n)
@@ -97,22 +149,25 @@ def _compute_edges(
 
             pairs = mask.nonzero(as_tuple=False)
             if pairs.numel() == 0:
+                processed_pairs += 1
+                if processed_pairs % 10 == 0 or processed_pairs == total_block_pairs:
+                    _render_progress(processed_pairs, total_block_pairs, started, edge_count)
                 continue
 
             src = (pairs[:, 0] + i0).cpu().numpy().astype(np.int32)
             dst = (pairs[:, 1] + j0).cpu().numpy().astype(np.int32)
-            src_all.append(src)
-            dst_all.append(dst)
+            edge_count += int(src.shape[0])
             degrees += np.bincount(src, minlength=n)
             degrees += np.bincount(dst, minlength=n)
+            for s, d in zip(src, dst):
+                uf.union(int(s), int(d))
 
-    if src_all:
-        src_cat = np.concatenate(src_all)
-        dst_cat = np.concatenate(dst_all)
-    else:
-        src_cat = np.empty((0,), dtype=np.int32)
-        dst_cat = np.empty((0,), dtype=np.int32)
-    return src_cat, dst_cat, degrees
+            processed_pairs += 1
+            if processed_pairs % 10 == 0 or processed_pairs == total_block_pairs:
+                _render_progress(processed_pairs, total_block_pairs, started, edge_count)
+
+    print()
+    return uf, degrees, edge_count
 
 
 def _write_component_summary(
@@ -131,10 +186,10 @@ def _write_component_summary(
 def _write_digit_reports(
     output_dir: Path,
     digit_map: dict[str, list[int]],
+    digit_token_text: dict[int, str],
     component_ids: np.ndarray,
     component_sizes: np.ndarray,
     degrees: np.ndarray,
-    tokens: list[str],
 ) -> None:
     rows: list[tuple[str, int, str, int, int, str]] = []
     for d in range(10):
@@ -149,7 +204,7 @@ def _write_digit_reports(
                 (
                     digit,
                     len(ids),
-                    tokens[token_id],
+                    digit_token_text.get(token_id, ""),
                     comp,
                     int(component_sizes[comp]),
                     str(int(degrees[token_id])),
@@ -230,32 +285,14 @@ def main() -> None:
     emb = emb / emb.norm(dim=-1, keepdim=True).clamp_min(1e-12)
 
     cosine_threshold = math.cos(math.radians(args.angle_threshold_deg))
-    src, dst, degrees = _compute_edges(emb, cosine_threshold=cosine_threshold, chunk_size=args.chunk_size)
+    uf, degrees, edge_count = _compute_edges(emb, cosine_threshold=cosine_threshold, chunk_size=args.chunk_size)
 
     n = emb.size(0)
-    if src.size == 0:
-        component_ids = np.arange(n, dtype=np.int32)
-        component_sizes = np.ones(n, dtype=np.int32)
-    else:
-        try:
-            from scipy.sparse import coo_matrix
-            from scipy.sparse.csgraph import connected_components
-
-            data = np.ones(src.shape[0] * 2, dtype=np.uint8)
-            row = np.concatenate([src, dst])
-            col = np.concatenate([dst, src])
-            graph = coo_matrix((data, (row, col)), shape=(n, n)).tocsr()
-            num_components, labels = connected_components(graph, directed=False, return_labels=True)
-            component_ids = labels.astype(np.int32)
-            component_sizes = np.bincount(component_ids, minlength=num_components).astype(np.int32)
-        except ImportError as err:
-            raise RuntimeError(
-                "scipy is required to compute connected components when edges are present. "
-                "Install scipy or rerun with a stricter angle threshold."
-            ) from err
-
-    tokens = _decode_tokens(tokenizer, n)
-    digit_map = _digit_token_map(tokens)
+    roots = np.array([uf.find(i) for i in range(n)], dtype=np.int32)
+    _, component_ids = np.unique(roots, return_inverse=True)
+    component_ids = component_ids.astype(np.int32)
+    component_sizes = np.bincount(component_ids).astype(np.int32)
+    digit_map, digit_token_text = _digit_token_map(tokenizer, n)
 
     with (output_dir / "analysis_summary.txt").open("w", encoding="utf-8") as f:
         f.write(f"model={args.model}\n")
@@ -263,19 +300,19 @@ def main() -> None:
         f.write(f"vocab_size_analyzed={n}\n")
         f.write(f"angle_threshold_deg={args.angle_threshold_deg}\n")
         f.write(f"cosine_threshold={cosine_threshold:.8f}\n")
-        f.write(f"num_edges={int(src.size)}\n")
+        f.write(f"num_edges={int(edge_count)}\n")
         f.write(f"num_components={int(component_sizes.shape[0])}\n")
         f.write(f"largest_component={int(component_sizes.max())}\n")
         f.write(f"isolated_tokens={(degrees == 0).sum()}\n")
 
     _write_component_summary(output_dir, component_ids, component_sizes)
-    _write_digit_reports(output_dir, digit_map, component_ids, component_sizes, degrees, tokens)
+    _write_digit_reports(output_dir, digit_map, digit_token_text, component_ids, component_sizes, degrees)
 
     if args.write_token_assignments:
         with (output_dir / "token_component_assignments.csv").open("w", encoding="utf-8") as f:
             f.write("token_id,token,component_id,component_size,degree\n")
             for token_id in range(n):
-                token = tokens[token_id].replace("\n", "\\n")
+                token = tokenizer.convert_ids_to_tokens(token_id).replace("\n", "\\n")
                 cid = int(component_ids[token_id])
                 f.write(f"{token_id},{token},{cid},{int(component_sizes[cid])},{int(degrees[token_id])}\n")
 

--- a/huggingface_model/gemma/270M/vocab_angle_token_dashboard.py
+++ b/huggingface_model/gemma/270M/vocab_angle_token_dashboard.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Interactive token-angle dashboard + island exporter for Gemma vocab embeddings."""
+from __future__ import annotations
+
+import argparse
+import math
+import time
+import uuid
+from pathlib import Path
+
+import numpy as np
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+class UnionFind:
+    def __init__(self, n: int) -> None:
+        self.parent = np.arange(n, dtype=np.int32)
+        self.rank = np.zeros(n, dtype=np.int8)
+
+    def find(self, x: int) -> int:
+        parent = self.parent
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = int(parent[x])
+        return x
+
+    def union(self, a: int, b: int) -> None:
+        ra = self.find(a)
+        rb = self.find(b)
+        if ra == rb:
+            return
+        rank = self.rank
+        parent = self.parent
+        if rank[ra] < rank[rb]:
+            parent[ra] = rb
+        elif rank[ra] > rank[rb]:
+            parent[rb] = ra
+        else:
+            parent[rb] = ra
+            rank[ra] += 1
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Token angle dashboard + island exporter")
+    p.add_argument("--model", default="google/gemma-3-270m")
+    p.add_argument("--embedding-source", choices=["input", "lm_head"], default="input")
+    p.add_argument("--tokens", required=True, help="Comma-separated token strings, e.g. '0,1,2'")
+    p.add_argument("--angle-threshold-deg", type=float, default=70.0)
+    p.add_argument("--chunk-size", type=int, default=512)
+    p.add_argument("--device", default="cpu")
+    p.add_argument("--dtype", choices=["float32", "float16", "bfloat16"], default="float32")
+    p.add_argument("--max-vocab", type=int, default=-1)
+    p.add_argument("--max-plot-vocab", type=int, default=20000)
+    p.add_argument("--top-k", type=int, default=200)
+    p.add_argument("--min-island-size", type=int, default=2)
+    p.add_argument("--output-dir", default="./gemma_token_angle_dashboard")
+    return p.parse_args()
+
+
+def _dtype(name: str) -> torch.dtype:
+    return {"float32": torch.float32, "float16": torch.float16, "bfloat16": torch.bfloat16}[name]
+
+
+def _progress(processed: int, total: int, started: float) -> None:
+    elapsed = max(time.time() - started, 1e-6)
+    rate = processed / elapsed
+    eta = (total - processed) / max(rate, 1e-9)
+    print(f"\rBlocks: {processed}/{total} ({100*processed/max(total,1):5.1f}%) ETA {eta:7.1f}s", end="", flush=True)
+
+
+def _resolve_token_ids(tokenizer: AutoTokenizer, token_texts: list[str]) -> list[int]:
+    ids: list[int] = []
+    for tok in token_texts:
+        tok = tok.strip()
+        token_id = tokenizer.convert_tokens_to_ids(tok)
+        if token_id is None or token_id == tokenizer.unk_token_id:
+            pieces = tokenizer(tok, add_special_tokens=False)["input_ids"]
+            if not pieces:
+                raise ValueError(f"Could not tokenize token text: {tok!r}")
+            token_id = int(pieces[0])
+        ids.append(int(token_id))
+    return ids
+
+
+def _build_islands(
+    emb: torch.Tensor,
+    cosine_threshold: float,
+    chunk_size: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    n = emb.size(0)
+    uf = UnionFind(n)
+    degrees = np.zeros(n, dtype=np.int64)
+
+    blocks = math.ceil(n / chunk_size)
+    total_pairs = blocks * (blocks + 1) // 2
+    done = 0
+    started = time.time()
+
+    for i0 in range(0, n, chunk_size):
+        i1 = min(i0 + chunk_size, n)
+        a = emb[i0:i1]
+        for j0 in range(i0, n, chunk_size):
+            j1 = min(j0 + chunk_size, n)
+            b = emb[j0:j1]
+            sims = torch.matmul(a, b.T)
+            mask = sims >= cosine_threshold
+            if i0 == j0:
+                tri = torch.triu(torch.ones_like(mask, dtype=torch.bool), diagonal=1)
+                mask = mask & tri
+            pairs = mask.nonzero(as_tuple=False)
+            if pairs.numel() > 0:
+                src = (pairs[:, 0] + i0).cpu().numpy().astype(np.int32)
+                dst = (pairs[:, 1] + j0).cpu().numpy().astype(np.int32)
+                degrees += np.bincount(src, minlength=n)
+                degrees += np.bincount(dst, minlength=n)
+                for s, d in zip(src, dst):
+                    uf.union(int(s), int(d))
+            done += 1
+            if done % 10 == 0 or done == total_pairs:
+                _progress(done, total_pairs, started)
+    print()
+
+    roots = np.array([uf.find(i) for i in range(n)], dtype=np.int32)
+    _, component_ids = np.unique(roots, return_inverse=True)
+    component_ids = component_ids.astype(np.int32)
+    return component_ids, degrees
+
+
+def _write_island_files(
+    output_dir: Path,
+    tokenizer: AutoTokenizer,
+    component_ids: np.ndarray,
+    component_sizes: np.ndarray,
+    degrees: np.ndarray,
+    min_island_size: int,
+) -> None:
+    islands_dir = output_dir / "islands"
+    islands_dir.mkdir(parents=True, exist_ok=True)
+
+    members_by_component: dict[int, list[int]] = {}
+    for token_id, component_id in enumerate(component_ids.tolist()):
+        members_by_component.setdefault(component_id, []).append(token_id)
+
+    for component_id, members in members_by_component.items():
+        if len(members) < min_island_size:
+            continue
+        file_name = f"island_{component_id}_size{len(members)}_{uuid.uuid4().hex[:10]}.txt"
+        path = islands_dir / file_name
+        with path.open("w", encoding="utf-8") as f:
+            f.write(f"component_id={component_id}\n")
+            f.write(f"component_size={len(members)}\n")
+            f.write("token_id\ttoken\tdegree\n")
+            for token_id in members:
+                token = tokenizer.convert_ids_to_tokens(token_id).replace("\n", "\\n")
+                f.write(f"{token_id}\t{token}\t{int(degrees[token_id])}\n")
+
+
+def _write_selected_token_csvs(
+    output_dir: Path,
+    tokenizer: AutoTokenizer,
+    emb: torch.Tensor,
+    selected_token_ids: list[int],
+    selected_token_texts: list[str],
+    top_k: int,
+) -> np.ndarray:
+    sims = torch.matmul(emb[selected_token_ids], emb.T).cpu().numpy()
+    sims = np.clip(sims, -1.0, 1.0)
+    angles = np.degrees(np.arccos(sims))
+
+    out_dir = output_dir / "selected_token_reports"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    for i, token_id in enumerate(selected_token_ids):
+        order = np.argsort(angles[i])
+        top = order[: max(1, min(top_k, len(order)))]
+        csv_path = out_dir / f"token_{token_id}_{selected_token_texts[i].replace(' ', '_')}.csv"
+        with csv_path.open("w", encoding="utf-8") as f:
+            f.write("rank,target_token_id,target_token,cosine,angle_deg\n")
+            for rank, target_id in enumerate(top, start=1):
+                tok = tokenizer.convert_ids_to_tokens(int(target_id)).replace("\n", "\\n")
+                f.write(
+                    f"{rank},{int(target_id)},{tok},{float(sims[i, target_id]):.8f},{float(angles[i, target_id]):.6f}\n"
+                )
+    return angles
+
+
+def _write_plotly_dashboard(
+    output_dir: Path,
+    tokenizer: AutoTokenizer,
+    selected_token_ids: list[int],
+    selected_token_texts: list[str],
+    angles: np.ndarray,
+    max_plot_vocab: int,
+) -> None:
+    import plotly.graph_objects as go
+    from plotly.subplots import make_subplots
+
+    plot_vocab = min(max_plot_vocab, angles.shape[1])
+    fig = make_subplots(rows=2, cols=1, subplot_titles=("Angle Distribution", "Token ID vs Angle"))
+
+    for i, (tid, text) in enumerate(zip(selected_token_ids, selected_token_texts)):
+        fig.add_trace(
+            go.Histogram(x=angles[i], name=f"{text} (id={tid})", opacity=0.5, nbinsx=90),
+            row=1,
+            col=1,
+        )
+        fig.add_trace(
+            go.Scattergl(
+                x=np.arange(plot_vocab),
+                y=angles[i, :plot_vocab],
+                mode="markers",
+                marker={"size": 3},
+                name=f"{text} (id={tid})",
+            ),
+            row=2,
+            col=1,
+        )
+
+    fig.update_layout(
+        barmode="overlay",
+        height=900,
+        title="Selected Token Angle Dashboard",
+        xaxis2_title="Token ID (truncated for plotting)",
+        yaxis2_title="Angle (degrees)",
+    )
+
+    html_path = output_dir / "selected_token_dashboard.html"
+    fig.write_html(str(html_path), include_plotlyjs="cdn")
+
+    with (output_dir / "selected_tokens_resolved.txt").open("w", encoding="utf-8") as f:
+        f.write("selected_token_text\tselected_token_id\tresolved_token\n")
+        for text, tid in zip(selected_token_texts, selected_token_ids):
+            resolved = tokenizer.convert_ids_to_tokens(tid)
+            f.write(f"{text}\t{tid}\t{resolved}\n")
+
+
+def main() -> None:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    model = AutoModelForCausalLM.from_pretrained(args.model, attn_implementation="eager")
+
+    emb = model.get_input_embeddings().weight.detach() if args.embedding_source == "input" else model.lm_head.weight.detach()
+    if args.max_vocab > 0:
+        emb = emb[: args.max_vocab]
+
+    emb = emb.to(device=args.device, dtype=_dtype(args.dtype))
+    emb = emb / emb.norm(dim=-1, keepdim=True).clamp_min(1e-12)
+
+    requested_tokens = [x.strip() for x in args.tokens.split(",") if x.strip()]
+    selected_token_ids = _resolve_token_ids(tokenizer, requested_tokens)
+    for token_id in selected_token_ids:
+        if token_id >= emb.size(0):
+            raise ValueError(f"Selected token id {token_id} is outside analyzed vocab size {emb.size(0)}")
+
+    angles = _write_selected_token_csvs(
+        output_dir=output_dir,
+        tokenizer=tokenizer,
+        emb=emb,
+        selected_token_ids=selected_token_ids,
+        selected_token_texts=requested_tokens,
+        top_k=args.top_k,
+    )
+    _write_plotly_dashboard(output_dir, tokenizer, selected_token_ids, requested_tokens, angles, args.max_plot_vocab)
+
+    threshold_cos = math.cos(math.radians(args.angle_threshold_deg))
+    component_ids, degrees = _build_islands(emb, threshold_cos, args.chunk_size)
+    component_sizes = np.bincount(component_ids)
+    _write_island_files(output_dir, tokenizer, component_ids, component_sizes, degrees, args.min_island_size)
+
+    with (output_dir / "run_summary.txt").open("w", encoding="utf-8") as f:
+        f.write(f"model={args.model}\n")
+        f.write(f"embedding_source={args.embedding_source}\n")
+        f.write(f"vocab_size={emb.size(0)}\n")
+        f.write(f"angle_threshold_deg={args.angle_threshold_deg}\n")
+        f.write(f"num_components={int(component_sizes.shape[0])}\n")
+        f.write(f"largest_component={int(component_sizes.max())}\n")
+        f.write(f"selected_tokens={','.join(requested_tokens)}\n")
+
+    print(f"Done. Outputs written to: {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/huggingface_model/gemma/270M/weekday_quant_angle_comparison.py
+++ b/huggingface_model/gemma/270M/weekday_quant_angle_comparison.py
@@ -8,17 +8,17 @@ from token_quant_angle_comparison import run_analysis
 
 
 def parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(description="Digit quantization angle comparison")
+    p = argparse.ArgumentParser(description="Weekday quantization angle comparison")
     p.add_argument("--model", default="google/gemma-3-270m")
     p.add_argument("--embedding-source", choices=["input", "lm_head"], default="input")
     p.add_argument("--device", default="cpu")
-    p.add_argument("--output-dir", default="./gemma_digit_quant_angles")
+    p.add_argument("--output-dir", default="./gemma_weekday_quant_angles")
     return p.parse_args()
 
 
 def main() -> None:
     a = parse_args()
-    run_analysis("digits", a.model, a.embedding_source, a.device, Path(a.output_dir))
+    run_analysis("weekdays", a.model, a.embedding_source, a.device, Path(a.output_dir))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Add a reusable analysis tool to study pairwise angles between Gemma 270M vocabulary embeddings and identify groups of tokens linked by angular similarity (default threshold 70°).
- Produce CSVs, plots, and a focused report for digit tokens `0-9` to support tokenizer/embedding inspection and downstream analyses.

### Description
- Added `huggingface_model/gemma/270M/vocab_angle_groups.py`, a CLI script that loads a HF model and builds an undirected graph connecting token pairs whose angle ≤ `--angle-threshold-deg` (default `70.0`).
- Script supports selecting embedding source (`--embedding-source` = `input` or `lm_head`), limiting analysis with `--max-vocab`, chunked similarity scanning via `--chunk-size`, device/dtype options and `--output-dir` for results.
- Outputs include `analysis_summary.txt`, `component_summary.csv`, `digit_report.csv`, `digit_report.md`, optional `token_component_assignments.csv` (with `--write-token-assignments`), and plot files (`component_sizes_top30.png`, `component_size_hist.png`, `degree_hist.png`).
- Robustness: plotting is skipped with a clear message when `matplotlib` is unavailable and connected-component computation raises a helpful error if `scipy` is missing when edges exist.

### Testing
- Ran syntax check with `python -m py_compile huggingface_model/gemma/270M/vocab_angle_groups.py`, which succeeded. 
- Executed `python huggingface_model/gemma/270M/vocab_angle_groups.py --help` which attempted to run but failed in this environment due to missing runtime packages (`numpy`/`matplotlib`), indicating the script is syntactically valid but requires those dependencies to run end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4981456cc83269affcc11e64d25e1)