### PR TITLE
Set default training device to cuda:0

### DIFF
--- a/train_args.py
+++ b/train_args.py
@@ -1413,7 +1413,7 @@ def parse_args():
     training_group.add_argument('--gradient_accumulation_steps', default=1, type=int)
 
     # System args
-    training_group.add_argument('--device', default='cuda', type=str)
+    training_group.add_argument('--device', default='cuda:0', type=str)
     training_group.add_argument("--dtype", type=str, default="float16", choices=["bfloat16", "float16", "float32"], help="torch data type for inference, e.g. 'int8'")
     training_group.add_argument('--compile', default=False, action=argparse.BooleanOptionalAction)
 


### PR DESCRIPTION
### Motivation
- Make the CLI default training device explicit by selecting GPU `cuda:0` instead of the ambiguous `cuda` string.

### Description
- Changed the default value of `--device` in `train_args.py` from `'cuda'` to `'cuda:0'`.

### Testing
- Verified the change is present by running `rg -n "default='cuda:0'" train_args.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7cfbea81c83268ca47ca0cc09ef76)