### PR TITLE
Add train_custom.py example demonstrating loss-wrapper extension and document in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,20 @@ Train from scratch:
 python3 train_mezo.py --dataset shakespeare_char --max_iters 2000 --batch_size 64 --block_size 256
 ```
 
+### Train Model with a Custom Loss Wrapper
+
+If you want to implement custom training behavior without editing the core loop
+in `train.py`, use `train_custom.py`. This example wraps the base loss function
+with an additional z-loss regularizer:
+
+```bash
+python3 train_custom.py --dataset shakespeare_char --compile=False
+```
+
+To implement the same idea directly in `train.py`, copy the wrapper logic from
+`CustomTrainer.__init__` and assign your wrapped callable back to
+`self.loss_fn`.
+
 Resume from an existing checkpoint:
 
 ```bash

--- a/train_custom.py
+++ b/train_custom.py
@@ -1,0 +1,58 @@
+"""Example entrypoint showing how to add custom training behavior without editing core loops.
+
+Usage:
+  python train_custom.py --dataset shakespeare_char --compile=False
+
+This file demonstrates two extension patterns:
+1) New training file: subclass ``Trainer`` and override setup hooks.
+2) In-place in ``train.py``: copy the same logic into ``Trainer.__init__`` after
+   ``self.setup()`` and keep the core train loop unchanged.
+"""
+
+import torch
+
+from train import Trainer
+from train_args import parse_args
+
+
+class CustomTrainer(Trainer):
+    """Trainer with an auxiliary z-loss term added to the base loss."""
+
+    def __init__(self, args, model_group, training_group, logging_group):
+        # Configure custom knobs before super() so they're available everywhere.
+        self.z_loss_weight = float(getattr(args, "z_loss_weight", 1e-4))
+        super().__init__(args, model_group, training_group, logging_group)
+
+        # Keep the original loss object and wrap it with custom logic.
+        base_loss_fn = self.loss_fn
+
+        def custom_loss(logits, targets, *loss_args, **loss_kwargs):
+            """Base CE loss + small z-loss regularizer on log-sum-exp(logits)."""
+            base = base_loss_fn(logits, targets, *loss_args, **loss_kwargs)
+            z = torch.logsumexp(logits.float(), dim=-1).pow(2).mean()
+            return base + self.z_loss_weight * z
+
+        # Optional: preserve helper methods used by existing logging code.
+        if hasattr(base_loss_fn, "set_model"):
+            custom_loss.set_model = base_loss_fn.set_model
+        if hasattr(base_loss_fn, "bit_statistics"):
+            custom_loss.bit_statistics = base_loss_fn.bit_statistics
+
+        self.loss_fn = custom_loss
+
+
+def main():
+    args, model_group, training_group, logging_group = parse_args()
+
+    # Allow CLI override if parse_args supports unknown attributes.
+    if not hasattr(args, "z_loss_weight"):
+        args.z_loss_weight = 1e-4
+
+    trainer = CustomTrainer(args, model_group, training_group, logging_group)
+
+    if not args.sample_only:
+        trainer.train()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide an example entrypoint for adding custom training behavior without editing the core training loop in `train.py`.
- Show a simple, realistic pattern for wrapping the existing loss function to add an auxiliary regularizer while remaining compatible with existing logging/hooks.

### Description
- Add `train_custom.py`, a standalone entrypoint that subclasses `Trainer` and wraps `self.loss_fn` to add a z-loss term (`logsumexp(logits)^2`) with a configurable `z_loss_weight`.
- Preserve compatibility by copying helper attributes from the base loss (e.g., `set_model`, `bit_statistics`) onto the wrapped callable so existing logging/training code continues to work.
- Update `README.md` with usage instructions for `train_custom.py` and a note explaining how to port the same wrapper logic into `Trainer.__init__` if desired.
- Keep the example minimal and safe to compile and run with existing CLI args (adds a CLI-friendly default for `z_loss_weight`).

### Testing
- Successfully compiled the new entrypoint with `python -m py_compile train_custom.py` (no runtime tests were run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c04e3d2b483269a2e7b7d2568d2b0)