### PR TITLE
feat(explorations): add default_inf lm-head geometry comparison yaml

### DIFF
--- a/explorations/lm_head_geometry_default_inf_comparison.yaml
+++ b/explorations/lm_head_geometry_default_inf_comparison.yaml
@@ -1,0 +1,80 @@
+# Compare LM head geometries (euclidean vs hyperbolic vs hyperspherical)
+# while keeping the rest aligned with default_inf.yaml.
+---
+
+named_static_groups:
+  # QK Norm
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  # Norm Type
+  - named_group: "peri_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [true]
+    use_post_ln: [false]
+
+  # Position Embeddings
+  - named_group: "rotary"
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+  # Embedding Norm
+  - named_group: "rmsnorm_wte"
+    norm_variant_wte: ["rmsnorm"]
+
+  # MLP Activation
+  - named_group: "squared_relu"
+    activation_variant: ["squared_relu"]
+
+  # Infinite Attention
+  - named_group: "infinite"
+    attention_variant: ["infinite"]
+    use_concat_heads: [true]
+
+  # MQA
+  - named_group: "mqa"
+    n_kv_group: [1]
+
+  # Keep a single head-dim choice for an apples-to-apples geometry comparison
+  - named_group: "hd_100"
+    n_qk_head_dim: [100]
+    n_v_head_dim: [100]
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [2500]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+  compile: [true]
+  log_rankme: [true]
+  log_areq: [true]
+
+parameter_groups:
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "infinite"
+      - "mqa"
+      - "squared_relu"
+      - "rmsnorm_wte"
+      - "hd_100"
+    n_head: [3]
+    softmax_variant_attn: ["softmax"]
+    lm_head_geometry: ["euclidean", "hyperspherical", "hyperbolic"]
+
+  # Optional curvature sweep for hyperbolic head only
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "infinite"
+      - "mqa"
+      - "squared_relu"
+      - "rmsnorm_wte"
+      - "hd_100"
+    n_head: [3]
+    softmax_variant_attn: ["softmax"]
+    lm_head_geometry: ["hyperbolic"]
+    lm_head_hyperbolic_c: [0.5, 1.0, 2.0]


### PR DESCRIPTION
### Motivation
- Provide a focused exploration to compare LM head geometry variants (`euclidean`, `hyperspherical`, `hyperbolic`) while keeping the rest of the configuration aligned with the `default_inf` style baseline.
- Isolate geometry as the primary variable by fixing head counts/dimensions and other attention/normalization choices to minimize confounders.

### Description
- Add `explorations/lm_head_geometry_default_inf_comparison.yaml` which defines `named_static_groups` and a `common_group` consistent with default-inf choices (qk norm, peri-ln, rotary, infinite attention, MQA, fixed head-dim).
- Add a `parameter_groups` sweep that compares `lm_head_geometry: ["euclidean","hyperspherical","hyperbolic"]` with `n_head: [3]` and `softmax_variant_attn: ["softmax"]` for an apples-to-apples comparison.
- Include a focused hyperbolic curvature sweep via `lm_head_hyperbolic_c: [0.5, 1.0, 2.0]` in a separate parameter group.

### Testing
- Verified the new YAML parses successfully with `yaml.safe_load` (Python validation run succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1d722f0c83269d763269a7f6c230)