### PR TITLE
Add run duration and completion timestamps to experiment logging

### DIFF
--- a/optimization_and_search/run_experiments.py
+++ b/optimization_and_search/run_experiments.py
@@ -45,6 +45,8 @@ METRIC_KEYS = [
     "zeus_avg_power_w",
     "zeus_train_step_energy_j",
     "zeus_energy_per_token_j",
+    "run_total_time_s",
+    "run_completed_at",
 ]
 
 
@@ -652,11 +654,24 @@ def completed_runs(log_file: Path) -> set[str]:
     return runs
 
 
-def append_log(log_file: Path, name: str, combo: dict, metrics: dict) -> None:
+def append_log(
+    log_file: Path,
+    name: str,
+    combo: dict,
+    metrics: dict,
+    run_total_time_s: float,
+    run_completed_at: str,
+) -> None:
     """
     Append a YAML entry with run details and metrics.
     """
-    entry = {'formatted_name': name, 'config': combo, **metrics}
+    entry = {
+        'formatted_name': name,
+        'config': combo,
+        **metrics,
+        'run_total_time_s': run_total_time_s,
+        'run_completed_at': run_completed_at,
+    }
     with log_file.open('a') as f:
         yaml.safe_dump(entry, f, explicit_start=True)
 
@@ -738,10 +753,14 @@ def run_experiment(
     # Build and run
     cmd = build_command(combo)
     print(f"Running: {' '.join(cmd)}")
+    run_started_at = datetime.now()
     try:
         subprocess.run(cmd, check=True)
     except subprocess.CalledProcessError:
         print(f"[red]Process exited with error for run:[/] {run_name}")
+    run_finished_at = datetime.now()
+    run_total_time_s = (run_finished_at - run_started_at).total_seconds()
+    run_completed_at = run_finished_at.strftime("%Y-%m-%d %H:%M:%S")
 
     # Read metrics (use existing or nan on failure)
     try:
@@ -749,7 +768,14 @@ def run_experiment(
     except Exception:
         metrics = {k: float("nan") for k in METRIC_KEYS}
 
-    append_log(log_file, run_name, combo, metrics)
+    append_log(
+        log_file,
+        run_name,
+        combo,
+        metrics,
+        run_total_time_s=run_total_time_s,
+        run_completed_at=run_completed_at,
+    )
 
 
 def main():

--- a/run_exploration_monitor.py
+++ b/run_exploration_monitor.py
@@ -302,33 +302,7 @@ class MonitorApp(App):
 
     def get_cell(self, entry: Dict, col_name: str):
         """Retrieve the value for a given column in an entry."""
-        if col_name in (
-            "best_val_loss",
-            "best_val_iter",
-            "best_val_tokens",
-            "num_params",
-            "peak_torch_allocated_mb",
-            "peak_torch_reserved_mb",
-            "peak_process_gpu_mb",
-            "iter_latency_avg",
-            "zeus_best_train_step_energy_j",
-            "avg_top1_prob",
-            "avg_top1_correct",
-            "avg_target_rank",
-            "avg_target_left_prob",
-            "avg_target_prob",
-            "target_rank_95",
-            "left_prob_95",
-            "avg_ln_f_cosine",
-            "ln_f_cosine_95",
-            "rankme",
-            "areq",
-            "zeus_total_energy_j",
-            "zeus_total_time_s",
-            "zeus_avg_power_w",
-            "zeus_train_step_energy_j",
-            "zeus_energy_per_token_j",
-        ):
+        if col_name in entry:
             return entry.get(col_name)
         return entry.get("config", {}).get(col_name)
 

--- a/run_exploration_monitor.py
+++ b/run_exploration_monitor.py
@@ -208,6 +208,8 @@ class MonitorApp(App):
             "zeus_avg_power_w",
             "zeus_train_step_energy_j",
             "zeus_energy_per_token_j",
+            "run_total_time_s",
+            "run_completed_at",
         ] + self.param_keys
         self.all_columns = base_cols.copy()
         self.columns = base_cols.copy()


### PR DESCRIPTION
### Motivation
- Include per-run timing metadata so users can see how long each experiment took and when it finished in the YAML logs.
- Surface those fields in the monitor UI so timelines and durations can be inspected alongside existing metrics.

### Description
- Added two new fields to the metrics schema: `run_total_time_s` and `run_completed_at` in `optimization_and_search/run_experiments.py` (`METRIC_KEYS`).
- Extended `append_log(...)` to accept and persist `run_total_time_s` and `run_completed_at` into each YAML entry written to the exploration log.
- Instrumented `run_experiment(...)` to capture wall-clock start/end around `subprocess.run(...)`, compute elapsed seconds, and format a completion timestamp for logging.
- Exposed both `run_total_time_s` and `run_completed_at` in the monitor by adding them to the default columns in `run_exploration_monitor.py`.

### Testing
- Compiled the modified modules with `python -m py_compile optimization_and_search/run_experiments.py run_exploration_monitor.py` which completed successfully.
- Static checks / basic syntax validation passed with no errors reported by the compile step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e516d87c0483269ecdcd5e1e3caa0c)