### PR TITLE
feat(model): add clustered coarse-to-fine LM head for efficient inference

### DIFF
--- a/explorations/lm_head_clustered_vs_softmax_no_mqa.yaml
+++ b/explorations/lm_head_clustered_vs_softmax_no_mqa.yaml
@@ -1,0 +1,32 @@
+# Compare clustered LM head against a baseline linear LM head.
+# Baseline uses softmax attention and no MQA (n_kv_group == n_head).
+---
+
+common_group:
+  dataset: ["minipile"]
+  out_dir: ["out-lm-head-clustered-vs-baseline"]
+  eval_interval: [1000]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+  compile: [true]
+
+parameter_groups:
+  # Baseline: standard linear lm_head, softmax attention, no MQA
+  - tensorboard_run_name: ["baseline_linear_softmax_no_mqa"]
+    attention_variant: ["causal"]
+    softmax_variant_attn: ["softmax"]
+    softmax_variant_output: ["softmax"]
+    n_head: [12]
+    n_kv_group: [12]
+    lm_head_variant: ["linear"]
+
+  # Variant: clustered lm_head with coarse-to-fine inference path
+  - tensorboard_run_name: ["clustered_lm_head_softmax_no_mqa"]
+    attention_variant: ["causal"]
+    softmax_variant_attn: ["softmax"]
+    softmax_variant_output: ["softmax"]
+    n_head: [12]
+    n_kv_group: [12]
+    lm_head_variant: ["clustered"]
+    lm_head_cluster_size: [256]
+    lm_head_inference_top_clusters: [1]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -102,6 +102,11 @@ class GPTConfig:
     attn_logit_softcapping: float | None = None
     final_logit_softcapping: float | None = None
 
+    # LM head variants
+    lm_head_variant: str = "linear"
+    lm_head_cluster_size: int = 256
+    lm_head_inference_top_clusters: int = 1
+
     # Final ln_f input mixing
     use_ln_f_input_mixer: bool = False
     ln_f_input_mixer_variant: str = "linear"

--- a/model.py
+++ b/model.py
@@ -79,7 +79,8 @@ class ClusteredLMHead(nn.Module):
         top_clusters = coarse.topk(top_k, dim=-1).indices
         mask = self.cluster_ids.to(flat.device).unsqueeze(0) == top_clusters.unsqueeze(-1)
         token_mask = mask.any(dim=1)
-        logits = flat.new_full((flat.size(0), self.vocab_size), float('-inf'))
+        neg_inf = torch.finfo(flat.dtype).min
+        logits = flat.new_full((flat.size(0), self.vocab_size), neg_inf)
         for row in range(flat.size(0)):
             active = token_mask[row]
             scores = flat[row] @ self.token_embeddings[active].t()

--- a/model.py
+++ b/model.py
@@ -86,7 +86,7 @@ class ClusteredLMHead(nn.Module):
             scores = flat[row] @ self.token_embeddings[active].t()
             if self.bias is not None:
                 scores = scores + self.bias[active]
-            logits[row, active] = scores
+            logits[row, active] = scores.to(dtype=logits.dtype)
         return logits.view(*x.shape[:-1], self.vocab_size)
 
 class GPT(nn.Module):

--- a/model.py
+++ b/model.py
@@ -48,6 +48,46 @@ from initializations.initialization_variations import init_dictionary
 from shared_param_utils import SharedParamGroupCreator
 from variations.block_variations import Block
 
+
+
+class ClusteredLMHead(nn.Module):
+    """Two-level clustered LM head for faster inference via coarse-to-fine scoring."""
+
+    def __init__(self, n_embd, vocab_size, cluster_size=256, bias=False):
+        super().__init__()
+        if cluster_size < 1:
+            raise ValueError("lm_head_cluster_size must be >= 1")
+        self.n_clusters = max(1, math.ceil(vocab_size / cluster_size))
+        self.vocab_size = vocab_size
+        self.cluster_ids = torch.arange(vocab_size) // cluster_size
+        self.cluster_prototypes = nn.Parameter(torch.empty(self.n_clusters, n_embd))
+        self.token_embeddings = nn.Parameter(torch.empty(vocab_size, n_embd))
+        nn.init.normal_(self.cluster_prototypes, mean=0.0, std=0.02)
+        nn.init.normal_(self.token_embeddings, mean=0.0, std=0.02)
+        self.bias = nn.Parameter(torch.zeros(vocab_size)) if bias else None
+
+    def forward(self, x, inference_top_clusters=1):
+        if self.training:
+            logits = x @ self.token_embeddings.t()
+            if self.bias is not None:
+                logits = logits + self.bias
+            return logits
+
+        flat = x.reshape(-1, x.size(-1))
+        coarse = flat @ self.cluster_prototypes.t()
+        top_k = min(max(1, inference_top_clusters), self.n_clusters)
+        top_clusters = coarse.topk(top_k, dim=-1).indices
+        mask = self.cluster_ids.to(flat.device).unsqueeze(0) == top_clusters.unsqueeze(-1)
+        token_mask = mask.any(dim=1)
+        logits = flat.new_full((flat.size(0), self.vocab_size), float('-inf'))
+        for row in range(flat.size(0)):
+            active = token_mask[row]
+            scores = flat[row] @ self.token_embeddings[active].t()
+            if self.bias is not None:
+                scores = scores + self.bias[active]
+            logits[row, active] = scores
+        return logits.view(*x.shape[:-1], self.vocab_size)
+
 class GPT(nn.Module):
 
     def __init__(self, config):
@@ -58,6 +98,7 @@ class GPT(nn.Module):
         self.config = config
 
         self.uses_numerical_multicontext = bool(config.numerical_multicontext)
+        self.lm_head_variant = getattr(config, 'lm_head_variant', 'linear')
         if self.uses_numerical_multicontext:
             if not config.multicontext:
                 raise ValueError("numerical_multicontext requires multicontext mode")
@@ -167,7 +208,10 @@ class GPT(nn.Module):
                 for i, vocab_size in enumerate(self.config.vocab_sizes):
                     self.transformer[f'lm_head_{i}'].weight = self.transformer[f'wte_{i}'].weight
             else:
-                self.lm_head = nn.Linear(config.n_embd, config.vocab_size, bias=False)
+                if self.lm_head_variant == 'clustered':
+                    self.lm_head = ClusteredLMHead(config.n_embd, config.vocab_size, cluster_size=config.lm_head_cluster_size, bias=False)
+                else:
+                    self.lm_head = nn.Linear(config.n_embd, config.vocab_size, bias=False)
 
         # Initialize and possibly import scale_up and scale_down matrices, if factorization is set
         if self.n_embd_wte:
@@ -195,7 +239,8 @@ class GPT(nn.Module):
                 for i, vocab_size in enumerate(self.config.vocab_sizes):
                     self.transformer[f'lm_head_{i}'].weight = self.transformer[f'wte_{i}'].weight
             else:
-                self.lm_head.weight = self.transformer.wte.weight # https://paperswithcode.com/method/weight-tying
+                if self.lm_head_variant != 'clustered':
+                    self.lm_head.weight = self.transformer.wte.weight # https://paperswithcode.com/method/weight-tying
 
         # import wte
         if self.config.import_wte_npy:
@@ -225,6 +270,12 @@ class GPT(nn.Module):
         if non_embedding and self.config.use_abs_pos_embeddings:
             n_params -= sum(p.numel() for p in self.transformer.wpe.parameters())
         return n_params
+
+    def _apply_lm_head(self, x):
+        if self.lm_head_variant == 'clustered':
+            top_clusters = getattr(self.config, 'lm_head_inference_top_clusters', 1)
+            return self.lm_head(x, inference_top_clusters=top_clusters)
+        return self.lm_head(x)
 
     def update_block_size(self, new_block_size):
         # Function to increase block size dynamically
@@ -608,7 +659,7 @@ class GPT(nn.Module):
                 if self.config.multidataset_wte and dataset_idx is not None:
                     logits = self.transformer[f'lm_head_{dataset_idx}'](x)
                 else:
-                    logits = self.lm_head(x)
+                    logits = self._apply_lm_head(x)
 
                 if self.config.final_logit_softcapping is not None:
                     logits = logits / self.config.final_logit_softcapping
@@ -624,7 +675,7 @@ class GPT(nn.Module):
                 if self.config.multidataset_wte and dataset_idx is not None:
                     logits = self.transformer[f'lm_head_{dataset_idx}'](x[:, [-1], :])
                 else:
-                    logits = self.lm_head(x[:, [-1], :]) # note: using list [-1] to preserve the time dim
+                    logits = self._apply_lm_head(x[:, [-1], :]) # note: using list [-1] to preserve the time dim
 
                 if self.config.final_logit_softcapping is not None:
                     logits = logits / self.config.final_logit_softcapping
@@ -709,7 +760,7 @@ class GPT(nn.Module):
         if self.config.multidataset_wte and dataset_idx is not None:
             logits = self.transformer[f'lm_head_{dataset_idx}'](x)
         else:
-            logits = self.lm_head(x)
+            logits = self._apply_lm_head(x)
         if self.final_logit_softcapping is not None:
             logits = torch.tanh(logits / self.final_logit_softcapping) \
                      * self.final_logit_softcapping

--- a/train_args.py
+++ b/train_args.py
@@ -321,6 +321,12 @@ def parse_args():
                                     help="Enable multi-context training on multiple simultaneous datasets")
     model_group.add_argument('--multidataset_wte', default=False, action=argparse.BooleanOptionalAction,
                                     help='Use separate token embeddings and lm heads per dataset when training_mode is multidataset')
+    model_group.add_argument('--lm_head_variant', default='linear', type=str, choices=['linear', 'clustered'],
+                                    help="LM head type: standard full projection or clustered coarse-to-fine.")
+    model_group.add_argument('--lm_head_cluster_size', default=256, type=int,
+                                    help="Cluster size for clustered lm head (tokens per leaf cluster).")
+    model_group.add_argument('--lm_head_inference_top_clusters', default=1, type=int,
+                                    help="How many top clusters to refine during inference for clustered lm head.")
     training_group.add_argument('--multicontext_datasets', default=None, nargs='+', type=str,
                                     help="List of datasets to train on in multi-context mode (e.g., --multicontext_datasets shakespeare wikitext103 openwebtext)")
     model_group.add_argument('--vocab_sizes', default=None, nargs='+', type=int,


### PR DESCRIPTION
### Motivation
- Reduce the cost of the final full vocab dot product by adding a coarse‑to‑fine LM head that first scores learned cluster prototypes and then evaluates only tokens in top cluster(s) at inference time.

### Description
- Add `ClusteredLMHead` in `model.py` implementing learned cluster prototypes, per-token embeddings, and coarse-to-fine inference path while keeping full logits computation during training.
- Integrate LM-head variant selection via `GPTConfig` fields `lm_head_variant`, `lm_head_cluster_size`, and `lm_head_inference_top_clusters` in `gpt_conf.py` set to sensible defaults.
- Expose CLI flags in `train_args.py` (`--lm_head_variant`, `--lm_head_cluster_size`, `--lm_head_inference_top_clusters`) to configure the behavior at runtime.
- Route LM head calls through a new helper `_apply_lm_head()` and preserve existing weight-tying for the default linear head while skipping direct `wte` tying when `clustered` is selected, and initialize cluster/token embeddings.

### Testing
- Ran `python -m py_compile model.py gpt_conf.py train_args.py` which succeeded with no syntax errors.
- Attempted a small runtime smoke test creating a `GPT` with `lm_head_variant='clustered'` but it failed to run due to a missing `rich` dependency in the environment (`ModuleNotFoundError: No module named 'rich'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25b572c6883268a5b84597f47614c)