### PR TITLE
Add optional LM-head vector normalization (capped hypersphere) and comparison sweep

### DIFF
--- a/explorations/default_inf_lm_head_norm_comparison.yaml
+++ b/explorations/default_inf_lm_head_norm_comparison.yaml
@@ -18,10 +18,7 @@ named_static_groups:
     use_rotary_embeddings: [true]
     use_abs_pos_embeddings: [false]
 
-  # Attention Softmax variants
-  - named_group: "relu2max"
-    softmax_variant_attn: ["relu2max"]
-
+  # Attention Softmax
   - named_group: "softmax"
     softmax_variant_attn: ["softmax"]
 
@@ -74,7 +71,7 @@ parameter_groups:
       - "qk_norm"
       - "peri_ln"
       - "rotary"
-      - "relu2max"
+      - "softmax"
       - "infinite"
       - "mqa"
     n_head:

--- a/explorations/default_inf_lm_head_norm_comparison.yaml
+++ b/explorations/default_inf_lm_head_norm_comparison.yaml
@@ -1,0 +1,103 @@
+# Compare optional lm_head vector normalizations on top of default_inf settings.
+---
+
+named_static_groups:
+  # QK Norm
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  # Norm Type
+  - named_group: "peri_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [true]
+    use_post_ln: [false]
+
+  # Position Embeddings
+  - named_group: "rotary"
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+  # Attention Softmax variants
+  - named_group: "relu2max"
+    softmax_variant_attn: ["relu2max"]
+
+  - named_group: "softmax"
+    softmax_variant_attn: ["softmax"]
+
+  # Infinite Attention
+  - named_group: "infinite"
+    attention_variant: ["infinite"]
+    use_concat_heads: [true]
+
+  # Head Dimension
+  - named_group: "hd_100"
+    n_qk_head_dim: [100]
+    n_v_head_dim: [100]
+
+  - named_group: "hd_150"
+    n_qk_head_dim: [150]
+    n_v_head_dim: [150]
+
+  - named_group: "hd_200"
+    n_qk_head_dim: [200]
+    n_v_head_dim: [200]
+
+  # MQA
+  - named_group: "mqa"
+    n_kv_group: [1]
+
+  # lm_head norm variants (optional)
+  - named_group: "lm_head_norm_none"
+    norm_variant_lm_head: [null]
+
+  - named_group: "lm_head_norm_hsnorm"
+    norm_variant_lm_head: ["hyperspherenorm"]
+
+  - named_group: "lm_head_norm_rmsnorm"
+    norm_variant_lm_head: ["rmsnorm"]
+
+  - named_group: "lm_head_norm_capped_hypersphere"
+    norm_variant_lm_head: ["cappedhyperspherenorm"]
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [2500]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+  compile: [true]
+  log_rankme: [true]
+  log_areq: [true]
+
+parameter_groups:
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "relu2max"
+      - "infinite"
+      - "mqa"
+    n_head:
+      range:
+        start: 1
+        end: 12
+        step: 1
+    named_group_variations:
+      - named_group_alternates: ["hd_100", "hd_150", "hd_200"]
+      - named_group_alternates: ["lm_head_norm_none", "lm_head_norm_hsnorm", "lm_head_norm_rmsnorm", "lm_head_norm_capped_hypersphere"]
+
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "softmax"
+      - "infinite"
+      - "mqa"
+    n_head:
+      range:
+        start: 1
+        end: 12
+        step: 1
+    named_group_variations:
+      - named_group_alternates: ["hd_100", "hd_150", "hd_200"]
+      - named_group_alternates: ["lm_head_norm_none", "lm_head_norm_hsnorm", "lm_head_norm_rmsnorm", "lm_head_norm_capped_hypersphere"]

--- a/explorations/default_inf_lm_head_norm_comparison.yaml
+++ b/explorations/default_inf_lm_head_norm_comparison.yaml
@@ -57,6 +57,13 @@ named_static_groups:
   - named_group: "lm_head_norm_capped_hypersphere"
     norm_variant_lm_head: ["cappedhyperspherenorm"]
 
+
+named_variation_groups:
+  - named_group: "head_dim_var"
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]
+  - named_group: "lm_head_norm_var"
+    named_group_alternates: ["lm_head_norm_none", "lm_head_norm_hsnorm", "lm_head_norm_rmsnorm", "lm_head_norm_capped_hypersphere"]
+
 common_group:
   dataset: ["minipile"]
   eval_interval: [2500]
@@ -80,8 +87,8 @@ parameter_groups:
         end: 12
         step: 1
     named_group_variations:
-      - named_group_alternates: ["hd_100", "hd_150", "hd_200"]
-      - named_group_alternates: ["lm_head_norm_none", "lm_head_norm_hsnorm", "lm_head_norm_rmsnorm", "lm_head_norm_capped_hypersphere"]
+      - "head_dim_var"
+      - "lm_head_norm_var"
 
   - named_group_static:
       - "qk_norm"
@@ -96,5 +103,5 @@ parameter_groups:
         end: 12
         step: 1
     named_group_variations:
-      - named_group_alternates: ["hd_100", "hd_150", "hd_200"]
-      - named_group_alternates: ["lm_head_norm_none", "lm_head_norm_hsnorm", "lm_head_norm_rmsnorm", "lm_head_norm_capped_hypersphere"]
+      - "head_dim_var"
+      - "lm_head_norm_var"

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -406,6 +406,12 @@ class GPTConfig:
     norm_abs_gain: bool | None = None
     norm_abs_radius_learning: bool | None = None
 
+    norm_variant_lm_head: str | None = None
+    norm_lm_head_radius: float | None = None
+    norm_lm_head_scale: float | None = None
+    norm_lm_head_gain: bool | None = None
+    norm_lm_head_radius_learning: bool | None = None
+
     bias: bool = False # True: bias in Linears and LayerNorms, like GPT-2. False: a bit better and faster
     prmsnorm_pct: float = 0.0625
     krmsnorm_num: float = 10

--- a/model.py
+++ b/model.py
@@ -150,6 +150,8 @@ class GPT(nn.Module):
             self.transformer['post_embedding_norm'] = self.build_norm_from_variant(config, "norm_variant_wte", "norm_wte")
         if self.config.norm_variant_abs is not None:
             self.transformer['post_abs_norm'] = self.build_norm_from_variant(config, "norm_variant_abs", "norm_abs")
+        if self.config.norm_variant_lm_head is not None:
+            self.transformer['lm_head_norm'] = self.build_norm_from_variant(config, "norm_variant_lm_head", "norm_lm_head")
 
         if self.config.use_abs_pos_embeddings:
             self.transformer['wpe'] = absolute_position_embedding_dict[config.absolute_pos_embedding_variant](config)
@@ -244,6 +246,15 @@ class GPT(nn.Module):
             if getattr(norm_config, src, None) is not None:
                 setattr(norm_config, f"hsnorm_{attr}", getattr(norm_config, src))
         return norm_dictionary[getattr(config, variant_key)](norm_config)
+
+    def apply_lm_head_norm(self, lm_head_weight):
+        if self.config.norm_variant_lm_head is None:
+            return lm_head_weight
+        return self.transformer.lm_head_norm(lm_head_weight)
+
+    def compute_lm_head_logits(self, x, lm_head_module):
+        weight = self.apply_lm_head_norm(lm_head_module.weight)
+        return F.linear(x, weight, lm_head_module.bias)
 
     def _init_weights(self, module):
         """
@@ -500,7 +511,7 @@ class GPT(nn.Module):
                     logits = [pred[:, [-1], :] for pred in logits]
                     losses = None
             else:
-                logits = [self.transformer[f'lm_head_{i}'](x) for i in range(len(token_list))]
+                logits = [self.compute_lm_head_logits(x, self.transformer[f'lm_head_{i}']) for i in range(len(token_list))]
 
                 # Soft‑cap **each** logits tensor (training & inference)
                 if self.config.final_logit_softcapping is not None:
@@ -606,9 +617,9 @@ class GPT(nn.Module):
             if targets is not None:
                 # if we are given some desired targets also calculate the loss
                 if self.config.multidataset_wte and dataset_idx is not None:
-                    logits = self.transformer[f'lm_head_{dataset_idx}'](x)
+                    logits = self.compute_lm_head_logits(x, self.transformer[f'lm_head_{dataset_idx}'])
                 else:
-                    logits = self.lm_head(x)
+                    logits = self.compute_lm_head_logits(x, self.lm_head)
 
                 if self.config.final_logit_softcapping is not None:
                     logits = logits / self.config.final_logit_softcapping
@@ -622,9 +633,9 @@ class GPT(nn.Module):
             else:
                 # inference-time mini-optimization: only forward the lm_head on the very last position
                 if self.config.multidataset_wte and dataset_idx is not None:
-                    logits = self.transformer[f'lm_head_{dataset_idx}'](x[:, [-1], :])
+                    logits = self.compute_lm_head_logits(x[:, [-1], :], self.transformer[f'lm_head_{dataset_idx}'])
                 else:
-                    logits = self.lm_head(x[:, [-1], :]) # note: using list [-1] to preserve the time dim
+                    logits = self.compute_lm_head_logits(x[:, [-1], :], self.lm_head) # note: using list [-1] to preserve the time dim
 
                 if self.config.final_logit_softcapping is not None:
                     logits = logits / self.config.final_logit_softcapping
@@ -707,9 +718,9 @@ class GPT(nn.Module):
             x = F.linear(x, self.transformer.scale_down.weight.t())
 
         if self.config.multidataset_wte and dataset_idx is not None:
-            logits = self.transformer[f'lm_head_{dataset_idx}'](x)
+            logits = self.compute_lm_head_logits(x, self.transformer[f'lm_head_{dataset_idx}'])
         else:
-            logits = self.lm_head(x)
+            logits = self.compute_lm_head_logits(x, self.lm_head)
         if self.final_logit_softcapping is not None:
             logits = torch.tanh(logits / self.final_logit_softcapping) \
                      * self.final_logit_softcapping

--- a/train_args.py
+++ b/train_args.py
@@ -767,6 +767,7 @@ def parse_args():
             "hyperspherenorm",
             "dact",
             "identity",
+            "cappedhyperspherenorm",
             ]
 
     model_group.add_argument("--norm_variant_attn", type=str, default="rmsnorm", choices=norm_variations)
@@ -776,6 +777,7 @@ def parse_args():
     ### WTE and Abs Pos Embedding Post Norms (optional, and default None)
     model_group.add_argument("--norm_variant_wte", type=str, default=None, choices=norm_variations)
     model_group.add_argument("--norm_variant_abs", type=str, default=None, choices=norm_variations)
+    model_group.add_argument("--norm_variant_lm_head", type=str, default=None, choices=norm_variations)
 
     model_group.add_argument("--norm_wte_radius", type=float, default=None)
     model_group.add_argument("--norm_wte_scale", type=float, default=None)
@@ -786,6 +788,11 @@ def parse_args():
     model_group.add_argument("--norm_abs_scale", type=float, default=None)
     model_group.add_argument("--norm_abs_gain", type=bool, default=None, action=argparse.BooleanOptionalAction)
     model_group.add_argument("--norm_abs_radius_learning", type=bool, default=None, action=argparse.BooleanOptionalAction)
+
+    model_group.add_argument("--norm_lm_head_radius", type=float, default=None)
+    model_group.add_argument("--norm_lm_head_scale", type=float, default=None)
+    model_group.add_argument("--norm_lm_head_gain", type=bool, default=None, action=argparse.BooleanOptionalAction)
+    model_group.add_argument("--norm_lm_head_radius_learning", type=bool, default=None, action=argparse.BooleanOptionalAction)
 
     ## Layernorm
     model_group.add_argument('--bias', default=False, action=argparse.BooleanOptionalAction, help="only used for layernorm variation option")

--- a/variations/norm_variations.py
+++ b/variations/norm_variations.py
@@ -202,6 +202,19 @@ class kRMSNorm(nn.Module):
 
         return x
 
+
+class CappedHyperSphereNorm(nn.Module):
+    """Project vectors onto a sqrt(n_embd) hypersphere only when outside the radius."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.radius = math.sqrt(config.n_embd)
+
+    def forward(self, x):
+        norms = x.norm(2, dim=-1, keepdim=True)
+        scale = torch.where(norms > self.radius, self.radius / (norms + 1e-8), torch.ones_like(norms))
+        return x * scale
+
 class IdentityNorm(nn.Module):
     def __init__(self, config=None):  # Accept config for API consistency
         super().__init__()
@@ -219,4 +232,5 @@ norm_dictionary = {
     "hyperspherenorm": HyperSphereNorm,
     "dact": DynamicActivation,
     "identity": IdentityNorm,
+    "cappedhyperspherenorm": CappedHyperSphereNorm,
 }


### PR DESCRIPTION
### Motivation
- Provide an optional normalization hook for LM-head weight vectors so alternative norms can be applied to the vectors used at final logit computation or be skipped (`None`).
- Allow per-site hypersphere overrides for LM-head using the same override pattern as other optional norm sites so experiments can compare behaviors cleanly.
- Add a new norm variant that only projects down vectors when their norm exceeds a `sqrt(n_embd)` radius to study a soft-cap behavior.

### Description
- Add `norm_variant_lm_head` and associated per-site overrides (`norm_lm_head_radius`, `norm_lm_head_scale`, `norm_lm_head_gain`, `norm_lm_head_radius_learning`) to `gpt_conf.py` and CLI flags in `train_args.py` to expose the new optional LM-head norm configuration.
- Implement `apply_lm_head_norm` and `compute_lm_head_logits` in `model.py` and route all LM-head logit paths (training, inference, multi-dataset/multicontext, and `forward_embedded`) through these helpers so the optional norm is applied functionally at logit time.
- Add `CappedHyperSphereNorm` to `variations/norm_variations.py` and register it in `norm_dictionary`; the class projects vectors onto a radius `sqrt(n_embd)` hypersphere only when their norm exceeds that radius.
- Add `explorations/default_inf_lm_head_norm_comparison.yaml` to compare LM-head norm settings (`null`, `hyperspherenorm`, `rmsnorm`, `cappedhyperspherenorm`) across default_inf-style sweeps.

### Testing
- Ran Python byte-compile check: `python -m py_compile variations/norm_variations.py gpt_conf.py train_args.py model.py` and it succeeded.
- Loaded the new exploration YAML with `yaml.safe_load` to verify the file parses and the top-level structure is valid, and it succeeded.
- Default behavior remains unchanged because `norm_variant_lm_head` defaults to `None`, so no runtime behavioral change unless the new option is enabled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef20452bdc8326b06f3dc91ce07fcb)