### PR TITLE
Add per-block component variants with layerlist support

### DIFF
--- a/explorations/default_inf_block_layerlist_example.yaml
+++ b/explorations/default_inf_block_layerlist_example.yaml
@@ -1,0 +1,56 @@
+# default_inf_block_layerlist_example.yaml
+#
+# Based on explorations/default_inf.yaml.
+# Demonstrates per-layer block component routing using block_component_variant_layerlist.
+---
+
+named_static_groups:
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  - named_group: "peri_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [true]
+    use_post_ln: [false]
+
+  - named_group: "rotary"
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+  - named_group: "relu2max"
+    softmax_variant_attn: ["relu2max"]
+
+  - named_group: "infinite"
+    attention_variant: ["infinite"]
+    use_concat_heads: [true]
+
+  - named_group: "hd_100"
+    n_qk_head_dim: [100]
+    n_v_head_dim: [100]
+
+  - named_group: "mqa"
+    n_kv_group: [1]
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [2500]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+  compile: [true]
+
+parameter_groups:
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "relu2max"
+      - "infinite"
+      - "mqa"
+      - "hd_100"
+    n_head: [8]
+    n_layer: [8]
+    # Repeats cyclically if n_layer is larger than this list.
+    # Valid entries: attn_mlp, attn_only, mlp_only, linear_only, router_linear
+    block_component_variant_layerlist:
+      - ["attn_only", "attn_mlp", "mlp_only", "router_linear", "linear_only", "attn_mlp", "attn_only", "router_linear"]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -44,8 +44,10 @@ class GPTConfig:
     n_cproj_layerlist: List[int] = field(default_factory=list)
     n_kv_group_layerlist: List[int] = field(default_factory=list)
     attention_variant_layerlist: List[str] = field(default_factory=list)
+    block_component_variant_layerlist: List[str] = field(default_factory=list)
     use_rotary_embeddings_layerlist: List[bool] = field(default_factory=list)
     window_size_layerlist: List[int] = field(default_factory=list)
+    block_component_variant: str = "attn_mlp"
 
     # For multicontext training
     multicontext: bool = False

--- a/train_args.py
+++ b/train_args.py
@@ -938,8 +938,10 @@ def parse_args():
     model_group.add_argument("--n_cproj_layerlist", nargs='+', action=LayerListAction, default=None)
     model_group.add_argument("--n_kv_group_layerlist", nargs='+', action=LayerListAction, default=None)
     model_group.add_argument("--attention_variant_layerlist", nargs='+', action=LayerListAction, default=None)
+    model_group.add_argument("--block_component_variant_layerlist", nargs='+', action=LayerListAction, default=None, help="Override block_component_variant per layer, cycling through the list.")
     model_group.add_argument("--use_rotary_embeddings_layerlist", nargs='+', action=LayerListAction, default=None, help="Override use_rotary_embeddings per layer, cycling through the list.")
     model_group.add_argument("--window_size_layerlist", nargs='+', action=LayerListAction, default=None, help="Override window_size per layer, cycling through the list.")
+    model_group.add_argument("--block_component_variant", type=str, default="attn_mlp", choices=["attn_mlp", "attn_only", "mlp_only", "linear_only", "router_linear"], help="Select which compute path each block uses.")
 
     ## Infinite Attention variation
     model_group.add_argument('--n_qk_head_dim', default=None, type=int)

--- a/variations/block_variations.py
+++ b/variations/block_variations.py
@@ -10,6 +10,7 @@ from variations.attention_variations import attention_dictionary
 from variations.mlp_variations import get_mlp_instance
 from variations.norm_variations import norm_dictionary
 from variations.learned_confidence_variations import learned_confidence_dictionary
+from variations.linear_variations import linear_dictionary
 from quantization.quantize import fake_quantize_act
 
 # type alias for the forward function
@@ -122,18 +123,19 @@ def attn_then_mlp_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor
         x_attn_in = block.pre_ln_attn(x_attn_in)
 
     # Attn Operation
-    attn_out = block.attn(x_attn_in, iter_num)
+    attn_out = block.attn(x_attn_in, iter_num) if block.block_component_variant in ("attn_mlp", "attn_only") else None
 
     # Attn Peri-LN
-    if block.use_peri_ln_attn:
+    if block.use_peri_ln_attn and attn_out is not None:
         attn_out = block.peri_ln_attn(attn_out)
 
     # Attn Output Scaling
-    if block.attn_resid_scaler is not None:
+    if block.attn_resid_scaler is not None and attn_out is not None:
         attn_out = block.attn_resid_scaler(attn_out)
 
     # Attn Skip Connection
-    x = block._combine_resid("attn", x, attn_out)
+    if attn_out is not None:
+        x = block._combine_resid("attn", x, attn_out)
 
     # Attn Post-LN
     if block.use_post_ln_attn:
@@ -147,18 +149,26 @@ def attn_then_mlp_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor
         x_mlp_in = block.pre_ln_mlp(x_mlp_in)
 
     # MLP Operation
-    mlp_out = block.mlp(x_mlp_in, iter_num)
+    mlp_out = block.mlp(x_mlp_in, iter_num) if block.block_component_variant in ("attn_mlp", "mlp_only") else None
+    if block.block_component_variant == "linear_only":
+        mlp_out = block.block_linear(x_mlp_in)
+    elif block.block_component_variant == "router_linear":
+        route_logits = block.block_router(x_mlp_in)
+        route_probs = torch.softmax(route_logits, dim=-1)
+        linear_out = block.block_linear(x_mlp_in)
+        mlp_out = route_probs[..., :1] * linear_out + route_probs[..., 1:2] * x_mlp_in
 
     # MLP Peri-LN
-    if block.use_peri_ln_mlp:
+    if block.use_peri_ln_mlp and mlp_out is not None:
         mlp_out = block.peri_ln_mlp(mlp_out)
 
     # MLP Output Scaling
-    if block.mlp_resid_scaler is not None:
+    if block.mlp_resid_scaler is not None and mlp_out is not None:
         mlp_out = block.mlp_resid_scaler(mlp_out)
 
     # MLP Skip Connection
-    x = block._combine_resid("mlp", x, mlp_out)
+    if mlp_out is not None:
+        x = block._combine_resid("mlp", x, mlp_out)
 
     # MLP Post-LN
     if block.use_post_ln_mlp:
@@ -386,6 +396,7 @@ class Block(nn.Module):
         self.use_peri_ln = getattr(config, "use_peri_ln", False)
 
         # Forward variation choice
+        self.block_component_variant = getattr(config, "block_component_variant", "attn_mlp")
         self.use_parallel_mlp = getattr(config, "use_parallel_mlp", False)
         self.use_edgellm_asic = getattr(config, "use_edgellm_asic", False)
 
@@ -427,6 +438,20 @@ class Block(nn.Module):
             self.mlp = get_mlp_instance(config)
         else:
             self.mlp = mlp
+
+        if self.block_component_variant in ("linear_only", "router_linear"):
+            linear_cls = linear_dictionary[config.linear_variant_attn]
+            linear_cls = linear_cls if not getattr(config, "use_flash_norm", False) else linear_cls
+            self.block_linear = linear_cls(
+                config.n_embd,
+                config.n_embd,
+                config=config,
+                method=getattr(config, "activations_quant_method", None),
+                bits=getattr(config, "quantize_linear_bits", None),
+                bias=getattr(config, "bias", True),
+            )
+            if self.block_component_variant == "router_linear":
+                self.block_router = nn.Linear(config.n_embd, 2, bias=True)
 
         self.attn_resid_type = getattr(config, "attn_residual_combination", "add")
         self.mlp_resid_type = getattr(config, "mlp_residual_combination", "add")


### PR DESCRIPTION
### Motivation
- Allow each transformer block to choose its compute path (attention, MLP, a plain linear, or a routed linear) to enable flexible per-layer architectures and lightweight ablations.
- Reuse existing layerlist mechanism so users can cycle different block behaviors across layers in experiment YAMLs.

### Description
- Added a new config field and default `block_component_variant` and a layerlist `block_component_variant_layerlist` in `gpt_conf.py` so the option can be set globally or per-layer.
- Exposed CLI flags in `train_args.py`: `--block_component_variant` and `--block_component_variant_layerlist` (layerlist follows the same cyclic semantics as other `*_layerlist` options).
- Updated `variations/block_variations.py` to import `linear_dictionary` and to conditionally execute attention/MLP paths in the sequential (`attn_then_mlp`) forward depending on `block_component_variant` values `attn_mlp`, `attn_only`, `mlp_only`, `linear_only`, and `router_linear`.
- Implemented `linear_only` which runs a learned linear transform, and `router_linear` which uses a small learned router (`nn.Linear` with a 2-way softmax) to mix between a linear transform and identity per token; instantiated `block_linear` and `block_router` when needed.
- Added a YAML example `explorations/default_inf_block_layerlist_example.yaml` (based on `default_inf.yaml`) demonstrating per-layer `block_component_variant_layerlist` usage.

### Testing
- Ran `python -m py_compile variations/block_variations.py train_args.py gpt_conf.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79fb0edbc83268306061c5857821f)