### PR TITLE
Add optional dual embedding + GLU-combined output heads

### DIFF
--- a/explorations/default_inf_dual_wte_glu_comparison.yaml
+++ b/explorations/default_inf_dual_wte_glu_comparison.yaml
@@ -1,0 +1,68 @@
+# Compare baseline vs dual_wte_glu_head using default_inf-inspired settings.
+---
+
+named_static_groups:
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  - named_group: "peri_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [true]
+    use_post_ln: [false]
+
+  - named_group: "rotary"
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+  - named_group: "softmax"
+    softmax_variant_attn: ["softmax"]
+
+  - named_group: "infinite"
+    attention_variant: ["infinite"]
+    use_concat_heads: [true]
+
+  - named_group: "mqa"
+    n_kv_group: [1]
+
+  # Keep architecture equal for a fair comparison.
+  - named_group: "hd_100_h3"
+    n_head: [3]
+    n_qk_head_dim: [100]
+    n_v_head_dim: [100]
+
+  - named_group: "baseline"
+    dual_wte_glu_head: [false]
+
+  - named_group: "dual_wte_glu"
+    dual_wte_glu_head: [true]
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [2500]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+  compile: [true]
+  log_rankme: [true]
+  log_areq: [true]
+
+parameter_groups:
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "softmax"
+      - "infinite"
+      - "mqa"
+      - "hd_100_h3"
+      - "baseline"
+
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "softmax"
+      - "infinite"
+      - "mqa"
+      - "hd_100_h3"
+      - "dual_wte_glu"

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -136,6 +136,7 @@ class GPTConfig:
     # weight tying
     n_embd_wte_scale_tying: bool = True
     wte_weight_tying: bool = True # Non-factorized wte weight tying
+    dual_wte_glu_head: bool = False
 
     # wte import/export
     import_wte_freeze: bool = False

--- a/model.py
+++ b/model.py
@@ -90,6 +90,9 @@ class GPT(nn.Module):
 
         # General weight tying
         self.wte_weight_tying = config.wte_weight_tying
+        self.dual_wte_glu_head = config.dual_wte_glu_head
+        if self.dual_wte_glu_head and (config.n_embd_wte or config.multicontext or config.multidataset_wte):
+            raise ValueError("dual_wte_glu_head currently supports only the standard single-context non-factorized embedding path")
 
         # Factorization Parameters
         self.n_embd_wte = config.n_embd_wte
@@ -139,6 +142,8 @@ class GPT(nn.Module):
                     # no factorization
                     word_embd = nn.Embedding(config.vocab_size, config.n_embd)
                     self.transformer['wte'] = word_embd
+                    if self.dual_wte_glu_head:
+                        self.transformer['wte2'] = nn.Embedding(config.vocab_size, config.n_embd)
 
 
         self.transformer['drop'] = nn.Dropout(config.dropout)
@@ -168,6 +173,8 @@ class GPT(nn.Module):
                     self.transformer[f'lm_head_{i}'].weight = self.transformer[f'wte_{i}'].weight
             else:
                 self.lm_head = nn.Linear(config.n_embd, config.vocab_size, bias=False)
+                if self.dual_wte_glu_head:
+                    self.lm_head2 = nn.Linear(config.n_embd, config.vocab_size, bias=False)
 
         # Initialize and possibly import scale_up and scale_down matrices, if factorization is set
         if self.n_embd_wte:
@@ -196,6 +203,8 @@ class GPT(nn.Module):
                     self.transformer[f'lm_head_{i}'].weight = self.transformer[f'wte_{i}'].weight
             else:
                 self.lm_head.weight = self.transformer.wte.weight # https://paperswithcode.com/method/weight-tying
+                if self.dual_wte_glu_head:
+                    self.lm_head2.weight = self.transformer.wte2.weight
 
         # import wte
         if self.config.import_wte_npy:
@@ -543,6 +552,8 @@ class GPT(nn.Module):
                 tok_emb = self.transformer[f'wte_{dataset_idx}'](idx)
             else:
                 tok_emb = self.transformer.wte(idx) # token embeddings of shape (b, t, n_embd)
+                if self.dual_wte_glu_head:
+                    tok_emb = tok_emb + self.transformer.wte2(idx)
             x = None
 
             tok_emb = self.add_embedding_gaussian_noise(tok_emb, iter_num=iter_num)
@@ -607,6 +618,8 @@ class GPT(nn.Module):
                 # if we are given some desired targets also calculate the loss
                 if self.config.multidataset_wte and dataset_idx is not None:
                     logits = self.transformer[f'lm_head_{dataset_idx}'](x)
+                elif self.dual_wte_glu_head:
+                    logits = self.lm_head(x) * self.lm_head2(x)
                 else:
                     logits = self.lm_head(x)
 
@@ -623,6 +636,8 @@ class GPT(nn.Module):
                 # inference-time mini-optimization: only forward the lm_head on the very last position
                 if self.config.multidataset_wte and dataset_idx is not None:
                     logits = self.transformer[f'lm_head_{dataset_idx}'](x[:, [-1], :])
+                elif self.dual_wte_glu_head:
+                    logits = self.lm_head(x[:, [-1], :]) * self.lm_head2(x[:, [-1], :])
                 else:
                     logits = self.lm_head(x[:, [-1], :]) # note: using list [-1] to preserve the time dim
 
@@ -650,6 +665,8 @@ class GPT(nn.Module):
             tok_emb = self.transformer[f'wte_{dataset_idx}'](idx)
         else:
             tok_emb = self.transformer.wte(idx)
+            if self.dual_wte_glu_head:
+                tok_emb = tok_emb + self.transformer.wte2(idx)
 
         tok_emb = self.add_embedding_gaussian_noise(tok_emb, iter_num=None)
 
@@ -708,6 +725,10 @@ class GPT(nn.Module):
 
         if self.config.multidataset_wte and dataset_idx is not None:
             logits = self.transformer[f'lm_head_{dataset_idx}'](x)
+        elif self.dual_wte_glu_head:
+            logits_1 = self.lm_head(x)
+            logits_2 = self.lm_head2(x)
+            logits = logits_1 * logits_2
         else:
             logits = self.lm_head(x)
         if self.final_logit_softcapping is not None:

--- a/train_args.py
+++ b/train_args.py
@@ -595,6 +595,8 @@ def parse_args():
     model_group.add_argument('--n_embd_wte', default=None, type=int, help="If different from n_embd, an adapter table will be automatically created")
     model_group.add_argument('--n_embd_wte_scale_tying', default=True, action=argparse.BooleanOptionalAction, help="Enable weight tying for scale up and scale down matrices, only has effects if n_embd_wte is not 'None'.")
     model_group.add_argument('--wte_weight_tying', default=True, action=argparse.BooleanOptionalAction, help="Enable weight tying for non-factorized wte")
+    model_group.add_argument('--dual_wte_glu_head', default=False, action=argparse.BooleanOptionalAction,
+                             help="Use two token embedding tables summed at input and GLU-combined dual tied output heads.")
     model_group.add_argument('--dropout', default=0.0, type=float)
     model_group.add_argument('--use_pre_ln', default=True,   action=argparse.BooleanOptionalAction, help="apply before any attn or mlp")
     model_group.add_argument('--use_peri_ln', default=False, action=argparse.BooleanOptionalAction, help="apply directly after each attn and mlp")


### PR DESCRIPTION
### Motivation

- Provide an experimental variant where two embedding tables produce token representations that are summed at input and produce two parallel LM head activations which are combined GLU-style before loss/inference.

### Description

- Added a new config field and CLI switch `dual_wte_glu_head` to enable the variant via `gpt_conf.py` and `train_args.py`.
- Created a second embedding table `wte2` and made the input token representation `wte(idx) + wte2(idx)` when the flag is enabled, with changes in `forward`, `embed_tokens`, and `forward_embedded` in `model.py`.
- Added a second LM head `lm_head2` that is weight-tied to `wte2` when global weight-tying is used, and combined the two head outputs with elementwise multiplication (`logits = lm_head(x) * lm_head2(x)`) for both training loss computation and inference logits.
- Added a guard to restrict `dual_wte_glu_head` to the standard single-context non-factorized embedding path to avoid incompatible code paths.

### Testing

- Ran `python -m py_compile model.py gpt_conf.py train_args.py` and the files compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a021ec00d788326943813114b5f6fde)