### PR TITLE
Add Cayley-rotation MLP variant and comparison exploration

### DIFF
--- a/explorations/cayley_rotation_baseline_comparison.yaml
+++ b/explorations/cayley_rotation_baseline_comparison.yaml
@@ -32,9 +32,9 @@ named_static_groups:
       activation_variant: ["squared_relu"]
 
   # Attention baseline (explicitly not mqa)
-  - named_group: "gqa_attention"
+  - named_group: "causal_attention"
     named_group_settings:
-      attention_variant: ["gqa"]
+      attention_variant: ["causal"]
 
 common_group:
   dataset: ["minipile"]
@@ -52,7 +52,7 @@ parameter_groups:
       - "rotary"
       - "rmsnorm_wte"
       - "squared_relu"
-      - "gqa_attention"
+      - "causal_attention"
 
   # New Cayley rotation MLP
   - compile: [true]
@@ -63,4 +63,4 @@ parameter_groups:
       - "rotary"
       - "rmsnorm_wte"
       - "squared_relu"
-      - "gqa_attention"
+      - "causal_attention"

--- a/explorations/cayley_rotation_baseline_comparison.yaml
+++ b/explorations/cayley_rotation_baseline_comparison.yaml
@@ -1,0 +1,66 @@
+# cayley_rotation_baseline_comparison.yaml
+# Based on explorations/default.yaml, but explicitly avoids ReLU2max and MQA
+# so Cayley-rotation MLP can be compared cleanly against baseline.
+---
+
+named_static_groups:
+  # QK Norm
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  # Norm Type
+  - named_group: "peri_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [true]
+    use_post_ln: [false]
+
+  # Position Embeddings
+  - named_group: "rotary"
+    named_group_settings:
+      use_rotary_embeddings: [true]
+      use_abs_pos_embeddings: [false]
+
+  # Embedding Norm
+  - named_group: "rmsnorm_wte"
+    named_group_settings:
+      norm_variant_wte: ["rmsnorm"]
+
+  # Activation (explicitly not relu2max)
+  - named_group: "squared_relu"
+    named_group_settings:
+      activation_variant: ["squared_relu"]
+
+  # Attention baseline (explicitly not mqa)
+  - named_group: "gqa_attention"
+    named_group_settings:
+      attention_variant: ["gqa"]
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [1000]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+
+parameter_groups:
+  # Baseline MLP
+  - compile: [true]
+    mlp_variant: ["mlp"]
+    named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "rmsnorm_wte"
+      - "squared_relu"
+      - "gqa_attention"
+
+  # New Cayley rotation MLP
+  - compile: [true]
+    mlp_variant: ["cayley_rotation"]
+    named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "rmsnorm_wte"
+      - "squared_relu"
+      - "gqa_attention"

--- a/train_args.py
+++ b/train_args.py
@@ -664,6 +664,7 @@ def parse_args():
             "dual_path",
             "dual_path_swiglu",
             "identity",
+            "cayley_rotation",
             ]
 
     model_group.add_argument('--use_parallel_mlp', default=False, action=argparse.BooleanOptionalAction)

--- a/variations/mlp_variations.py
+++ b/variations/mlp_variations.py
@@ -860,6 +860,48 @@ class DualPathSwiglu(nn.Module):
         return x
 
 
+class CayleyRotationMLP(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+
+        self.activation_variant = activation_dictionary[config.activation_variant](config=config)
+
+        if config.learn_mlp_x_offset:
+            self.activation_x_offset = nn.Parameter(torch.tensor(config.mlp_x_offset))
+        else:
+            self.register_buffer("activation_x_offset", torch.tensor(config.mlp_x_offset))
+
+        if config.learn_mlp_y_offset:
+            self.activation_y_offset = nn.Parameter(torch.tensor(config.mlp_y_offset))
+        else:
+            self.register_buffer("activation_y_offset", torch.tensor(config.mlp_y_offset))
+
+        mlp_hidden = config.mlp_size if config.mlp_size is not None else config.mlp_expansion_factor * config.n_embd
+        self.c_fc = nn.Linear(config.n_embd, mlp_hidden, bias=(config.mlp_up_bias if config.mlp_up_bias is not None else config.bias))
+
+        # One learnable skew-symmetric seed per hidden scalar gate.
+        self.skew_seed = nn.Parameter(torch.randn(mlp_hidden, config.n_embd, config.n_embd) * 0.02)
+        self.eye = nn.Parameter(torch.eye(config.n_embd), requires_grad=False)
+        self.dropout = nn.Dropout(config.dropout)
+
+    def forward(self, x, iter_num=None):
+        x_in = x
+        gates = self.c_fc(x)
+        gates = self.activation_variant(gates - self.activation_x_offset) - self.activation_y_offset
+
+        # Build skew-symmetric matrices from learned seeds and combine using post-activation scalars.
+        skew_seeds = self.skew_seed - self.skew_seed.transpose(-1, -2)
+        skew = torch.einsum('bth,hnm->btnm', gates, skew_seeds)
+
+        eye = self.eye.to(dtype=x.dtype, device=x.device).unsqueeze(0).unsqueeze(0)
+        half_skew = 0.5 * skew
+        cayley = torch.linalg.solve(eye - half_skew, eye + half_skew)
+
+        x = torch.matmul(cayley, x_in.unsqueeze(-1)).squeeze(-1)
+        x = self.dropout(x)
+        return x
+
+
 class KanMLP(nn.Module):
     def __init__(self, config):
         super().__init__()
@@ -890,7 +932,8 @@ mlp_dictionary = {
     "identity": MLP_Identity,
     "kan": KanMLP,
     "dual_path": DualPathMLP,
-    "dual_path_swiglu": DualPathSwiglu
+    "dual_path_swiglu": DualPathSwiglu,
+    "cayley_rotation": CayleyRotationMLP,
     }
 
 def get_mlp_instance(config):


### PR DESCRIPTION
### Motivation
- Add a new MLP variation that applies learned skew-symmetric Cayley rotations to token representations so the Cayley-rotation MLP can be compared cleanly against the baseline MLP.
- Provide a dedicated experiment configuration that disables ReLU2max and MQA so the Cayley-rotation model is evaluated under the same normalization/attention/activation settings as the baseline.

### Description
- Implemented `CayleyRotationMLP` in `variations/mlp_variations.py`, which builds skew-symmetric matrices from a learned seed per hidden scalar gate and applies the Cayley transform to rotate inputs before dropout.
- Registered the new variant in `mlp_dictionary` as `"cayley_rotation"` and added the class to the module exports used by `get_mlp_instance`.
- Exposed the new variant name in the CLI `mlp_variants` list in `train_args.py` so it can be selected via `--mlp_variant cayley_rotation`.
- Added an experiment file `explorations/cayley_rotation_baseline_comparison.yaml` that pins normalization, rotary embeddings, RMSNorm WTE, `squared_relu` activation, and GQA attention, and defines two parameter groups (baseline `mlp` and `cayley_rotation`) for direct comparison.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073facf5d083269a458bdd681864ca)