### PR TITLE
Add hyperbolic LM-head manifold, compute logits on hyperboloid, and add experiment config

### DIFF
--- a/explorations/hyperbolic_vs_baseline_default_inf.yaml
+++ b/explorations/hyperbolic_vs_baseline_default_inf.yaml
@@ -1,0 +1,92 @@
+# hyperbolic_vs_baseline_default_inf.yaml
+# Based on explorations/default_inf.yaml:
+# - both arms use softmax attention
+# - both arms use n_head=3 and n_kv_group=3
+# - only difference is LM-head manifold (hyperbolic vs euclidean)
+---
+
+named_static_groups:
+  # QK Norm
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  # Norm Type
+  - named_group: "peri_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [true]
+    use_post_ln: [false]
+
+  # Position Embeddings
+  - named_group: "rotary"
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+  # Attention type
+  - named_group: "infinite"
+    attention_variant: ["infinite"]
+    use_concat_heads: [true]
+
+  # Head dimensions (from default_inf)
+  - named_group: "hd_100"
+    n_qk_head_dim: [100]
+    n_v_head_dim: [100]
+
+  - named_group: "hd_150"
+    n_qk_head_dim: [150]
+    n_v_head_dim: [150]
+
+  - named_group: "hd_200"
+    n_qk_head_dim: [200]
+    n_v_head_dim: [200]
+
+  # Attention softmax variant (shared by both arms)
+  - named_group: "softmax"
+    softmax_variant_attn: ["softmax"]
+
+  # Fixed head and KV grouping for both comparison arms
+  - named_group: "h3_kv3"
+    n_head: [3]
+    n_kv_group: [3]
+
+  # LM-head manifolds
+  - named_group: "lm_head_hyperbolic"
+    lm_head_manifold: ["hyperbolic"]
+    hyperbolic_curvature: [1.0]
+    hyperbolic_logit_scale: [1.0]
+
+  - named_group: "lm_head_euclidean"
+    lm_head_manifold: ["euclidean"]
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [2500]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+  compile: [true]
+  log_rankme: [true]
+  log_areq: [true]
+  tensorboard_run_name: ["hyperbolic_vs_baseline_default_inf"]
+
+parameter_groups:
+  # Hyperbolic arm
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "infinite"
+      - "softmax"
+      - "h3_kv3"
+      - "lm_head_hyperbolic"
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]
+
+  # Regular (Euclidean) arm
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "softmax"
+      - "infinite"
+      - "h3_kv3"
+      - "lm_head_euclidean"
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -102,6 +102,11 @@ class GPTConfig:
     attn_logit_softcapping: float | None = None
     final_logit_softcapping: float | None = None
 
+    # LM-head manifold options
+    lm_head_manifold: str = "euclidean"  # "euclidean" or "hyperbolic"
+    hyperbolic_curvature: float = 1.0
+    hyperbolic_logit_scale: float = 1.0
+
     # Final ln_f input mixing
     use_ln_f_input_mixer: bool = False
     ln_f_input_mixer_variant: str = "linear"

--- a/model.py
+++ b/model.py
@@ -214,6 +214,42 @@ class GPT(nn.Module):
         # report number of parameters
         print("number of parameters: %.2fM" % (self.get_num_params()/1e6,))
 
+    def compute_lm_logits(self, hidden_states, lm_head):
+        """Compute logits in Euclidean space or via a hyperbolic manifold."""
+        if self.config.lm_head_manifold == "euclidean":
+            return lm_head(hidden_states)
+        if self.config.lm_head_manifold != "hyperbolic":
+            raise ValueError(
+                f"Unsupported lm_head_manifold={self.config.lm_head_manifold}. "
+                "Expected 'euclidean' or 'hyperbolic'."
+            )
+
+        if self.config.hyperbolic_curvature <= 0:
+            raise ValueError("hyperbolic_curvature must be positive for hyperbolic lm head")
+
+        # Hyperboloid model with curvature c > 0 and radius sqrt(K), K = 1/c.
+        # Map hidden vectors and token prototypes to hyperboloid:
+        # phi(x) = [sqrt(K + ||x||^2), x]
+        # d_H(phi(x), phi(w)) = sqrt(K) * arcosh(-<phi(x),phi(w)>_L / K)
+        # logits = -scale * d_H^2
+        c = self.config.hyperbolic_curvature
+        K = 1.0 / c
+
+        eps = 1e-6
+        x = hidden_states
+        w = lm_head.weight
+
+        x_sq = (x * x).sum(dim=-1, keepdim=True)
+        w_sq = (w * w).sum(dim=-1, keepdim=True).transpose(0, 1)
+        x0 = torch.sqrt(torch.clamp(x_sq + K, min=eps))
+        w0 = torch.sqrt(torch.clamp(w_sq + K, min=eps))
+
+        spatial_dot = torch.matmul(x, w.transpose(0, 1))
+        lorentz_inner = -x0 * w0 + spatial_dot
+        acosh_arg = torch.clamp(-lorentz_inner / K, min=1.0 + eps)
+        d_h = math.sqrt(K) * torch.acosh(acosh_arg)
+        return -self.config.hyperbolic_logit_scale * (d_h * d_h)
+
     def get_num_params(self, non_embedding=True):
         """
         Return the number of parameters in the model.
@@ -500,7 +536,7 @@ class GPT(nn.Module):
                     logits = [pred[:, [-1], :] for pred in logits]
                     losses = None
             else:
-                logits = [self.transformer[f'lm_head_{i}'](x) for i in range(len(token_list))]
+                logits = [self.compute_lm_logits(x, self.transformer[f'lm_head_{i}']) for i in range(len(token_list))]
 
                 # Soft‑cap **each** logits tensor (training & inference)
                 if self.config.final_logit_softcapping is not None:
@@ -606,9 +642,9 @@ class GPT(nn.Module):
             if targets is not None:
                 # if we are given some desired targets also calculate the loss
                 if self.config.multidataset_wte and dataset_idx is not None:
-                    logits = self.transformer[f'lm_head_{dataset_idx}'](x)
+                    logits = self.compute_lm_logits(x, self.transformer[f'lm_head_{dataset_idx}'])
                 else:
-                    logits = self.lm_head(x)
+                    logits = self.compute_lm_logits(x, self.lm_head)
 
                 if self.config.final_logit_softcapping is not None:
                     logits = logits / self.config.final_logit_softcapping
@@ -622,9 +658,9 @@ class GPT(nn.Module):
             else:
                 # inference-time mini-optimization: only forward the lm_head on the very last position
                 if self.config.multidataset_wte and dataset_idx is not None:
-                    logits = self.transformer[f'lm_head_{dataset_idx}'](x[:, [-1], :])
+                    logits = self.compute_lm_logits(x[:, [-1], :], self.transformer[f'lm_head_{dataset_idx}'])
                 else:
-                    logits = self.lm_head(x[:, [-1], :]) # note: using list [-1] to preserve the time dim
+                    logits = self.compute_lm_logits(x[:, [-1], :], self.lm_head) # note: using list [-1] to preserve the time dim
 
                 if self.config.final_logit_softcapping is not None:
                     logits = logits / self.config.final_logit_softcapping
@@ -707,9 +743,9 @@ class GPT(nn.Module):
             x = F.linear(x, self.transformer.scale_down.weight.t())
 
         if self.config.multidataset_wte and dataset_idx is not None:
-            logits = self.transformer[f'lm_head_{dataset_idx}'](x)
+            logits = self.compute_lm_logits(x, self.transformer[f'lm_head_{dataset_idx}'])
         else:
-            logits = self.lm_head(x)
+            logits = self.compute_lm_logits(x, self.lm_head)
         if self.final_logit_softcapping is not None:
             logits = torch.tanh(logits / self.final_logit_softcapping) \
                      * self.final_logit_softcapping


### PR DESCRIPTION
### Motivation
- Provide an alternative LM-head that scores tokens in a hyperbolic manifold instead of Euclidean dot-products to compare geometric effects on final logits. 
- Expose hyperbolic head hyper-parameters in configuration so experiments can toggle and tune curvature and scaling. 
- Add an experiment spec to compare hyperbolic vs euclidean LM-heads under the same attention/architecture settings.

### Description
- Added `lm_head_manifold`, `hyperbolic_curvature`, and `hyperbolic_logit_scale` to `GPTConfig` in `gpt_conf.py` to configure the LM-head manifold and related hyper-parameters. 
- Implemented `compute_lm_logits(self, hidden_states, lm_head)` in `model.py` which dispatches to the regular linear head when `lm_head_manifold == "euclidean"` and computes logits from squared hyperbolic distance in the hyperboloid model when `lm_head_manifold == "hyperbolic"`; this includes validation of `hyperbolic_curvature` and manifold option. 
- Replaced direct calls to the linear `lm_head(...)` with `compute_lm_logits(...)` in all forward/embed code paths so both training and inference use the selected manifold implementation. 
- Added an experiment file `explorations/hyperbolic_vs_baseline_default_inf.yaml` that defines two arms (hyperbolic vs euclidean LM-heads) with matching attention and head dimensions for head-to-head comparison.

### Testing
- Ran a minimal smoke test by importing the model, instantiating `GPTConfig`, creating a `GPT` model, and running a forward/inference pass with random inputs for `lm_head_manifold = "euclidean"`, which produced logits of the expected shape. 
- Repeated the same smoke forward pass with `lm_head_manifold = "hyperbolic"` and `hyperbolic_curvature > 0`, which produced logits and did not raise exceptions. 
- No additional automated unit/CI tests were modified; these basic smoke checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eedee7c3a883269db6fa94b54313ac)