### PR TITLE
feat(lm-head): add hyperbolic manifold LM head geometry option

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -101,6 +101,9 @@ class GPTConfig:
     # Softcapping params
     attn_logit_softcapping: float | None = None
     final_logit_softcapping: float | None = None
+    lm_head_geometry: str = "euclidean"  # euclidean | hyperspherical | hyperbolic
+    lm_head_logit_scale: float = 1.0
+    lm_head_hyperbolic_c: float = 1.0
 
     # Final ln_f input mixing
     use_ln_f_input_mixer: bool = False

--- a/model.py
+++ b/model.py
@@ -40,6 +40,7 @@ from variations.linear_variations import linear_dictionary
 from variations.router_variations import router_dictionary
 from variations.output_vector_variants import output_vector_variant_dict
 from variations.numerical_mapping_variations import get_numerical_embedding, get_numerical_output
+from variations.lm_head_variations import lm_head_dictionary
 from quantization.quantize import quantize_dictionary, dequantize, fake_quantize_act
 from quantization.quant_utils import set_variant, create_activation_buffers
 
@@ -134,7 +135,7 @@ class GPT(nn.Module):
                     for i, vocab_size in enumerate(self.config.vocab_sizes):
                         embedding_layer = nn.Embedding(vocab_size, config.n_embd)
                         self.transformer[f'wte_{i}'] = embedding_layer
-                        self.transformer[f'lm_head_{i}'] = nn.Linear(config.n_embd, vocab_size, bias=False)
+                        self.transformer[f'lm_head_{i}'] = self.build_lm_head(config.n_embd, vocab_size)
                 else:
                     # no factorization
                     word_embd = nn.Embedding(config.vocab_size, config.n_embd)
@@ -160,14 +161,14 @@ class GPT(nn.Module):
             self.softmax_layer_output = softmax_dictionary[config.softmax_variant_output](config)
 
         if config.n_embd_wte:
-            self.lm_head = nn.Linear(config.n_embd_wte, config.vocab_size, bias=False)
+            self.lm_head = self.build_lm_head(config.n_embd_wte, config.vocab_size)
         else:
             #TODO: currently multicontext is in own category, add support later for WTE factorization
             if (config.multicontext or config.multidataset_wte) and not self.uses_numerical_multicontext:
                 for i, vocab_size in enumerate(self.config.vocab_sizes):
                     self.transformer[f'lm_head_{i}'].weight = self.transformer[f'wte_{i}'].weight
             else:
-                self.lm_head = nn.Linear(config.n_embd, config.vocab_size, bias=False)
+                self.lm_head = self.build_lm_head(config.n_embd, config.vocab_size)
 
         # Initialize and possibly import scale_up and scale_down matrices, if factorization is set
         if self.n_embd_wte:
@@ -244,6 +245,12 @@ class GPT(nn.Module):
             if getattr(norm_config, src, None) is not None:
                 setattr(norm_config, f"hsnorm_{attr}", getattr(norm_config, src))
         return norm_dictionary[getattr(config, variant_key)](norm_config)
+
+    def build_lm_head(self, in_features: int, vocab_size: int):
+        variant = getattr(self.config, "lm_head_geometry", "euclidean")
+        if variant not in lm_head_dictionary:
+            raise ValueError(f"Unsupported lm_head_geometry: {variant}")
+        return lm_head_dictionary[variant](in_features, vocab_size, self.config)
 
     def _init_weights(self, module):
         """

--- a/tests/test_lm_head_geometries.py
+++ b/tests/test_lm_head_geometries.py
@@ -1,0 +1,45 @@
+import unittest
+
+import torch
+
+from gpt_conf import GPTConfig
+from model import GPT
+
+
+class LMHeadGeometryTest(unittest.TestCase):
+    def _run_geometry(self, geometry: str):
+        torch.manual_seed(0)
+        config = GPTConfig(
+            block_size=8,
+            vocab_size=32,
+            n_layer=1,
+            n_head=2,
+            n_embd=16,
+            dropout=0.0,
+            use_abs_pos_embeddings=False,
+            lm_head_geometry=geometry,
+            lm_head_logit_scale=1.0,
+            lm_head_hyperbolic_c=1.0,
+        )
+        model = GPT(config)
+        idx = torch.randint(0, config.vocab_size, (2, 5))
+        targets = torch.randint(0, config.vocab_size, (2, 5))
+        logits, loss = model(idx, targets=targets)
+
+        self.assertEqual(tuple(logits.shape), (2, 5, config.vocab_size))
+        self.assertIsNotNone(loss)
+        self.assertTrue(torch.isfinite(logits).all().item())
+        self.assertTrue(torch.isfinite(loss).item())
+
+    def test_euclidean_geometry(self):
+        self._run_geometry("euclidean")
+
+    def test_hyperspherical_geometry(self):
+        self._run_geometry("hyperspherical")
+
+    def test_hyperbolic_geometry(self):
+        self._run_geometry("hyperbolic")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/train_args.py
+++ b/train_args.py
@@ -615,6 +615,12 @@ def parse_args():
     model_group.add_argument('--use_flex_attn', default=None,  action=argparse.BooleanOptionalAction, help="option for using flex attention for sliding windows")
     model_group.add_argument('--attn_logit_softcapping', default=None, action=argparse.BooleanOptionalAction, help="option for softcapping attention (before masking)")
     model_group.add_argument('--final_logit_softcapping', default=None, action=argparse.BooleanOptionalAction, help="option for softcapping final logits")
+    model_group.add_argument('--lm_head_geometry', type=str, default='euclidean', choices=['euclidean', 'hyperspherical', 'hyperbolic'],
+                             help='Geometry for output classifier logits.')
+    model_group.add_argument('--lm_head_logit_scale', type=float, default=1.0,
+                             help='Global scale on LM head logits (all geometries).')
+    model_group.add_argument('--lm_head_hyperbolic_c', type=float, default=1.0,
+                             help='Positive curvature parameter c for hyperbolic LM head.')
     model_group.add_argument('--use_ln_f_input_mixer', default=False, action=argparse.BooleanOptionalAction, help='blend outputs of all blocks before final layer norm')
     model_group.add_argument('--ln_f_input_mixer_variant', default='linear', type=str,
                              choices=['linear', 'router_top1', 'router_topk', 'decoder'],

--- a/variations/lm_head_variations.py
+++ b/variations/lm_head_variations.py
@@ -1,0 +1,72 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class EuclideanLMHead(nn.Module):
+    """Standard linear language-model head."""
+
+    def __init__(self, in_features: int, vocab_size: int, config):
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(vocab_size, in_features))
+        nn.init.normal_(self.weight, mean=0.0, std=0.02)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return F.linear(x, self.weight)
+
+
+class HypersphericalLMHead(nn.Module):
+    """Cosine-similarity LM head (vectors constrained to a hypersphere)."""
+
+    def __init__(self, in_features: int, vocab_size: int, config):
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(vocab_size, in_features))
+        nn.init.normal_(self.weight, mean=0.0, std=0.02)
+        self.logit_scale = float(getattr(config, "lm_head_logit_scale", 1.0))
+        self.eps = 1e-6
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x_n = F.normalize(x, p=2, dim=-1, eps=self.eps)
+        w_n = F.normalize(self.weight, p=2, dim=-1, eps=self.eps)
+        return self.logit_scale * F.linear(x_n, w_n)
+
+
+class HyperbolicLMHead(nn.Module):
+    """Poincare-ball classifier: logits are negative squared hyperbolic distances."""
+
+    def __init__(self, in_features: int, vocab_size: int, config):
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(vocab_size, in_features))
+        nn.init.normal_(self.weight, mean=0.0, std=0.02)
+        self.c = float(getattr(config, "lm_head_hyperbolic_c", 1.0))
+        self.logit_scale = float(getattr(config, "lm_head_logit_scale", 1.0))
+        self.eps = 1e-6
+
+    def _project_ball(self, x: torch.Tensor) -> torch.Tensor:
+        max_norm = (1.0 - self.eps) / (self.c ** 0.5)
+        x_norm = x.norm(dim=-1, keepdim=True).clamp_min(self.eps)
+        scale = torch.clamp(max_norm / x_norm, max=1.0)
+        return x * scale
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x_ball = self._project_ball(x)
+        w_ball = self._project_ball(self.weight)
+
+        x2 = x_ball.pow(2).sum(dim=-1, keepdim=True)  # (B,T,1) or (N,1)
+        w2 = w_ball.pow(2).sum(dim=-1).view(*([1] * (x.dim() - 1)), -1)  # (...,V)
+        cross = torch.matmul(x_ball, w_ball.transpose(0, 1))  # (...,V)
+        sqdist = (x2 + w2 - 2.0 * cross).clamp_min(0.0)
+
+        denom = (1.0 - self.c * x2) * (1.0 - self.c * w2)
+        denom = denom.clamp_min(self.eps)
+        argument = 1.0 + 2.0 * self.c * sqdist / denom
+        argument = argument.clamp_min(1.0 + self.eps)
+        d = torch.acosh(argument) / (self.c ** 0.5)
+        return -self.logit_scale * d.pow(2)
+
+
+lm_head_dictionary = {
+    "euclidean": EuclideanLMHead,
+    "hyperspherical": HypersphericalLMHead,
+    "hyperbolic": HyperbolicLMHead,
+}


### PR DESCRIPTION
### Motivation
- Provide a pluggable LM-head that can use alternative output geometries (euclidean, hyperspherical, hyperbolic) so the classifier can operate on manifolds instead of only using standard linear logits.
- Allow experiments comparing cosine/hyperspherical logits and hyperbolic (Poincaré-ball) logits for improved representational geometry of class prototypes.

### Description
- Added `variations/lm_head_variations.py` with three LM head implementations: `EuclideanLMHead`, `HypersphericalLMHead` (cosine similarity), and `HyperbolicLMHead` (negative squared Poincaré-ball distance) and exported `lm_head_dictionary`.
- Added config knobs to `GPTConfig` in `gpt_conf.py`: `lm_head_geometry`, `lm_head_logit_scale`, and `lm_head_hyperbolic_c` to choose geometry and tuning parameters.
- Exposed CLI flags in `train_args.py`: `--lm_head_geometry`, `--lm_head_logit_scale`, and `--lm_head_hyperbolic_c` for runtime selection.
- Wired `model.py` to use a new factory `build_lm_head(in_features, vocab_size)` which constructs the selected LM head from `lm_head_dictionary` and preserves existing weight-tying semantics by relying on a `weight` parameter on each head.
- Added unit tests `tests/test_lm_head_geometries.py` that instantiate a tiny `GPT` config and assert output shape and finiteness for `euclidean`, `hyperspherical`, and `hyperbolic` heads.

### Testing
- Ran static checks: `python -m py_compile model.py gpt_conf.py train_args.py variations/lm_head_variations.py tests/test_lm_head_geometries.py` succeeded.
- Ran unit tests: `python -m unittest tests/test_lm_head_geometries.py` was executed but failed in this environment due to missing runtime dependency (`torch` not installed), so the tests could not be validated here.
- Added the new unit test file `tests/test_lm_head_geometries.py` which will run in CI where `torch` is available and should validate output shapes and numerical finiteness for all three geometries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eedee7c3a883269db6fa94b54313ac)