### PR TITLE
Add hyperbolic LM-head logits and experiment config for hyperbolic vs softmax infinite-attention

### DIFF
--- a/explorations/default_inf_hyperbolic_vs_baseline.yaml
+++ b/explorations/default_inf_hyperbolic_vs_baseline.yaml
@@ -1,0 +1,86 @@
+# Compare hyperbolic / relu2max infinite-attention runs against a baseline.
+# Baseline = softmax attention, and explicitly *not* MQA.
+---
+
+named_static_groups:
+  # QK Norm
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  # Norm Type
+  - named_group: "peri_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [true]
+    use_post_ln: [false]
+
+  # Position Embeddings
+  - named_group: "rotary"
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+  # MLP Activation
+  - named_group: "squared_relu"
+    activation_variant: ["squared_relu"]
+
+  # Attention Softmax Variant
+  - named_group: "relu2max"
+    softmax_variant_attn: ["relu2max"]
+
+  - named_group: "softmax"
+    softmax_variant_attn: ["softmax"]
+
+  # Infinite Attention
+  - named_group: "infinite"
+    attention_variant: ["infinite"]
+    use_concat_heads: [true]
+
+  # Head Dimension
+  - named_group: "hd_100"
+    n_qk_head_dim: [100]
+    n_v_head_dim: [100]
+
+  - named_group: "hd_150"
+    n_qk_head_dim: [150]
+    n_v_head_dim: [150]
+
+  - named_group: "hd_200"
+    n_qk_head_dim: [200]
+    n_v_head_dim: [200]
+
+  # Full KV groups (not MQA)
+  - named_group: "no_mqa"
+    n_head: [12]
+    n_kv_group: [12]
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [2500]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+  compile: [true]
+  log_rankme: [true]
+  log_areq: [true]
+
+parameter_groups:
+  # Experiment arm (non-baseline): relu2max + no MQA
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "squared_relu"
+      - "relu2max"
+      - "infinite"
+      - "no_mqa"
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]
+
+  # Baseline arm: softmax + no MQA
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "squared_relu"
+      - "softmax"
+      - "infinite"
+      - "no_mqa"
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -102,6 +102,11 @@ class GPTConfig:
     attn_logit_softcapping: float | None = None
     final_logit_softcapping: float | None = None
 
+    # LM-head manifold options
+    lm_head_manifold: str = "euclidean"  # "euclidean" or "hyperbolic"
+    hyperbolic_curvature: float = 1.0
+    hyperbolic_logit_scale: float = 1.0
+
     # Final ln_f input mixing
     use_ln_f_input_mixer: bool = False
     ln_f_input_mixer_variant: str = "linear"

--- a/model.py
+++ b/model.py
@@ -214,6 +214,42 @@ class GPT(nn.Module):
         # report number of parameters
         print("number of parameters: %.2fM" % (self.get_num_params()/1e6,))
 
+    def compute_lm_logits(self, hidden_states, lm_head):
+        """Compute logits in Euclidean space or via a hyperbolic manifold."""
+        if self.config.lm_head_manifold == "euclidean":
+            return lm_head(hidden_states)
+        if self.config.lm_head_manifold != "hyperbolic":
+            raise ValueError(
+                f"Unsupported lm_head_manifold={self.config.lm_head_manifold}. "
+                "Expected 'euclidean' or 'hyperbolic'."
+            )
+
+        if self.config.hyperbolic_curvature <= 0:
+            raise ValueError("hyperbolic_curvature must be positive for hyperbolic lm head")
+
+        # Hyperboloid model with curvature c > 0 and radius sqrt(K), K = 1/c.
+        # Map hidden vectors and token prototypes to hyperboloid:
+        # phi(x) = [sqrt(K + ||x||^2), x]
+        # d_H(phi(x), phi(w)) = sqrt(K) * arcosh(-<phi(x),phi(w)>_L / K)
+        # logits = -scale * d_H^2
+        c = self.config.hyperbolic_curvature
+        K = 1.0 / c
+
+        eps = 1e-6
+        x = hidden_states
+        w = lm_head.weight
+
+        x_sq = (x * x).sum(dim=-1, keepdim=True)
+        w_sq = (w * w).sum(dim=-1, keepdim=True).transpose(0, 1)
+        x0 = torch.sqrt(torch.clamp(x_sq + K, min=eps))
+        w0 = torch.sqrt(torch.clamp(w_sq + K, min=eps))
+
+        spatial_dot = torch.matmul(x, w.transpose(0, 1))
+        lorentz_inner = -x0 * w0 + spatial_dot
+        acosh_arg = torch.clamp(-lorentz_inner / K, min=1.0 + eps)
+        d_h = math.sqrt(K) * torch.acosh(acosh_arg)
+        return -self.config.hyperbolic_logit_scale * (d_h * d_h)
+
     def get_num_params(self, non_embedding=True):
         """
         Return the number of parameters in the model.
@@ -500,7 +536,7 @@ class GPT(nn.Module):
                     logits = [pred[:, [-1], :] for pred in logits]
                     losses = None
             else:
-                logits = [self.transformer[f'lm_head_{i}'](x) for i in range(len(token_list))]
+                logits = [self.compute_lm_logits(x, self.transformer[f'lm_head_{i}']) for i in range(len(token_list))]
 
                 # Soft‑cap **each** logits tensor (training & inference)
                 if self.config.final_logit_softcapping is not None:
@@ -606,9 +642,9 @@ class GPT(nn.Module):
             if targets is not None:
                 # if we are given some desired targets also calculate the loss
                 if self.config.multidataset_wte and dataset_idx is not None:
-                    logits = self.transformer[f'lm_head_{dataset_idx}'](x)
+                    logits = self.compute_lm_logits(x, self.transformer[f'lm_head_{dataset_idx}'])
                 else:
-                    logits = self.lm_head(x)
+                    logits = self.compute_lm_logits(x, self.lm_head)
 
                 if self.config.final_logit_softcapping is not None:
                     logits = logits / self.config.final_logit_softcapping
@@ -622,9 +658,9 @@ class GPT(nn.Module):
             else:
                 # inference-time mini-optimization: only forward the lm_head on the very last position
                 if self.config.multidataset_wte and dataset_idx is not None:
-                    logits = self.transformer[f'lm_head_{dataset_idx}'](x[:, [-1], :])
+                    logits = self.compute_lm_logits(x[:, [-1], :], self.transformer[f'lm_head_{dataset_idx}'])
                 else:
-                    logits = self.lm_head(x[:, [-1], :]) # note: using list [-1] to preserve the time dim
+                    logits = self.compute_lm_logits(x[:, [-1], :], self.lm_head) # note: using list [-1] to preserve the time dim
 
                 if self.config.final_logit_softcapping is not None:
                     logits = logits / self.config.final_logit_softcapping
@@ -707,9 +743,9 @@ class GPT(nn.Module):
             x = F.linear(x, self.transformer.scale_down.weight.t())
 
         if self.config.multidataset_wte and dataset_idx is not None:
-            logits = self.transformer[f'lm_head_{dataset_idx}'](x)
+            logits = self.compute_lm_logits(x, self.transformer[f'lm_head_{dataset_idx}'])
         else:
-            logits = self.lm_head(x)
+            logits = self.compute_lm_logits(x, self.lm_head)
         if self.final_logit_softcapping is not None:
             logits = torch.tanh(logits / self.final_logit_softcapping) \
                      * self.final_logit_softcapping


### PR DESCRIPTION
### Motivation

- Provide an option to compute language-model logits on a hyperbolic manifold instead of Euclidean dot-products to enable experiments with non-Euclidean output spaces. 
- Expose curvature and scaling hyperparameters to control hyperbolic logit behavior. 
- Make the model runtime-selectable between Euclidean and hyperbolic LM heads to compare downstream behavior without changing other model code. 
- Add an experiment configuration to compare infinite-attention runs with hyperbolic vs softmax attention baselines.

### Description

- Added three new config fields to `GPTConfig`: `lm_head_manifold`, `hyperbolic_curvature`, and `hyperbolic_logit_scale` to select and parameterize the LM-head manifold. 
- Implemented `GPT.compute_lm_logits` which computes logits either by calling the original linear `lm_head` for the Euclidean case or by computing squared hyperbolic distances in the hyperboloid model (with radius `sqrt(1/c)`) and returning negative scaled squared distances as logits for the hyperbolic case. 
- Replaced direct `lm_head(...)` calls throughout the forward paths and `embed_tokens` with `compute_lm_logits(...)` so the manifold selection is applied consistently. 
- Added `explorations/default_inf_hyperbolic_vs_baseline.yaml` to define sweep arms comparing `relu2max` infinite-attention runs against a `softmax` baseline (both using no MQA) across multiple head-dimension settings.

### Testing

- Ran a smoke forward-pass using random input tensors through the model with both `lm_head_manifold = "euclidean"` and `lm_head_manifold = "hyperbolic"` and observed expected logits shapes and no runtime errors. 
- Ran core model unit tests and lint checks in the repository; these tests completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eedee7c3a883269db6fa94b54313ac)