### PR TITLE
feat(norm): add ProjectOutL2Norm variation and default_inf comparison sweep

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -78,3 +78,8 @@ This file gives coding agents the minimum repository-specific rules needed to co
 ## PR/Commit Notes
 - Commit title format: `<type(scope): summary>`
 
+## Variation Workflow Addendum
+- Whenever adding a new model variation (e.g., a new option under `variations/...`),
+  also add a corresponding YAML exploration file in `explorations/` based on
+  `explorations/default_inf.yaml` so the new variation can be compared directly
+  against default settings.

--- a/explorations/projectoutl2norm_inf_comparison.yaml
+++ b/explorations/projectoutl2norm_inf_comparison.yaml
@@ -1,0 +1,105 @@
+# Compare ProjectOutL2Norm vs default RMSNorm-WTE under default_inf-style settings.
+---
+
+named_static_groups:
+  # QK Norm
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  # Norm Type
+  - named_group: "peri_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [true]
+    use_post_ln: [false]
+
+  # Position Embeddings
+  - named_group: "rotary"
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+  # Embedding Norm
+  - named_group: "rmsnorm_wte"
+    norm_variant_wte: ["rmsnorm"]
+
+  - named_group: "projectoutl2norm_wte"
+    norm_variant_wte: ["projectoutl2norm"]
+
+  # MLP Activation
+  - named_group: "squared_relu"
+    activation_variant: ["squared_relu"]
+
+  # Relu2Max
+  - named_group: "relu2max"
+    softmax_variant_attn: ["relu2max"]
+
+  # Softmax
+  - named_group: "softmax"
+    softmax_variant_attn: ["softmax"]
+
+  # Infinite Attention
+  - named_group: "infinite"
+    attention_variant: ["infinite"]
+    use_concat_heads: [true]
+
+  # Head Dimension
+  - named_group: "hd_100"
+    n_qk_head_dim: [100]
+    n_v_head_dim: [100]
+
+  - named_group: "hd_150"
+    n_qk_head_dim: [150]
+    n_v_head_dim: [150]
+
+  - named_group: "hd_200"
+    n_qk_head_dim: [200]
+    n_v_head_dim: [200]
+
+  # MQA
+  - named_group: "mqa"
+    n_kv_group: [1]
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [2500]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+  compile: [true]
+  log_rankme: [true]
+  log_areq: [true]
+
+named_variation_groups:
+  - named_group: "wte_norm_var"
+    named_group_alternates: ["rmsnorm_wte", "projectoutl2norm_wte"]
+
+parameter_groups:
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "relu2max"
+      - "infinite"
+      - "mqa"
+    named_group_variations:
+      - "wte_norm_var"
+    n_head:
+      range:
+        start: 1
+        end: 12
+        step: 1
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "softmax"
+      - "infinite"
+      - "mqa"
+    named_group_variations:
+      - "wte_norm_var"
+    n_head:
+      range:
+        start: 1
+        end: 12
+        step: 1
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -419,6 +419,10 @@ class GPTConfig:
     hsnorm_scale: float = 1.0
     hsnorm_radius_learning: bool = False
 
+    pol2norm_eps: float = 1e-8
+    pol2norm_learn_scale: bool = True
+    pol2norm_init_scale: float | None = None
+
     dact_alpha_init: float = 1.0
     dact_activation: str = 'tanh'
     dact_use_gamma: bool = True

--- a/train_args.py
+++ b/train_args.py
@@ -765,6 +765,7 @@ def parse_args():
             "rmsnorm",
             "layernorm",
             "hyperspherenorm",
+            "projectoutl2norm",
             "dact",
             "identity",
             ]
@@ -805,6 +806,11 @@ def parse_args():
     model_group.add_argument("--hsnorm_scale", type=float, default=1.0)
     model_group.add_argument("--hsnorm_radius", type=float, default=None)
     model_group.add_argument("--hsnorm_radius_learning", default=False, action=argparse.BooleanOptionalAction)
+
+    ## ProjectOutL2Norm
+    model_group.add_argument("--pol2norm_eps", type=float, default=1e-8)
+    model_group.add_argument("--pol2norm_learn_scale", default=True, action=argparse.BooleanOptionalAction)
+    model_group.add_argument("--pol2norm_init_scale", type=float, default=None)
 
     activation_variations = [
             "celu",

--- a/variations/norm_variations.py
+++ b/variations/norm_variations.py
@@ -99,6 +99,52 @@ class HyperSphereNorm(nn.Module):
         hypersphere_norm = x.norm(2, dim=-1, keepdim=True)
         return  x / hypersphere_norm * radius * self.gain
 
+class ProjectOutL2Norm(nn.Module):
+    """
+    Remove the component of x along a learned direction, then L2-normalize.
+    """
+
+    def __init__(self, config):
+        super().__init__()
+        self.dim = config.n_embd
+        self.eps = config.pol2norm_eps
+
+        # Learned direction to project out
+        self.direction = nn.Parameter(torch.randn(self.dim))
+
+        # Optional learned radius after normalization
+        self.learn_scale = config.pol2norm_learn_scale
+        init_scale = config.pol2norm_init_scale
+        if init_scale is None:
+            init_scale = math.sqrt(self.dim)
+        if self.learn_scale:
+            self.log_scale = nn.Parameter(torch.tensor(math.log(init_scale)))
+        else:
+            self.register_buffer(
+                "fixed_scale",
+                torch.tensor(float(init_scale)),
+                persistent=False,
+            )
+
+    def forward(self, x):
+        if x.shape[-1] != self.dim:
+            raise ValueError(
+                f"Expected last dimension {self.dim}, got {x.shape[-1]}"
+            )
+
+        # Normalize learned direction
+        u = F.normalize(self.direction, p=2, dim=0, eps=self.eps)
+
+        # Component of x along u
+        coeff = (x * u).sum(dim=-1, keepdim=True)
+
+        # Remove that component then L2 normalize
+        z = x - coeff * u
+        y = F.normalize(z, p=2, dim=-1, eps=self.eps)
+
+        scale = self.log_scale.exp() if self.learn_scale else self.fixed_scale
+        return scale * y
+
 class pRMSNorm(nn.Module):
     """Partial RMS Normalization"""
 
@@ -217,6 +263,7 @@ norm_dictionary = {
     "prmsnorm": pRMSNorm,
     "krmsnorm": kRMSNorm,
     "hyperspherenorm": HyperSphereNorm,
+    "projectoutl2norm": ProjectOutL2Norm,
     "dact": DynamicActivation,
     "identity": IdentityNorm,
 }


### PR DESCRIPTION
### Motivation
- Add a new normalization option that projects out a learned direction then L2-normalizes, and provide an easy way to compare it against default settings.
- Ensure repository workflow requires adding an `explorations/` YAML for every new variation so comparisons to default configurations are straightforward.

### Description
- Implemented `ProjectOutL2Norm` in `variations/norm_variations.py` which learns a direction to project out, L2-normalizes the residual, and optionally applies a learned scale; the class is registered as `"projectoutl2norm"` in `norm_dictionary`.
- Added configuration fields in `gpt_conf.py`: `pol2norm_eps`, `pol2norm_learn_scale`, and `pol2norm_init_scale` (default `None` so the layer initializes scale to `sqrt(n_embd)` to match hypersphere-style default magnitude behavior).
- Exposed CLI/options in `train_args.py` by adding `projectoutl2norm` to `norm_variations` and adding `--pol2norm_eps`, `--pol2norm_learn_scale`, and `--pol2norm_init_scale` arguments.
- Created `explorations/projectoutl2norm_inf_comparison.yaml`, a new exploration YAML based on `explorations/default_inf.yaml`, to compare `rmsnorm_wte` vs `projectoutl2norm_wte` under default-style settings.
- Updated `Agents.md` with a `Variation Workflow Addendum` requiring that new model variations be accompanied by an `explorations/` YAML derived from `default_inf.yaml` for direct comparisons.

### Testing
- Ran Python byte-compile: `python -m py_compile variations/norm_variations.py gpt_conf.py train_args.py` and it succeeded.
- Verified references with ripgrep: `rg -n "projectoutl2norm|pol2norm" variations/norm_variations.py gpt_conf.py train_args.py explorations/projectoutl2norm_inf_comparison.yaml Agents.md` and found the new symbols in the updated files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c6aa9d34832685c4c14c8ae7919c)