### PR TITLE
Add configurable custom block composition with per-block layerlist overrides

### DIFF
--- a/explorations/custom_block_layerlist_example.yaml
+++ b/explorations/custom_block_layerlist_example.yaml
@@ -1,42 +1,40 @@
 # Example derived from default_inf.yaml style, without relu2max.
----
-configs:
-  - name: "custom_block_layerlist_demo"
-    dataset: "minipile"
-    max_iters: 10000
-    eval_interval: 2500
-    compile: true
-    never_save_checkpoint: true
+- name: "custom_block_layerlist_demo"
+  dataset: "minipile"
+  max_iters: 10000
+  eval_interval: 2500
+  compile: true
+  never_save_checkpoint: true
 
-    # Keep the same baseline style as default_inf (infinite + softmax + rotary)
-    attention_variant: "infinite"
-    softmax_variant_attn: "softmax"
-    use_qk_norm: true
-    use_qk_norm_scale: true
-    use_pre_ln: true
-    use_peri_ln: true
-    use_post_ln: false
-    use_rotary_embeddings: true
-    use_abs_pos_embeddings: false
-    n_kv_group: 1
+  # Keep the same baseline style as default_inf (infinite + softmax + rotary)
+  attention_variant: "infinite"
+  softmax_variant_attn: "softmax"
+  use_qk_norm: true
+  use_qk_norm_scale: true
+  use_pre_ln: true
+  use_peri_ln: true
+  use_post_ln: false
+  use_rotary_embeddings: true
+  use_abs_pos_embeddings: false
+  n_kv_group: 1
 
-    # Enable new custom block assembly.
-    use_custom_module_block: true
+  # Enable new custom block assembly.
+  use_custom_module_block: true
 
-    # Per-block overrides (cycled if shorter than n_layer):
-    # block 0: attention -> mlp
-    # block 1: attention -> linear -> mlp
-    # block 2: attention -> router_linear -> mlp -> linear
-    block_module_order_layerlist:
-      - "attention,mlp"
-      - "attention,linear,mlp"
-      - "attention,router_linear,mlp,linear"
+  # Per-block overrides (cycled if shorter than n_layer):
+  # block 0: attention -> mlp
+  # block 1: attention -> linear -> mlp
+  # block 2: attention -> router_linear -> mlp -> linear
+  block_module_order_layerlist:
+    - "attention,mlp"
+    - "attention,linear,mlp"
+    - "attention,router_linear,mlp,linear"
 
-    # false => skip after each module, true => one skip from block input to block output
-    block_single_residual_layerlist: [false, true, false]
+  # false => skip after each module, true => one skip from block input to block output
+  block_single_residual_layerlist: [false, true, false]
 
-    # Optional normal layer lists can still be mixed in freely
-    n_head_layerlist: [4, 8, 12]
-    n_qk_head_dim_layerlist: [100, 150, 200]
-    n_v_head_dim_layerlist: [100, 150, 200]
-    mlp_size_layerlist: [768, 1024, 1536]
+  # Optional normal layer lists can still be mixed in freely
+  n_head_layerlist: [4, 8, 12]
+  n_qk_head_dim_layerlist: [100, 150, 200]
+  n_v_head_dim_layerlist: [100, 150, 200]
+  mlp_size_layerlist: [768, 1024, 1536]

--- a/explorations/custom_block_layerlist_example.yaml
+++ b/explorations/custom_block_layerlist_example.yaml
@@ -1,0 +1,42 @@
+# Example derived from default_inf.yaml style, without relu2max.
+---
+configs:
+  - name: "custom_block_layerlist_demo"
+    dataset: "minipile"
+    max_iters: 10000
+    eval_interval: 2500
+    compile: true
+    never_save_checkpoint: true
+
+    # Keep the same baseline style as default_inf (infinite + softmax + rotary)
+    attention_variant: "infinite"
+    softmax_variant_attn: "softmax"
+    use_qk_norm: true
+    use_qk_norm_scale: true
+    use_pre_ln: true
+    use_peri_ln: true
+    use_post_ln: false
+    use_rotary_embeddings: true
+    use_abs_pos_embeddings: false
+    n_kv_group: 1
+
+    # Enable new custom block assembly.
+    use_custom_module_block: true
+
+    # Per-block overrides (cycled if shorter than n_layer):
+    # block 0: attention -> mlp
+    # block 1: attention -> linear -> mlp
+    # block 2: attention -> router_linear -> mlp -> linear
+    block_module_order_layerlist:
+      - "attention,mlp"
+      - "attention,linear,mlp"
+      - "attention,router_linear,mlp,linear"
+
+    # false => skip after each module, true => one skip from block input to block output
+    block_single_residual_layerlist: [false, true, false]
+
+    # Optional normal layer lists can still be mixed in freely
+    n_head_layerlist: [4, 8, 12]
+    n_qk_head_dim_layerlist: [100, 150, 200]
+    n_v_head_dim_layerlist: [100, 150, 200]
+    mlp_size_layerlist: [768, 1024, 1536]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -46,6 +46,12 @@ class GPTConfig:
     attention_variant_layerlist: List[str] = field(default_factory=list)
     use_rotary_embeddings_layerlist: List[bool] = field(default_factory=list)
     window_size_layerlist: List[int] = field(default_factory=list)
+    block_module_order_layerlist: List[str] = field(default_factory=list)
+    block_single_residual_layerlist: List[bool] = field(default_factory=list)
+
+    use_custom_module_block: bool = False
+    block_module_order: str = "attention,mlp"
+    block_single_residual: bool = False
 
     # For multicontext training
     multicontext: bool = False

--- a/model.py
+++ b/model.py
@@ -45,7 +45,7 @@ from quantization.quant_utils import set_variant, create_activation_buffers
 
 from initializations.initialization_variations import init_dictionary
 
-from shared_param_utils import SharedParamGroupCreator
+from shared_param_utils import SharedParamGroupCreator, apply_layerlists_to_config
 from variations.block_variations import Block
 
 class GPT(nn.Module):
@@ -142,7 +142,7 @@ class GPT(nn.Module):
 
 
         self.transformer['drop'] = nn.Dropout(config.dropout)
-        self.transformer['h'] = nn.ModuleList([Block(config, mlp=shared_mlp_array[i], attn=shared_attn_array[i]) for i in range(config.n_layer)])
+        self.transformer['h'] = nn.ModuleList([Block(apply_layerlists_to_config(config, layer_idx=i), mlp=shared_mlp_array[i], attn=shared_attn_array[i]) for i in range(config.n_layer)])
         self.transformer['ln_f'] = norm_dictionary[config.norm_variant_output](config)
 
         # Optional post-embedding normalizations

--- a/shared_param_utils.py
+++ b/shared_param_utils.py
@@ -46,6 +46,72 @@ class SharedParamGroupCreator:
             self.fire_pos_enc = FIRE(config, num_heads=config.n_head)
 
 
+
+
+def apply_layerlists_to_config(base_config, layer_idx: int, group_idx: int | None = None):
+    """Return a deepcopy of ``base_config`` with any ``*_layerlist`` overrides applied."""
+    layer_config = copy.deepcopy(base_config)
+    layer_config.layer_idx = layer_idx
+    if group_idx is None:
+        group_idx = layer_idx
+
+    _SENTINEL_NONE = {"", "none", "null"}
+
+    def _is_none(txt) -> bool:
+        return str(txt).strip().lower() in _SENTINEL_NONE
+
+    def _as_bool(txt):
+        if _is_none(txt):
+            return None
+        truthy_values = {"1", "true", "yes", "y", "on"}
+        falsy_values = {"0", "false", "no", "n", "off"}
+        txt_lower = str(txt).strip().lower()
+        if txt_lower in truthy_values:
+            return True
+        if txt_lower in falsy_values:
+            return False
+        raise ValueError(f"Invalid boolean value: {txt}")
+
+    for attr in dir(base_config):
+        if not attr.endswith("_layerlist"):
+            continue
+        lst = getattr(base_config, attr)
+        if not lst:
+            continue
+        core_attr = attr[:-10]
+        raw_val = lst[group_idx % len(lst)]
+
+        if hasattr(base_config, core_attr):
+            ref_val = getattr(base_config, core_attr)
+            if ref_val is not None:
+                if isinstance(ref_val, bool):
+                    raw_val = _as_bool(raw_val)
+                elif isinstance(ref_val, int):
+                    raw_val = int(raw_val)
+                elif isinstance(ref_val, float):
+                    raw_val = float(raw_val)
+            else:
+                anno = type(base_config).__annotations__.get(core_attr)
+                hinted = str
+                if anno:
+                    origin = get_origin(anno)
+                    args = get_args(anno)
+                    if origin is None:
+                        hinted = anno
+                    elif len(args) == 2 and type(None) in args:
+                        hinted = next(a for a in args if a is not type(None))
+
+                if _is_none(raw_val):
+                    raw_val = None
+                elif hinted is bool:
+                    raw_val = _as_bool(raw_val)
+                elif hinted is int:
+                    raw_val = int(raw_val)
+                elif hinted is float:
+                    raw_val = float(raw_val)
+
+        setattr(layer_config, core_attr, raw_val)
+    return layer_config
     def create_shared_param_group(self, layer_type):
         """
         Creates a shared list of layer blocks (either MLP or Attn), optionally
@@ -101,73 +167,8 @@ class SharedParamGroupCreator:
             # overrides.  Example:  --mlp_size_layerlist 100 200 300
             # → layer 0→100, 1→200, 2→300, 3→100, 4→200, ...
             # ------------------------------------------------------------------
-            layer_config = copy.deepcopy(self.config)
-            layer_config.layer_idx = i
             group_idx = i // shared_size
-
-            for attr in dir(self.config):
-                if attr.endswith("_layerlist"):
-                    lst = getattr(self.config, attr)
-                    if not lst:          # [], None, or empty → ignore
-                        continue
-                    core_attr = attr[:-10]         # strip "_layerlist"
-                    # raw_val   = lst[i % len(lst)]  # cyclic selection
-                    raw_val = lst[group_idx % len(lst)]    # cyclic selection with group_idx
-
-
-                    if hasattr(self.config, core_attr):
-                        ref_val = getattr(self.config, core_attr)
-
-
-                        _SENTINEL_NONE = {"", "none", "null"}
-
-                        def _is_none(txt) -> bool:
-                            return str(txt).strip().lower() in _SENTINEL_NONE
-
-                        def _as_bool(txt):
-                            if _is_none(txt):
-                                return None
-                            truthy_values = {"1", "true", "yes", "y", "on"}
-                            falsy_values = {"0", "false", "no", "n", "off"}
-                            txt_lower = str(txt).strip().lower()
-                            if txt_lower in truthy_values:
-                                return True
-                            elif txt_lower in falsy_values:
-                                return False
-                            else:
-                                raise ValueError(f"Invalid boolean value: {txt}")
-                        # a) If the runtime value is *not* None we can
-                        #    rely on its actual Python type.
-                        if ref_val is not None:
-                            if isinstance(ref_val, bool):
-                                raw_val = _as_bool(raw_val)
-                            elif isinstance(ref_val, int):
-                                raw_val = int(raw_val)
-                            elif isinstance(ref_val, float):
-                                raw_val = float(raw_val)
-                        # b) Otherwise, fall back to the dataclass annotation
-                        #    to guess the intended type (handles `T | None`).
-                        else:
-                            anno = type(self.config).__annotations__.get(core_attr)
-                            hinted = str  # default: leave string as-is
-                            if anno:
-                                origin = get_origin(anno)
-                                args   = get_args(anno)
-                                if origin is None:
-                                    hinted = anno
-                                elif len(args) == 2 and type(None) in args:
-                                    hinted = next(a for a in args if a is not type(None))
-
-                            if _is_none(raw_val):
-                                raw_val = None
-                            elif hinted is bool:
-                                raw_val = _as_bool(raw_val)
-                            elif hinted is int:
-                                raw_val = int(raw_val)
-                            elif hinted is float:
-                                raw_val = float(raw_val)
-
-                    setattr(layer_config, core_attr, raw_val)
+            layer_config = apply_layerlists_to_config(self.config, layer_idx=i, group_idx=group_idx)
 
             # Decide which sharing mode we are in
             if seq_len > 1:

--- a/shared_param_utils.py
+++ b/shared_param_utils.py
@@ -45,7 +45,119 @@ class SharedParamGroupCreator:
         if config.shared_fire_embeddings:
             self.fire_pos_enc = FIRE(config, num_heads=config.n_head)
 
+    def create_shared_param_group(self, layer_type):
+        """
+        Creates a shared list of layer blocks (either MLP or Attn), optionally
+        reusing blocks every 'shared_size' layers and reflecting them symmetrically
+        if 'shared_sym' is True.
 
+        For attention layers, we can cycle through multiple attention variants
+        if config.attention_list is not empty.
+
+        Args:
+            layer_type (str): "mlp" or "attn"
+
+        Returns:
+            list of layer_blocks
+        """
+
+        if layer_type == "mlp":
+            shared_size = self.config.shared_mlp_size
+            shared_sym  = self.config.shared_mlp_sym
+            seq_len     = self.config.shared_mlp_seq
+
+        elif layer_type == "attn":
+            shared_size = self.config.shared_attn_size
+            shared_sym = self.config.shared_attn_sym
+            seq_len     = self.config.shared_attn_seq
+        else:
+            sys.exit(f"{layer_type} not supported. Use 'mlp' or 'attn' only.")
+
+        shared_group = []
+        layer_block = None
+
+        # For cycling multiple attention variants
+        attn_variant_index = 0
+
+        # ────────────────────────────────
+        # Cyclic-sequence sharing pool
+        # ────────────────────────────────
+        if seq_len < 1:
+            raise ValueError("shared_*_seq must be ≥ 1")
+        seq_pool: list[nn.Module | None] = [None] * seq_len
+
+        # If we'll mirror, build only the *first half plus centre* for odd n.
+        if shared_sym:
+            num_physical = (self.config.n_layer + 1) // 2   # ceil(n/2)
+        else:
+            num_physical = self.config.n_layer
+
+        for i in range(num_physical):
+            # ------------------------------------------------------------------
+            # Build a per-layer clone of the config and apply any *layerlist
+            # overrides.  Example:  --mlp_size_layerlist 100 200 300
+            # → layer 0→100, 1→200, 2→300, 3→100, 4→200, ...
+            # ------------------------------------------------------------------
+            group_idx = i // shared_size
+            layer_config = apply_layerlists_to_config(self.config, layer_idx=i, group_idx=group_idx)
+
+            # Decide which sharing mode we are in
+            if seq_len > 1:
+                # ---------------------------------------------
+                # combined: sequence + size
+                # group_idx  = i // size      ← which full block we’re in
+                # seq_idx    = group_idx % k  ← which letter A/B/C…
+                # ---------------------------------------------
+                seq_idx  = (i // shared_size) % seq_len if shared_size > 1 else i % seq_len
+                layer_block = seq_pool[seq_idx]
+                if layer_block is None:
+                    layer_block = _build_block(layer_type, layer_config, self.fire_pos_enc)
+
+                    seq_pool[seq_idx] = layer_block
+            else:
+                # create a new block only every k layers,
+                # otherwise keep re-using the last one
+                if i % shared_size == 0 or layer_block is None:
+                    layer_block = _build_block(layer_type, layer_config, self.fire_pos_enc)
+
+            # Add this (possibly reused) block for *every* logical layer
+            shared_group.append(layer_block)
+
+        # ────────────────────────────────
+        # Optional symmetry mirroring
+        # ────────────────────────────────
+        if shared_sym:
+            # exclude centre element for odd n to avoid duplication
+            mirror = list(reversed(shared_group[:-1])) if self.config.n_layer % 2 else list(reversed(shared_group))
+            shared_group.extend(mirror)
+
+        # ── pretty debug print ──────────────────────────────
+        letters = _label_sequence(shared_group)
+        if layer_type == "mlp":
+            mlp_sizes = [getattr(blk, "_debug_size", "?") for blk in shared_group]
+
+        tbl = Table(
+            title=f"{layer_type.upper()} sharing",
+            header_style="bold magenta",
+            show_lines=False,
+            pad_edge=False,
+        )
+        tbl.add_column("Layer")
+        tbl.add_column("Type")
+        if layer_type == "mlp":
+            tbl.add_column("mlp_size")
+
+        for i, letter in enumerate(letters):
+            row_letter = Text(letter, style="cyan" if layer_type == "mlp" else "green")
+            if layer_type == "mlp":
+                size_cell = Text(str(mlp_sizes[i]), style="yellow")
+                tbl.add_row(str(i), row_letter, size_cell)
+            else:
+                tbl.add_row(str(i), row_letter)
+
+        _console.print(tbl)
+
+        return shared_group
 
 
 def apply_layerlists_to_config(base_config, layer_idx: int, group_idx: int | None = None):
@@ -112,120 +224,6 @@ def apply_layerlists_to_config(base_config, layer_idx: int, group_idx: int | Non
 
         setattr(layer_config, core_attr, raw_val)
     return layer_config
-    def create_shared_param_group(self, layer_type):
-        """
-        Creates a shared list of layer blocks (either MLP or Attn), optionally
-        reusing blocks every 'shared_size' layers and reflecting them symmetrically
-        if 'shared_sym' is True.
-
-        For attention layers, we can cycle through multiple attention variants
-        if config.attention_list is not empty.
-
-        Args:
-            layer_type (str): "mlp" or "attn"
-
-        Returns:
-            list of layer_blocks
-        """
-
-        if layer_type == "mlp":
-            shared_size = self.config.shared_mlp_size
-            shared_sym  = self.config.shared_mlp_sym
-            seq_len     = self.config.shared_mlp_seq
-
-        elif layer_type == "attn":
-            shared_size = self.config.shared_attn_size
-            shared_sym = self.config.shared_attn_sym
-            seq_len     = self.config.shared_attn_seq
-        else:
-            sys.exit(f"{layer_type} not supported. Use 'mlp' or 'attn' only.")
-
-        shared_group = []
-        layer_block = None
-
-        # For cycling multiple attention variants
-        attn_variant_index = 0
-
-        # ────────────────────────────────
-        # Cyclic-sequence sharing pool
-        # ────────────────────────────────
-        if seq_len < 1:
-            raise ValueError("shared_*_seq must be ≥ 1")
-        seq_pool: list[nn.Module | None] = [None] * seq_len
-
-        # If we'll mirror, build only the *first half plus centre* for odd n.
-        if shared_sym:
-            num_physical = (self.config.n_layer + 1) // 2   # ceil(n/2)
-        else:
-            num_physical = self.config.n_layer
-
-        for i in range(num_physical):
-
-
-            # ------------------------------------------------------------------
-            # Build a per-layer clone of the config and apply any *layerlist
-            # overrides.  Example:  --mlp_size_layerlist 100 200 300
-            # → layer 0→100, 1→200, 2→300, 3→100, 4→200, ...
-            # ------------------------------------------------------------------
-            group_idx = i // shared_size
-            layer_config = apply_layerlists_to_config(self.config, layer_idx=i, group_idx=group_idx)
-
-            # Decide which sharing mode we are in
-            if seq_len > 1:
-                # ---------------------------------------------
-                # combined: sequence + size
-                # group_idx  = i // size      ← which full block we’re in
-                # seq_idx    = group_idx % k  ← which letter A/B/C…
-                # ---------------------------------------------
-                seq_idx  = (i // shared_size) % seq_len if shared_size > 1 else i % seq_len
-                layer_block = seq_pool[seq_idx]
-                if layer_block is None:
-                    layer_block = _build_block(layer_type, layer_config, self.fire_pos_enc)
-
-                    seq_pool[seq_idx] = layer_block
-            else:
-                # create a new block only every k layers,
-                # otherwise keep re-using the last one
-                if i % shared_size == 0 or layer_block is None:
-                    layer_block = _build_block(layer_type, layer_config, self.fire_pos_enc)
-
-            # Add this (possibly reused) block for *every* logical layer
-            shared_group.append(layer_block)
-
-        # ────────────────────────────────
-        # Optional symmetry mirroring
-        # ────────────────────────────────
-        if shared_sym:
-            # exclude centre element for odd n to avoid duplication
-            mirror = list(reversed(shared_group[:-1])) if self.config.n_layer % 2 else list(reversed(shared_group))
-            shared_group.extend(mirror)
-
-        # ── pretty debug print ──────────────────────────────
-        letters = _label_sequence(shared_group)
-        if layer_type == "mlp":
-            mlp_sizes = [getattr(blk, "_debug_size", "?") for blk in shared_group]
-
-        tbl = Table(
-            title=f"{layer_type.upper()} sharing",
-            header_style="bold magenta",
-            show_lines=False,
-            pad_edge=False,
-        )
-        tbl.add_column("Layer")
-        tbl.add_column("Type")
-        if layer_type == "mlp":
-            tbl.add_column("mlp_size")
-
-        for i, letter in enumerate(letters):
-            row_letter = Text(letter, style="cyan" if layer_type == "mlp" else "green")
-            if layer_type == "mlp":
-                tbl.add_row(str(i), row_letter, str(mlp_sizes[i]))
-            else:
-                tbl.add_row(str(i), row_letter)
-
-        _console.print(tbl)
-
-        return shared_group
 
 # ─────────────────────────────────────────────────────────────
 # Helper to move logic out of the main loop

--- a/train_args.py
+++ b/train_args.py
@@ -940,6 +940,13 @@ def parse_args():
     model_group.add_argument("--attention_variant_layerlist", nargs='+', action=LayerListAction, default=None)
     model_group.add_argument("--use_rotary_embeddings_layerlist", nargs='+', action=LayerListAction, default=None, help="Override use_rotary_embeddings per layer, cycling through the list.")
     model_group.add_argument("--window_size_layerlist", nargs='+', action=LayerListAction, default=None, help="Override window_size per layer, cycling through the list.")
+    model_group.add_argument("--block_module_order_layerlist", nargs='+', action=LayerListAction, default=None, help="Override custom block module order per layer/group, e.g. attention,linear,mlp")
+    model_group.add_argument("--block_single_residual_layerlist", nargs='+', action=LayerListAction, default=None, help="Override custom block single-residual mode per layer/group.")
+
+    # Custom module block composition
+    model_group.add_argument("--use_custom_module_block", type=bool, default=False, action=argparse.BooleanOptionalAction, help="Enable custom ordered module assembly inside each block.")
+    model_group.add_argument("--block_module_order", type=str, default="attention,mlp", help="Comma-separated module order from: attention, mlp, linear, router_linear.")
+    model_group.add_argument("--block_single_residual", type=bool, default=False, action=argparse.BooleanOptionalAction, help="Use one block-level residual (input->output) instead of per-module residuals.")
 
     ## Infinite Attention variation
     model_group.add_argument('--n_qk_head_dim', default=None, type=int)

--- a/variations/block_variations.py
+++ b/variations/block_variations.py
@@ -11,6 +11,7 @@ from variations.mlp_variations import get_mlp_instance
 from variations.norm_variations import norm_dictionary
 from variations.learned_confidence_variations import learned_confidence_dictionary
 from quantization.quantize import fake_quantize_act
+from variations.linear_variations import linear_dictionary
 
 # type alias for the forward function
 BlockForward = Callable[['Block', torch.Tensor, int], torch.Tensor]
@@ -253,10 +254,58 @@ def edgellm_asic_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor:
     return x
 
 
+
+
+class OptionalRouterLinear(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        linear_cls = linear_dictionary[getattr(config, "linear_variant_mlp", "linear")]
+        self.router = linear_cls(config.n_embd, 1, config=config, method=config.quantize_linear_method, bits=config.quantize_linear_bits, bias=True)
+        self.transform = linear_cls(config.n_embd, config.n_embd, config=config, method=config.quantize_linear_method, bits=config.quantize_linear_bits, bias=True)
+
+    def forward(self, x, _iter_num):
+        gate = torch.sigmoid(self.router(x))
+        return gate * self.transform(x)
+
+
+class CustomModuleBlock(nn.Module):
+    def __init__(self, config, attn_module, mlp_module):
+        super().__init__()
+        self.single_residual = getattr(config, "block_single_residual", False)
+        self.module_types = [m.strip().lower() for m in getattr(config, "block_module_order", "attention,mlp").split(",") if m.strip()]
+        self.modules_list = nn.ModuleList()
+        linear_cls = linear_dictionary[getattr(config, "linear_variant_mlp", "linear")]
+        for module_type in self.module_types:
+            if module_type == "attention":
+                self.modules_list.append(attn_module)
+            elif module_type == "mlp":
+                self.modules_list.append(mlp_module)
+            elif module_type == "linear":
+                self.modules_list.append(linear_cls(config.n_embd, config.n_embd, config=config, method=config.quantize_linear_method, bits=config.quantize_linear_bits, bias=True))
+            elif module_type == "router_linear":
+                self.modules_list.append(OptionalRouterLinear(config))
+            else:
+                raise ValueError(f"Unknown module type in block_module_order: {module_type}")
+
+    def forward(self, x, iter_num):
+        x0 = x
+        for module in self.modules_list:
+            try:
+                out = module(x, iter_num)
+            except TypeError:
+                out = module(x)
+            if self.single_residual:
+                x = out
+            else:
+                x = x + out
+        if self.single_residual:
+            x = x0 + x
+        return x
 block_forward_variations = {
     "parallel_mlp": parallel_mlp_forward,
     "attn_then_mlp": attn_then_mlp_forward,
     "edgellm_asic": edgellm_asic_forward,
+    "custom_module": attn_then_mlp_forward,
 }
 
 
@@ -325,6 +374,7 @@ normalization_setup_variations = {
     "parallel_mlp": _setup_norms_parallel,
     "attn_then_mlp": _setup_norms_sequential,
     "edgellm_asic": _setup_norms_sequential,
+    "custom_module": _setup_norms_sequential,
 }
 
 
@@ -365,6 +415,7 @@ resid_scaler_setup_variations = {
     "parallel_mlp": _setup_resid_scalers_parallel,
     "attn_then_mlp": _setup_resid_scalers_sequential,
     "edgellm_asic": _setup_resid_scalers_sequential,
+    "custom_module": _setup_resid_scalers_sequential,
 }
 
 
@@ -391,7 +442,10 @@ class Block(nn.Module):
 
         self.use_flash_norm = getattr(config, "use_flash_norm", False)
 
-        if self.use_parallel_mlp:
+        self.use_custom_module_block = getattr(config, "use_custom_module_block", False)
+        if self.use_custom_module_block:
+            variant = "custom_module"
+        elif self.use_parallel_mlp:
             variant = "parallel_mlp"
         elif self.use_edgellm_asic:
             variant = "edgellm_asic"
@@ -427,6 +481,10 @@ class Block(nn.Module):
             self.mlp = get_mlp_instance(config)
         else:
             self.mlp = mlp
+
+        if self.use_custom_module_block:
+            self.custom_module_block = CustomModuleBlock(config, self.attn, self.mlp)
+            self.block_forward = lambda x, iter_num: self.custom_module_block(x, iter_num)
 
         self.attn_resid_type = getattr(config, "attn_residual_combination", "add")
         self.mlp_resid_type = getattr(config, "mlp_residual_combination", "add")


### PR DESCRIPTION
### Motivation
- Provide a flexible per-block composition API so blocks can be composed from one or more of `attention`, `mlp`, `linear`, or an optional `router_linear` transform and support alternate residual styles. 
- Allow users to set those per-block choices via existing layerlist override machinery so layerwise configs can be expressed easily in YAML.

### Description
- Add new config flags and layerlists: `use_custom_module_block`, `block_module_order`, `block_single_residual`, plus `block_module_order_layerlist` and `block_single_residual_layerlist` in `gpt_conf.py` to expose the per-block composition options.
- Add `apply_layerlists_to_config(...)` to `shared_param_utils.py` and integrate it into shared-parameter creation and block construction so each `Block` receives a layerlist-resolved `config` (used in `model.py`).
- Implement `OptionalRouterLinear` and `CustomModuleBlock` in `variations/block_variations.py` to instantiate module sequences composed from `attention`, `mlp`, `linear`, and `router_linear`, and support two residual modes (`per-module` or a single input→output skip).
- Add `explorations/custom_block_layerlist_example.yaml` derived from `default_inf.yaml` that demonstrates how to specify arbitrary `block_module_order_layerlist` and `block_single_residual_layerlist` alongside existing layerlists.

### Testing
- Ran `python -m py_compile gpt_conf.py shared_param_utils.py variations/block_variations.py model.py` and it completed successfully (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a3f69e54832681b3b331e27a0862)