### PR TITLE
Add ProjectOutL2Norm normalization and exploration

### DIFF
--- a/explorations/project_out_l2norm_vs_default_inf.yaml
+++ b/explorations/project_out_l2norm_vs_default_inf.yaml
@@ -1,0 +1,83 @@
+# Compare ProjectOutL2Norm variants against the default infinite-attention baseline.
+---
+
+named_static_groups:
+  # Baseline (mirrors explorations/default_inf.yaml defaults)
+  - named_group: "baseline_norms"
+    norm_variant_attn: ["rmsnorm"]
+    norm_variant_output: ["rmsnorm"]
+
+  # New norm variation from this change
+  - named_group: "projectout_attn_output"
+    norm_variant_attn: ["projectout_l2norm"]
+    norm_variant_output: ["projectout_l2norm"]
+
+  # Keep core default_inf settings aligned
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  - named_group: "peri_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [true]
+    use_post_ln: [false]
+
+  - named_group: "rotary"
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+  - named_group: "infinite"
+    attention_variant: ["infinite"]
+    use_concat_heads: [true]
+
+  - named_group: "softmax"
+    softmax_variant_attn: ["softmax"]
+
+  - named_group: "mqa"
+    n_kv_group: [1]
+
+  - named_group: "hd_100"
+    n_qk_head_dim: [100]
+    n_v_head_dim: [100]
+
+  # ProjectOutL2Norm hyperparameters to explore
+  - named_group: "projout_default_scale"
+    proj_out_norm_learn_scale: [true]
+    proj_out_norm_init_scale: [1.0]
+    proj_out_norm_eps: [1.0e-8]
+
+  - named_group: "projout_sqrtd_scale"
+    proj_out_norm_learn_scale: [false]
+    proj_out_norm_init_scale: [27.7128129211]  # sqrt(768), common n_embd default
+    proj_out_norm_eps: [1.0e-8]
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [2500]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+  compile: [true]
+
+parameter_groups:
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "softmax"
+      - "infinite"
+      - "mqa"
+      - "hd_100"
+      - "baseline_norms"
+    n_head: [3, 6, 9, 12]
+
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "softmax"
+      - "infinite"
+      - "mqa"
+      - "hd_100"
+      - "projectout_attn_output"
+    n_head: [3, 6, 9, 12]
+    named_group_alternates: ["projout_default_scale", "projout_sqrtd_scale"]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -80,6 +80,11 @@ class GPTConfig:
     l2_norm_attn_v_dim: str = "embed"     # 'embed' or 'hidden'
     l2_norm_attn_cproj_dim: str = "embed" # 'embed' or 'hidden'
 
+    # ProjectOutL2Norm options
+    proj_out_norm_eps: float = 1e-8
+    proj_out_norm_learn_scale: bool = True
+    proj_out_norm_init_scale: float = 1.0
+
     ## MLA Variations
     mla_latent_dim: int | None = None   # d_c  (proj dimension of the shared latent)
     mla_rotary_dim: int       = 32      # d_r  (# rotary channels per head)

--- a/train_args.py
+++ b/train_args.py
@@ -765,6 +765,7 @@ def parse_args():
             "rmsnorm",
             "layernorm",
             "hyperspherenorm",
+            "projectout_l2norm",
             "dact",
             "identity",
             ]
@@ -805,6 +806,11 @@ def parse_args():
     model_group.add_argument("--hsnorm_scale", type=float, default=1.0)
     model_group.add_argument("--hsnorm_radius", type=float, default=None)
     model_group.add_argument("--hsnorm_radius_learning", default=False, action=argparse.BooleanOptionalAction)
+
+    ## ProjectOutL2Norm
+    model_group.add_argument("--proj_out_norm_eps", type=float, default=1e-8)
+    model_group.add_argument("--proj_out_norm_learn_scale", default=True, action=argparse.BooleanOptionalAction)
+    model_group.add_argument("--proj_out_norm_init_scale", type=float, default=1.0)
 
     activation_variations = [
             "celu",

--- a/variations/norm_variations.py
+++ b/variations/norm_variations.py
@@ -210,6 +210,38 @@ class IdentityNorm(nn.Module):
     def forward(self, x):
         return self.identity(x)
 
+class ProjectOutL2Norm(nn.Module):
+    """Project out a learned direction from activations, then L2-normalize."""
+
+    def __init__(self, config):
+        super().__init__()
+        ndim = config.n_embd
+        self.eps = config.proj_out_norm_eps
+        self.learn_scale = config.proj_out_norm_learn_scale
+
+        # Learned direction to project out (v in docs).
+        self.direction = nn.Parameter(torch.randn(ndim))
+
+        if self.learn_scale:
+            self.log_scale = nn.Parameter(torch.tensor(math.log(config.proj_out_norm_init_scale)))
+        else:
+            self.register_buffer(
+                "fixed_scale",
+                torch.tensor(float(config.proj_out_norm_init_scale)),
+                persistent=False,
+            )
+
+    def forward(self, x):
+        # u = v / ||v||
+        u = F.normalize(self.direction, p=2, dim=0, eps=self.eps)
+        # z = x - <x, u>u
+        coeff = (x * u).sum(dim=-1, keepdim=True)
+        z = x - coeff * u
+        # y = z / ||z||
+        y = F.normalize(z, p=2, dim=-1, eps=self.eps)
+        scale = self.log_scale.exp() if self.learn_scale else self.fixed_scale
+        return scale * y
+
 
 norm_dictionary = {
     "layernorm": LayerNorm,
@@ -219,4 +251,5 @@ norm_dictionary = {
     "hyperspherenorm": HyperSphereNorm,
     "dact": DynamicActivation,
     "identity": IdentityNorm,
+    "projectout_l2norm": ProjectOutL2Norm,
 }


### PR DESCRIPTION
### Motivation
- Provide a normalization variant that removes a learned direction from activations (subtract component along learned unit vector) then L2-normalizes, to enable experiments that specifically ablate learned directions without collapsing post-normalization.
- Expose hyperparameters and CLI knobs so the new behavior can be tuned and compared against existing norms in search/experiments.

### Description
- Implement `ProjectOutL2Norm` in `variations/norm_variations.py` which normalizes a learned direction `v` to `u = normalize(v)`, computes `z = x - <x,u>u`, L2-normalizes `z`, and optionally scales the result with a learned or fixed scale. 
- Register the new variant in `norm_dictionary` as `projectout_l2norm` and add related config/constructor wiring so it can be selected like other norm variants.
- Add new `GPTConfig` fields (`proj_out_norm_eps`, `proj_out_norm_learn_scale`, `proj_out_norm_init_scale`) in `gpt_conf.py` and expose corresponding CLI flags in `train_args.py`, and add `projectout_l2norm` to the list of available `norm_variations`.
- Add an exploration file `explorations/project_out_l2norm_vs_default_inf.yaml` that compares the new norm against a baseline (rmsnorm) under default infinite-attention-like settings and with two scale presets.

### Testing
- Ran `python -m py_compile variations/norm_variations.py gpt_conf.py train_args.py`, which completed without syntax errors. 
- Attempted a lightweight runtime argument-parse check for the new flags, but the invocation failed due to `ModuleNotFoundError: No module named 'torch'` in this environment, so full runtime validation could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f489506483268fb25f3ea5c03f81)