### PR TITLE
Add QuadPathMagnitudeSwiglu MLP variant, tests, and HP-search configs

### DIFF
--- a/explorations/quad_path_equal_param_default_inf.yaml
+++ b/explorations/quad_path_equal_param_default_inf.yaml
@@ -1,0 +1,97 @@
+# quad_path_equal_param_default_inf.yaml
+---
+
+named_static_groups:
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  - named_group: "peri_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [true]
+    use_post_ln: [false]
+
+  - named_group: "rotary"
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+  - named_group: "softmax"
+    softmax_variant_attn: ["softmax"]
+
+  - named_group: "infinite"
+    attention_variant: ["infinite"]
+    use_concat_heads: [true]
+
+  # Equal-parameter family around quad_path_magnitude_swiglu mlp_size=768.
+  # Relative projection multipliers:
+  #   mlp=2x, swiglu=3x, dual_path=3x, quad_path_magnitude_swiglu=6x.
+  # Match total MLP params by scaling hidden sizes accordingly.
+  - named_group: "mlp_equal_params"
+    mlp_variant: ["mlp"]
+    mlp_size: [2304]
+
+  - named_group: "swiglu_equal_params"
+    mlp_variant: ["swiglu"]
+    mlp_size: [1536]
+
+  - named_group: "dual_path_equal_params"
+    mlp_variant: ["dual_path"]
+    mlp_size: [1536]
+
+  - named_group: "quad_path_equal_params"
+    mlp_variant: ["quad_path_magnitude_swiglu"]
+    mlp_size: [768]
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [2500]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+  compile: [true]
+  log_rankme: [true]
+  log_areq: [true]
+  n_layer: [6]
+  n_head: [3]
+  n_kv_group: [3]
+  n_embd: [384]
+  n_qk_head_dim: [100]
+  n_v_head_dim: [100]
+
+parameter_groups:
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "softmax"
+      - "infinite"
+      - "mlp_equal_params"
+    activation_variant: ["gelu", "silu", "squared_relu"]
+
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "softmax"
+      - "infinite"
+      - "swiglu_equal_params"
+    activation_variant: ["gelu", "silu", "squared_relu"]
+
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "softmax"
+      - "infinite"
+      - "dual_path_equal_params"
+    activation_variant: ["gelu", "silu", "squared_relu"]
+
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "softmax"
+      - "infinite"
+      - "quad_path_equal_params"
+    activation_variant: ["gelu", "silu", "squared_relu"]
+
+tensorboard_run_name: ["quad_path_equal_param_default_inf_no_relu2max_no_mqa"]

--- a/hp_searches/quad_path_efficiency.sh
+++ b/hp_searches/quad_path_efficiency.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# hp_searches/quad_path_efficiency.sh
+
+for target in params iter; do
+  python3 hyperparam_search.py \
+    --orig_settings ./hp_searches/quad_path_efficiency.yaml \
+    --param_names \
+    n_layer \
+    n_head \
+    n_kv_group \
+    n_embd \
+    mlp_size \
+    n_qk_head_dim \
+    n_v_head_dim \
+    --increments \
+    1 \
+    1 \
+    1 \
+    64 \
+    128 \
+    32 \
+    32 \
+    --random_iterations 1 \
+    --iterations 1 \
+    --num_iterations 100 \
+    --efficiency_target "${target}" \
+    --max_iters_increase 2500 \
+    --results_file "quad_path_efficiency_target_${target}.yaml"
+done

--- a/hp_searches/quad_path_efficiency.yaml
+++ b/hp_searches/quad_path_efficiency.yaml
@@ -1,0 +1,43 @@
+# hp_searches/quad_path_efficiency.yaml
+# Efficiency-targeted search baseline for quad-path magnitude SwiGLU.
+# Derived from efficiency_targets_demo.yaml with default_inf-style core settings,
+# using softmax infinite attention (no relu2max, no mqa).
+
+# dataset
+# keep small for quick search iterations
+dataset: "minipile"
+
+# position embeddings
+use_rotary_embeddings: true
+use_abs_pos_embeddings: false
+never_save_checkpoint: true
+
+# norm settings (default_inf-inspired)
+use_qk_norm: true
+use_qk_norm_scale: true
+use_peri_ln: true
+
+# attention settings (default_inf-inspired, minus relu2max + mqa)
+attention_variant: "infinite"
+softmax_variant_attn: "softmax"
+use_concat_heads: true
+
+# training settings
+eta_variant: "iteration"
+max_iters: 500
+eval_interval: 500
+compile: true
+batch_size: 32
+
+# model family under search
+mlp_variant: "quad_path_magnitude_swiglu"
+activation_variant: "silu"
+
+# searchable starting point
+n_layer: 6
+n_head: 3
+n_kv_group: 3
+n_embd: 384
+mlp_size: 768
+n_qk_head_dim: 64
+n_v_head_dim: 64

--- a/tests/test_quad_path_magnitude_swiglu.py
+++ b/tests/test_quad_path_magnitude_swiglu.py
@@ -1,0 +1,32 @@
+import unittest
+
+import torch
+
+from gpt_conf import GPTConfig
+from variations.mlp_variations import get_mlp_instance
+
+
+class QuadPathMagnitudeSwigluTest(unittest.TestCase):
+    def test_forward_shape_matches_embedding_dim(self):
+        config = GPTConfig(
+            n_embd=16,
+            n_layer=1,
+            n_head=1,
+            mlp_variant="quad_path_magnitude_swiglu",
+            mlp_expansion_factor=2,
+            dropout=0.0,
+            bias=False,
+        )
+        mlp = get_mlp_instance(config)
+
+        x = torch.randn(3, 5, config.n_embd)
+        out = mlp(x)
+
+        self.assertEqual(out.shape, x.shape)
+        self.assertEqual(mlp.c_proj_pos_neg.in_features, mlp.c_proj_neg_neg.in_features)
+        self.assertEqual(mlp.c_proj_pos_neg.in_features, mlp.c_proj_pos_pos.in_features)
+        self.assertEqual(mlp.c_proj_pos_neg.in_features, mlp.c_proj_neg_pos.in_features)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/train_args.py
+++ b/train_args.py
@@ -663,6 +663,7 @@ def parse_args():
             "swiglu",
             "dual_path",
             "dual_path_swiglu",
+            "quad_path_magnitude_swiglu",
             "identity",
             ]
 

--- a/variations/mlp_variations.py
+++ b/variations/mlp_variations.py
@@ -859,6 +859,177 @@ class DualPathSwiglu(nn.Module):
 
         return x
 
+class QuadPathMagnitudeSwiglu(nn.Module):
+    """SwiGLU-style two up projections with 4-way sign routing to separate c_proj heads."""
+    def __init__(self, config):
+        super().__init__()
+
+        self.full_quant_iteration = config.full_quant_iteration
+        self.eval_interval = config.eval_interval
+
+        self.activation_variant = activation_dictionary[config.activation_variant](config=config)
+
+        self.l2_norm_mlp_up = config.l2_norm_mlp_up
+        self.l2_norm_mlp_down = config.l2_norm_mlp_down
+        self.l2_norm_mlp_up_dim = config.l2_norm_mlp_up_dim
+        self.l2_norm_mlp_down_dim = config.l2_norm_mlp_down_dim
+
+        if config.learn_mlp_x_offset:
+            self.activation_x_offset = nn.Parameter(torch.tensor(config.mlp_x_offset))
+        else:
+            self.register_buffer("activation_x_offset", torch.tensor(config.mlp_x_offset))
+
+        if config.learn_mlp_y_offset:
+            self.activation_y_offset = nn.Parameter(torch.tensor(config.mlp_y_offset))
+        else:
+            self.register_buffer("activation_y_offset", torch.tensor(config.mlp_y_offset))
+
+        self.linear_variant_mlp_up = linear_dictionary[set_variant(config.linear_variant_mlp_up, config.linear_variant_mlp)]
+        self.linear_variant_mlp_down = linear_dictionary[set_variant(config.linear_variant_mlp_down, config.linear_variant_mlp)]
+
+        self.quantization_mlp_dict = {}
+        self.quantization_mlp_dict["activations_quant_method"] = config.activations_quant_method
+
+        for arg, val in vars(config).items():
+            if arg.startswith("quantize_") and "mlp_act" in arg and arg.endswith("_bits"):
+                self.quantization_mlp_dict[arg] = set_variant(val, config.quantize_mlp_act_bits)
+            elif arg.startswith("quantize_") and "mlp_act" in arg:
+                self.quantization_mlp_dict[arg] = set_variant(val, config.quantize_mlp_act)
+                if config.store_activations and arg != "quantize_mlp_act" and self.quantization_mlp_dict[arg]:
+                    create_activation_buffers(self, arg)
+            elif arg.startswith("quantize_") and "linear_mlp" in arg and arg.endswith("_bits"):
+                self.quantization_mlp_dict[arg] = set_variant(val, config.quantize_linear_bits)
+            elif arg.startswith("quantize_") and "linear_mlp" in arg and arg.endswith("_method"):
+                self.quantization_mlp_dict[arg] = set_variant(val, config.quantize_linear_method)
+
+        mlp_expansion_size = config.mlp_size if config.mlp_size is not None else config.mlp_expansion_factor * config.n_embd
+
+        use_up_bias = config.mlp_up_bias if config.mlp_up_bias is not None else config.bias
+        use_down_bias = config.mlp_down_bias if config.mlp_down_bias is not None else config.bias
+
+        self.c_fc_in1 = self.linear_variant_mlp_up(
+            config.n_embd,
+            mlp_expansion_size,
+            config,
+            self.quantization_mlp_dict["quantize_linear_mlp_up_method"],
+            self.quantization_mlp_dict["quantize_linear_mlp_up_bits"],
+            bias=use_up_bias
+        )
+        self.c_fc_in2 = self.linear_variant_mlp_up(
+            config.n_embd,
+            mlp_expansion_size,
+            config,
+            self.quantization_mlp_dict["quantize_linear_mlp_up_method"],
+            self.quantization_mlp_dict["quantize_linear_mlp_up_bits"],
+            bias=use_up_bias
+        )
+
+        self.c_proj_pos_neg = self.linear_variant_mlp_down(
+            mlp_expansion_size,
+            config.n_embd,
+            config,
+            self.quantization_mlp_dict["quantize_linear_mlp_down_method"],
+            self.quantization_mlp_dict["quantize_linear_mlp_down_bits"],
+            bias=use_down_bias
+        )
+        self.c_proj_neg_neg = self.linear_variant_mlp_down(
+            mlp_expansion_size,
+            config.n_embd,
+            config,
+            self.quantization_mlp_dict["quantize_linear_mlp_down_method"],
+            self.quantization_mlp_dict["quantize_linear_mlp_down_bits"],
+            bias=use_down_bias
+        )
+        self.c_proj_pos_pos = self.linear_variant_mlp_down(
+            mlp_expansion_size,
+            config.n_embd,
+            config,
+            self.quantization_mlp_dict["quantize_linear_mlp_down_method"],
+            self.quantization_mlp_dict["quantize_linear_mlp_down_bits"],
+            bias=use_down_bias
+        )
+        self.c_proj_neg_pos = self.linear_variant_mlp_down(
+            mlp_expansion_size,
+            config.n_embd,
+            config,
+            self.quantization_mlp_dict["quantize_linear_mlp_down_method"],
+            self.quantization_mlp_dict["quantize_linear_mlp_down_bits"],
+            bias=use_down_bias
+        )
+
+        self.post_act_l2_norm = config.mlp_post_act_l2_norm
+        self.cproj_scale = config.mlp_cproj_scale
+        self.dropout = nn.Dropout(config.dropout)
+
+    def _up_project(self, x, layer):
+        if self.l2_norm_mlp_up:
+            up_dim = 1 if self.l2_norm_mlp_up_dim == 'embed' else 0
+            weight = F.normalize(layer.weight, p=2, dim=up_dim)
+            return F.linear(x, weight, layer.bias)
+        return layer(x)
+
+    def _down_project(self, x, layer):
+        if self.l2_norm_mlp_down:
+            down_dim = 0 if self.l2_norm_mlp_down_dim == 'embed' else 1
+            weight = F.normalize(layer.weight, p=2, dim=down_dim)
+            return F.linear(x, weight, layer.bias)
+        return layer(x)
+
+    def forward(self, x, iter_num=None):
+        if self.quantization_mlp_dict["quantize_mlp_act_input"]:
+            num_bits = self.quantization_mlp_dict["quantize_mlp_act_input_bits"]
+            quant_method = self.quantization_mlp_dict["activations_quant_method"]
+            x = fake_quantize_act(self, "mlp_act_input", x, num_bits, quant_method, iter_num)
+
+        up1 = self._up_project(x, self.c_fc_in1)
+        up2 = self._up_project(x, self.c_fc_in2)
+
+        if self.quantization_mlp_dict["quantize_mlp_act_activation_input"]:
+            num_bits = self.quantization_mlp_dict["quantize_mlp_act_activation_input_bits"]
+            quant_method = self.quantization_mlp_dict["activations_quant_method"]
+            up1 = fake_quantize_act(self, "mlp_act_activation_input", up1, num_bits, quant_method, iter_num)
+            up2 = fake_quantize_act(self, "mlp_act_activation_input", up2, num_bits, quant_method, iter_num)
+
+        swiglu_gate = self.activation_variant(up1 - self.activation_x_offset) - self.activation_y_offset
+        swiglu_out = swiglu_gate * up2
+
+        magnitude = torch.abs(swiglu_out)
+        routed = self.activation_variant(magnitude - self.activation_x_offset) - self.activation_y_offset
+
+        if self.post_act_l2_norm:
+            routed = routed / routed.norm(dim=-1, keepdim=True).clamp_min(1e-6)
+
+        if self.cproj_scale is not None and self.cproj_scale != 1.0:
+            routed = routed / self.cproj_scale
+
+        pos_up1 = up1 >= 0
+        pos_up2 = up2 >= 0
+        mask_pos_neg = (pos_up1 & ~pos_up2).to(routed.dtype)
+        mask_neg_neg = (~pos_up1 & ~pos_up2).to(routed.dtype)
+        mask_pos_pos = (pos_up1 & pos_up2).to(routed.dtype)
+        mask_neg_pos = (~pos_up1 & pos_up2).to(routed.dtype)
+
+        x = (
+            self._down_project(routed * mask_pos_neg, self.c_proj_pos_neg)
+            + self._down_project(routed * mask_neg_neg, self.c_proj_neg_neg)
+            + self._down_project(routed * mask_pos_pos, self.c_proj_pos_pos)
+            + self._down_project(routed * mask_neg_pos, self.c_proj_neg_pos)
+        )
+
+        if self.quantization_mlp_dict["quantize_mlp_act_activation_output"]:
+            num_bits = self.quantization_mlp_dict["quantize_mlp_act_activation_output_bits"]
+            quant_method = self.quantization_mlp_dict["activations_quant_method"]
+            x = fake_quantize_act(self, "mlp_act_activation_output", x, num_bits, quant_method, iter_num)
+
+        x = self.dropout(x)
+
+        if self.quantization_mlp_dict["quantize_mlp_act_output"]:
+            num_bits = self.quantization_mlp_dict["quantize_mlp_act_output_bits"]
+            quant_method = self.quantization_mlp_dict["activations_quant_method"]
+            x = fake_quantize_act(self, "mlp_act_output", x, num_bits, quant_method, iter_num)
+
+        return x
+
 
 class KanMLP(nn.Module):
     def __init__(self, config):
@@ -890,7 +1061,8 @@ mlp_dictionary = {
     "identity": MLP_Identity,
     "kan": KanMLP,
     "dual_path": DualPathMLP,
-    "dual_path_swiglu": DualPathSwiglu
+    "dual_path_swiglu": DualPathSwiglu,
+    "quad_path_magnitude_swiglu": QuadPathMagnitudeSwiglu,
     }
 
 def get_mlp_instance(config):
@@ -899,4 +1071,3 @@ def get_mlp_instance(config):
     if mlp_class is None:
         raise ValueError(f"Unsupported MLP variant: {mlp_type}")
     return mlp_class(config)
-


### PR DESCRIPTION
### Motivation
- Introduce a quad-path SwiGLU-style MLP that routes activations into four down-projection heads based on sign and magnitude to experiment with richer routing and capacity allocations for MLP blocks.
- Expose the new MLP variant to training argument parsing so it can be selected in experiments and searches.
- Provide exploration and hyperparameter-search baseline artifacts to evaluate efficiency and equal-parameter comparisons for the new variant.

### Description
- Implemented `QuadPathMagnitudeSwiglu` in `variations/mlp_variations.py`, including two up projections, SwiGLU gating, magnitude-based routing, four distinct down-projection heads, optional L2 normalization, cproj scaling, and activation/linear quantization hooks.
- Registered the new variant in the MLP dictionary as `"quad_path_magnitude_swiglu"` and added it to the `--mlp_variant` choices in `train_args.py`.
- Added a unit test `tests/test_quad_path_magnitude_swiglu.py` that verifies the forward output shape matches embedding dimension and that the four down-projection layers share the intended input sizes.
- Added experiment config `explorations/quad_path_equal_param_default_inf.yaml`, a hyperparameter search baseline `hp_searches/quad_path_efficiency.yaml`, and a driver script `hp_searches/quad_path_efficiency.sh` to run efficiency-targeted searches for the quad-path variant.

### Testing
- Ran the new unit test `tests/test_quad_path_magnitude_swiglu.py`, which executed the forward pass and shape/assertion checks and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3bfa0bce083269984ac1512331dde)