### PR TITLE
Add per-layer MLP activation heatmap export to colorize_dataset.py

### DIFF
--- a/analyze_with_dataset.py
+++ b/analyze_with_dataset.py
@@ -1,4 +1,4 @@
-# colorize_dataset.py  (rolling-window mode added)
+# analyze_with_dataset.py  (rolling-window mode added)
 """Colourise a dataset split using a trained GPT model.
 
 Modes
@@ -18,7 +18,7 @@ Example
 -------
 ```bash
 # rolling window, colour 3 000 tokens starting  at offset 50 000
-python colorize_dataset.py \
+python analyze_with_dataset.py \
   --out_dir out/my_run \
   --dataset tiny_shakespeare \
   --split train \

--- a/colorize_dataset.py
+++ b/colorize_dataset.py
@@ -165,6 +165,12 @@ def parse_args():
         default="attention_head_hist.html",
         help="Output HTML file for per-layer per-head attention output histograms",
     )
+    p.add_argument("--analysis_layers", default="all", help="Layer selection for analysis: 'all' or comma-separated 1-based layer ids")
+    p.add_argument("--analysis_heads", default="all", help="Head selection for attention analysis: 'all' or comma-separated 1-based head ids")
+    p.add_argument("--plot_residual_magnitude", action=argparse.BooleanOptionalAction, default=False,
+                   help="Plot residual magnitude trace across model stages")
+    p.add_argument("--residual_magnitude_file", default="residual_magnitude.html",
+                   help="Output HTML file for residual magnitude traces")
     p.add_argument(
         "--components",
         choices=["wte", "attn", "mlp", "resid"],
@@ -230,6 +236,23 @@ def main():
     heatmap_traces = None
     heatmap_inputs = None
     attn_head_traces = None
+    residual_mag_traces = []
+
+    def parse_selection(spec: str, max_count: int):
+        if spec == "all":
+            return list(range(max_count))
+        out = []
+        for tok in spec.split(","):
+            tok = tok.strip()
+            if not tok:
+                continue
+            idx = int(tok) - 1
+            if 0 <= idx < max_count:
+                out.append(idx)
+        return sorted(set(out))
+
+    selected_layers = parse_selection(args.analysis_layers, model.config.n_layer)
+    selected_heads = parse_selection(args.analysis_heads, model.config.n_head)
 
     if args.display == "token":
         ids: List[int] = []
@@ -281,6 +304,8 @@ def main():
                 heatmap_inputs = [[] for _ in range(model.config.n_layer)]
                 attn_head_traces = [[[] for _ in range(model.config.n_head)] for _ in range(model.config.n_layer)]
             for li, blk in enumerate(model.transformer.h):
+                if li not in selected_layers:
+                    continue
                 if hasattr(blk.mlp, "activation_variant"):
                     act_call_counts[li] = 0
                     def make_act_hook(layer_idx):
@@ -304,6 +329,31 @@ def main():
                             attn_head_traces[layer_idx][hi].append(per_head[hi])
                     return hook
                 handles.append(blk.attn.register_forward_hook(make_attn_head_hook(li)))
+        if args.plot_residual_magnitude:
+            residual_points = {"after_wte": None, "after_norm_wte": None, "after_attn": {}, "after_mlp": {}, "after_ln_f": None}
+            def wte_hook(module, inp, out):
+                residual_points["after_wte"] = out[0, -1, :].detach().float()
+            handles.append(model.transformer.wte.register_forward_hook(wte_hook))
+            if hasattr(model.transformer, "post_embedding_norm"):
+                def norm_wte_hook(module, inp, out):
+                    residual_points["after_norm_wte"] = out[0, -1, :].detach().float()
+                handles.append(model.transformer.post_embedding_norm.register_forward_hook(norm_wte_hook))
+            for li, blk in enumerate(model.transformer.h):
+                if li not in selected_layers:
+                    continue
+                def make_attn_mag_hook(layer_idx):
+                    def hook(module, inp, out):
+                        residual_points["after_attn"][layer_idx] = out[0, -1, :].detach().float()
+                    return hook
+                def make_mlp_mag_hook(layer_idx):
+                    def hook(module, inp, out):
+                        residual_points["after_mlp"][layer_idx] = out[0, -1, :].detach().float()
+                    return hook
+                handles.append(blk.attn.register_forward_hook(make_attn_mag_hook(li)))
+                handles.append(blk.mlp.register_forward_hook(make_mlp_mag_hook(li)))
+            def lnf_hook(module, inp, out):
+                residual_points["after_ln_f"] = out[0, -1, :].detach().float()
+            handles.append(model.transformer.ln_f.register_forward_hook(lnf_hook))
         if args.display != "token" and args.activation_view != "none":
             def t0_hook(module, inp, out):
                 activations["t0"] = out[0, -1, :].detach()
@@ -339,6 +389,23 @@ def main():
 
         for h in handles:
             h.remove()
+        if args.plot_residual_magnitude:
+            stage_names = ["after_wte", "after_norm_wte"]
+            mags = []
+            for st in stage_names:
+                v = residual_points[st]
+                mags.append(float(v.norm().item()) if v is not None else np.nan)
+            for li in selected_layers:
+                stage_names.append(f"after_attn_l{li+1}")
+                v = residual_points["after_attn"].get(li)
+                mags.append(float(v.norm().item()) if v is not None else np.nan)
+                stage_names.append(f"after_mlp_l{li+1}")
+                v = residual_points["after_mlp"].get(li)
+                mags.append(float(v.norm().item()) if v is not None else np.nan)
+            stage_names.append("after_ln_f")
+            v = residual_points["after_ln_f"]
+            mags.append(float(v.norm().item()) if v is not None else np.nan)
+            residual_mag_traces.append((stage_names, mags))
 
         if args.activation_view != "none" and "resid" in args.components and activations["t0"] is not None:
             resid = activations["t0"].float().clone()
@@ -581,11 +648,11 @@ def main():
             subplot_titles=[f"attn layer {i+1}" for i in range(attn_rows)],
         )
         attn_payload = {}
-        for li in range(model.config.n_layer):
+        for li in selected_layers:
             if not any(attn_head_traces[li][hi] for hi in range(model.config.n_head)):
                 continue
             head_means = []
-            for hi in range(model.config.n_head):
+            for hi in selected_heads:
                 if not attn_head_traces[li][hi]:
                     head_means.append(np.array([], dtype=np.float32))
                     continue
@@ -595,10 +662,10 @@ def main():
             max_len = max((m.shape[0] for m in head_means), default=0)
             if max_len == 0:
                 continue
-            z = np.full((model.config.n_head, max_len), np.nan, dtype=np.float32)
-            for hi, m in enumerate(head_means):
+            z = np.full((len(selected_heads), max_len), np.nan, dtype=np.float32)
+            for row_i, m in enumerate(head_means):
                 if m.shape[0] > 0:
-                    z[hi, :m.shape[0]] = m
+                    z[row_i, :m.shape[0]] = m
             attn_fig.add_trace(go.Heatmap(z=z, coloraxis="coloraxis", showscale=(li == 0)), row=li + 1, col=1)
             attn_fig.update_yaxes(title_text="head", row=li + 1, col=1)
         attn_fig.update_layout(height=max(260 * attn_rows, 400), coloraxis={"colorscale": "RdBu", "cmid": 0.0})
@@ -607,8 +674,8 @@ def main():
         console.print(f"[cyan]Saved attention head heatmaps → {args.attention_head_heatmap_file}[/cyan]")
 
         attn_hist = make_subplots(rows=attn_rows, cols=1, shared_xaxes=False, subplot_titles=[f"attn layer {i+1}" for i in range(attn_rows)])
-        for li in range(model.config.n_layer):
-            for hi in range(model.config.n_head):
+        for li in selected_layers:
+            for hi in selected_heads:
                 if not attn_head_traces[li][hi]:
                     continue
                 arr = np.stack(attn_head_traces[li][hi], axis=0).reshape(-1)
@@ -623,6 +690,18 @@ def main():
         attn_hist.update_layout(height=max(260 * attn_rows, 400))
         attn_hist.write_html(args.attention_head_hist_file)
         console.print(f"[cyan]Saved attention head histograms → {args.attention_head_hist_file}[/cyan]")
+
+    if args.plot_residual_magnitude and residual_mag_traces:
+        from plotly.subplots import make_subplots
+        import plotly.graph_objects as go
+        fig = make_subplots(rows=1, cols=1)
+        stage_names = residual_mag_traces[0][0]
+        arr = np.array([m for _, m in residual_mag_traces], dtype=np.float32)
+        fig.add_trace(go.Heatmap(z=arr.T, x=list(range(arr.shape[0])), y=stage_names, coloraxis="coloraxis"))
+        fig.update_layout(height=max(320, 22 * len(stage_names)), coloraxis={"colorscale": "Viridis"})
+        fig.write_html(args.residual_magnitude_file)
+        np.savez(Path(args.residual_magnitude_file).with_suffix(".npz"), stage_names=np.array(stage_names, dtype=object), magnitudes=arr)
+        console.print(f"[cyan]Saved residual magnitude traces → {args.residual_magnitude_file}[/cyan]")
 
 if __name__ == "__main__":
     main()

--- a/colorize_dataset.py
+++ b/colorize_dataset.py
@@ -145,6 +145,17 @@ def parse_args():
         help="Output HTML file for activation heatmaps",
     )
     p.add_argument(
+        "--activation_hist_file",
+        default="activation_hist.html",
+        help="Output HTML file for activation-input histograms overlaid with activation curves",
+    )
+    p.add_argument(
+        "--activation_hist_bins",
+        type=int,
+        default=120,
+        help="Number of bins for per-layer activation-input histograms",
+    )
+    p.add_argument(
         "--components",
         choices=["wte", "attn", "mlp", "resid"],
         nargs="+",
@@ -207,6 +218,7 @@ def main():
 
     lines: List[str] = []
     heatmap_traces = None
+    heatmap_inputs = None
 
     if args.display == "token":
         ids: List[int] = []
@@ -255,6 +267,7 @@ def main():
         if args.activation_heatmap:
             if heatmap_traces is None:
                 heatmap_traces = [[] for _ in range(model.config.n_layer)]
+                heatmap_inputs = [[] for _ in range(model.config.n_layer)]
             for li, blk in enumerate(model.transformer.h):
                 if hasattr(blk.mlp, "activation_variant"):
                     act_call_counts[li] = 0
@@ -262,7 +275,9 @@ def main():
                         def hook(module, inp, out):
                             # SwigLU / DualPath* can call activation multiple times; take the first call per token.
                             if act_call_counts[layer_idx] == 0:
+                                in_vec = inp[0][0, -1, :].detach().float().cpu()
                                 vec = out[0, -1, :].detach().float().cpu()
+                                heatmap_inputs[layer_idx].append(in_vec.numpy())
                                 heatmap_traces[layer_idx].append(vec.numpy())
                             act_call_counts[layer_idx] += 1
                         return hook
@@ -494,6 +509,47 @@ def main():
         fig.write_html(args.activation_heatmap_file)
         np.savez(Path(args.activation_heatmap_file).with_suffix('.npz'), **npy_payload)
         console.print(f"[cyan]Saved activation heatmaps → {args.activation_heatmap_file}[/cyan]")
+
+        hist_fig = make_subplots(
+            rows=rows,
+            cols=1,
+            shared_xaxes=False,
+            subplot_titles=[f"layer {i+1}" for i in range(rows)],
+            specs=[[{"secondary_y": True}] for _ in range(rows)],
+        )
+        hist_payload = {}
+        for i, layer_inputs in enumerate(heatmap_inputs):
+            if not layer_inputs:
+                continue
+            arr_in = np.concatenate([a.reshape(-1) for a in layer_inputs], axis=0)
+            hist_payload[f"layer_{i+1}_activation_input"] = arr_in
+            counts, edges = np.histogram(arr_in, bins=args.activation_hist_bins, density=True)
+            centers = (edges[:-1] + edges[1:]) * 0.5
+            layer_mlp = model.transformer.h[i].mlp
+            x_eval = torch.from_numpy(centers.astype(np.float32)).to(args.device)
+            with torch.no_grad():
+                y_eval = layer_mlp.activation_variant(x_eval).detach().float().cpu().numpy()
+
+            hist_fig.add_trace(
+                go.Bar(x=centers, y=counts, name=f"L{i+1} hist", marker_color="rgba(55, 83, 109, 0.55)"),
+                row=i + 1,
+                col=1,
+                secondary_y=False,
+            )
+            hist_fig.add_trace(
+                go.Scatter(x=centers, y=y_eval, mode="lines", name=f"L{i+1} act(x)", line={"color": "crimson", "width": 2}),
+                row=i + 1,
+                col=1,
+                secondary_y=True,
+            )
+            hist_fig.update_yaxes(title_text="density", row=i + 1, col=1, secondary_y=False)
+            hist_fig.update_yaxes(title_text="activation(x)", row=i + 1, col=1, secondary_y=True)
+            hist_fig.update_xaxes(title_text="activation input", row=i + 1, col=1)
+
+        hist_fig.update_layout(height=max(280 * rows, 400), barmode="overlay")
+        hist_fig.write_html(args.activation_hist_file)
+        np.savez(Path(args.activation_hist_file).with_suffix('.npz'), **hist_payload)
+        console.print(f"[cyan]Saved activation histograms → {args.activation_hist_file}[/cyan]")
 
 if __name__ == "__main__":
     main()

--- a/colorize_dataset.py
+++ b/colorize_dataset.py
@@ -156,6 +156,16 @@ def parse_args():
         help="Number of bins for per-layer activation-input histograms",
     )
     p.add_argument(
+        "--attention_head_heatmap_file",
+        default="attention_head_heatmap.html",
+        help="Output HTML file for per-layer per-head attention output heatmaps",
+    )
+    p.add_argument(
+        "--attention_head_hist_file",
+        default="attention_head_hist.html",
+        help="Output HTML file for per-layer per-head attention output histograms",
+    )
+    p.add_argument(
         "--components",
         choices=["wte", "attn", "mlp", "resid"],
         nargs="+",
@@ -219,6 +229,7 @@ def main():
     lines: List[str] = []
     heatmap_traces = None
     heatmap_inputs = None
+    attn_head_traces = None
 
     if args.display == "token":
         ids: List[int] = []
@@ -268,6 +279,7 @@ def main():
             if heatmap_traces is None:
                 heatmap_traces = [[] for _ in range(model.config.n_layer)]
                 heatmap_inputs = [[] for _ in range(model.config.n_layer)]
+                attn_head_traces = [[[] for _ in range(model.config.n_head)] for _ in range(model.config.n_layer)]
             for li, blk in enumerate(model.transformer.h):
                 if hasattr(blk.mlp, "activation_variant"):
                     act_call_counts[li] = 0
@@ -282,6 +294,16 @@ def main():
                             act_call_counts[layer_idx] += 1
                         return hook
                     handles.append(blk.mlp.activation_variant.register_forward_hook(make_act_hook(li)))
+                def make_attn_head_hook(layer_idx):
+                    def hook(module, inp, out):
+                        vec = out[0, -1, :].detach().float().cpu().numpy()
+                        if vec.shape[0] % model.config.n_head != 0:
+                            return
+                        per_head = vec.reshape(model.config.n_head, -1)
+                        for hi in range(model.config.n_head):
+                            attn_head_traces[layer_idx][hi].append(per_head[hi])
+                    return hook
+                handles.append(blk.attn.register_forward_hook(make_attn_head_hook(li)))
         if args.display != "token" and args.activation_view != "none":
             def t0_hook(module, inp, out):
                 activations["t0"] = out[0, -1, :].detach()
@@ -550,6 +572,57 @@ def main():
         hist_fig.write_html(args.activation_hist_file)
         np.savez(Path(args.activation_hist_file).with_suffix('.npz'), **hist_payload)
         console.print(f"[cyan]Saved activation histograms → {args.activation_hist_file}[/cyan]")
+
+        attn_rows = model.config.n_layer
+        attn_fig = make_subplots(
+            rows=attn_rows,
+            cols=1,
+            shared_xaxes=True,
+            subplot_titles=[f"attn layer {i+1}" for i in range(attn_rows)],
+        )
+        attn_payload = {}
+        for li in range(model.config.n_layer):
+            if not any(attn_head_traces[li][hi] for hi in range(model.config.n_head)):
+                continue
+            head_means = []
+            for hi in range(model.config.n_head):
+                if not attn_head_traces[li][hi]:
+                    head_means.append(np.array([], dtype=np.float32))
+                    continue
+                arr = np.stack(attn_head_traces[li][hi], axis=0)
+                attn_payload[f"layer_{li+1}_head_{hi+1}"] = arr
+                head_means.append(arr.mean(axis=1))
+            max_len = max((m.shape[0] for m in head_means), default=0)
+            if max_len == 0:
+                continue
+            z = np.full((model.config.n_head, max_len), np.nan, dtype=np.float32)
+            for hi, m in enumerate(head_means):
+                if m.shape[0] > 0:
+                    z[hi, :m.shape[0]] = m
+            attn_fig.add_trace(go.Heatmap(z=z, coloraxis="coloraxis", showscale=(li == 0)), row=li + 1, col=1)
+            attn_fig.update_yaxes(title_text="head", row=li + 1, col=1)
+        attn_fig.update_layout(height=max(260 * attn_rows, 400), coloraxis={"colorscale": "RdBu", "cmid": 0.0})
+        attn_fig.write_html(args.attention_head_heatmap_file)
+        np.savez(Path(args.attention_head_heatmap_file).with_suffix(".npz"), **attn_payload)
+        console.print(f"[cyan]Saved attention head heatmaps → {args.attention_head_heatmap_file}[/cyan]")
+
+        attn_hist = make_subplots(rows=attn_rows, cols=1, shared_xaxes=False, subplot_titles=[f"attn layer {i+1}" for i in range(attn_rows)])
+        for li in range(model.config.n_layer):
+            for hi in range(model.config.n_head):
+                if not attn_head_traces[li][hi]:
+                    continue
+                arr = np.stack(attn_head_traces[li][hi], axis=0).reshape(-1)
+                counts, edges = np.histogram(arr, bins=args.activation_hist_bins, density=True)
+                centers = (edges[:-1] + edges[1:]) * 0.5
+                attn_hist.add_trace(
+                    go.Scatter(x=centers, y=counts, mode="lines", name=f"L{li+1}H{hi+1}", line={"width": 1}),
+                    row=li + 1, col=1
+                )
+            attn_hist.update_yaxes(title_text="density", row=li + 1, col=1)
+            attn_hist.update_xaxes(title_text="attn output", row=li + 1, col=1)
+        attn_hist.update_layout(height=max(260 * attn_rows, 400))
+        attn_hist.write_html(args.attention_head_hist_file)
+        console.print(f"[cyan]Saved attention head histograms → {args.attention_head_hist_file}[/cyan]")
 
 if __name__ == "__main__":
     main()

--- a/colorize_dataset.py
+++ b/colorize_dataset.py
@@ -31,10 +31,10 @@ python colorize_dataset.py \
 from __future__ import annotations
 
 import argparse, io, pickle, math
+import numpy as np
 from pathlib import Path
 from typing import Callable, List, Sequence
 
-import numpy as np
 import torch, torch.nn.functional as F
 from rich.console import Console
 from rich.table import Table
@@ -134,6 +134,17 @@ def parse_args():
         ),
     )
     p.add_argument(
+        "--activation_heatmap",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Collect per-layer activation traces and save heatmap HTML/NPY outputs",
+    )
+    p.add_argument(
+        "--activation_heatmap_file",
+        default="activation_heatmap.html",
+        help="Output HTML file for activation heatmaps",
+    )
+    p.add_argument(
         "--components",
         choices=["wte", "attn", "mlp", "resid"],
         nargs="+",
@@ -195,6 +206,7 @@ def main():
     tokens_left = min(args.num_tokens, len(data) - 1 - pos)
 
     lines: List[str] = []
+    heatmap_traces = None
 
     if args.display == "token":
         ids: List[int] = []
@@ -239,6 +251,22 @@ def main():
 
         activations = {"t0": None, "attn": [], "mlp": [], "ar": [], "mr": []}
         handles = []
+        act_call_counts = {}
+        if args.activation_heatmap:
+            if heatmap_traces is None:
+                heatmap_traces = [[] for _ in range(model.config.n_layer)]
+            for li, blk in enumerate(model.transformer.h):
+                if hasattr(blk.mlp, "activation_variant"):
+                    act_call_counts[li] = 0
+                    def make_act_hook(layer_idx):
+                        def hook(module, inp, out):
+                            # SwigLU / DualPath* can call activation multiple times; take the first call per token.
+                            if act_call_counts[layer_idx] == 0:
+                                vec = out[0, -1, :].detach().float().cpu()
+                                heatmap_traces[layer_idx].append(vec.numpy())
+                            act_call_counts[layer_idx] += 1
+                        return hook
+                    handles.append(blk.mlp.activation_variant.register_forward_hook(make_act_hook(li)))
         if args.display != "token" and args.activation_view != "none":
             def t0_hook(module, inp, out):
                 activations["t0"] = out[0, -1, :].detach()
@@ -445,6 +473,27 @@ def main():
         fig.write_html(args.plot_file)
         console.print(f"[cyan]Saved plot → {args.plot_file}[/cyan]")
 
+
+    if args.activation_heatmap and heatmap_traces is not None:
+        from plotly.subplots import make_subplots
+        import plotly.graph_objects as go
+
+        rows = len(heatmap_traces)
+        fig = make_subplots(rows=rows, cols=1, shared_xaxes=True,
+                            subplot_titles=[f"layer {i+1}" for i in range(rows)])
+        npy_payload = {}
+        for i, layer_series in enumerate(heatmap_traces):
+            if not layer_series:
+                continue
+            arr = np.stack(layer_series, axis=0)  # (tokens, hidden_or_mlp_dim)
+            npy_payload[f"layer_{i+1}"] = arr
+            fig.add_trace(go.Heatmap(z=arr.T, coloraxis="coloraxis", showscale=(i == 0)), row=i+1, col=1)
+            fig.update_yaxes(title_text="unit", row=i+1, col=1)
+
+        fig.update_layout(height=max(280 * rows, 400), coloraxis={"colorscale": "RdBu", "cmid": 0.0})
+        fig.write_html(args.activation_heatmap_file)
+        np.savez(Path(args.activation_heatmap_file).with_suffix('.npz'), **npy_payload)
+        console.print(f"[cyan]Saved activation heatmaps → {args.activation_heatmap_file}[/cyan]")
 
 if __name__ == "__main__":
     main()

--- a/demos/dataset_analysis.sh
+++ b/demos/dataset_analysis.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# demos/dataset_colorization.sh
+# demos/dataset_analysis.sh
 
 set -euo pipefail
 

--- a/demos/dataset_analysis.sh
+++ b/demos/dataset_analysis.sh
@@ -3,19 +3,40 @@
 
 set -euo pipefail
 
-output_dir="${1:?Usage: $0 <out_dir> [dataset]}"
+root_out_dir="${1:?Usage: $0 <out_dir_root> [dataset]}"
 dataset="${2:-minipile}"
-
-run_name="$(basename "$output_dir")"
 results_dir="results"
 mkdir -p "$results_dir"
 
-python analyze_with_dataset.py \
-  --out_dir "$output_dir" \
-  --dataset "$dataset" \
-  --display topk \
-  --activation_heatmap \
-  --activation_heatmap_file "$results_dir/${run_name}_activation_heatmap.html" \
-  --activation_hist_file "$results_dir/${run_name}_activation_hist.html" \
-  --attention_head_heatmap_file "$results_dir/${run_name}_attn_head_heatmap.html" \
-  --attention_head_hist_file "$results_dir/${run_name}_attn_head_hist.html"
+if [[ ! -d "$root_out_dir" ]]; then
+  echo "Error: '$root_out_dir' is not a directory" >&2
+  exit 1
+fi
+
+# Analyze every run directory recursively: any directory containing ckpt.pt.
+# Typical use: out/ contains subdirs for runs; each run has its own checkpoint.
+mapfile -t run_dirs < <(find "$root_out_dir" -type f -name ckpt.pt -printf '%h\n' | sort -u)
+
+if [[ ${#run_dirs[@]} -eq 0 ]]; then
+  echo "No run directories containing ckpt.pt found under '$root_out_dir'" >&2
+  exit 1
+fi
+
+for output_dir in "${run_dirs[@]}"; do
+  run_name="$(basename "$output_dir")"
+  echo "Analyzing: $output_dir (dataset=$dataset)"
+
+  python analyze_with_dataset.py \
+    --out_dir "$output_dir" \
+    --dataset "$dataset" \
+    --display topk \
+    --analysis_layers all \
+    --analysis_heads all \
+    --activation_heatmap \
+    --activation_heatmap_file "$results_dir/${run_name}_activation_heatmap.html" \
+    --activation_hist_file "$results_dir/${run_name}_activation_hist.html" \
+    --attention_head_heatmap_file "$results_dir/${run_name}_attn_head_heatmap.html" \
+    --attention_head_hist_file "$results_dir/${run_name}_attn_head_hist.html" \
+    --plot_residual_magnitude \
+    --residual_magnitude_file "$results_dir/${run_name}_residual_magnitude.html"
+done

--- a/demos/dataset_colorization.sh
+++ b/demos/dataset_colorization.sh
@@ -12,7 +12,7 @@ python train.py \
   --colorize_mode all \
   --max_iters 10000
 
-python colorize_dataset.py \
+python analyze_with_dataset.py \
   --out_dir        out \
   --dataset        filipino/tagalog_filipino_eng_translation  \
   --split          val \

--- a/demos/dataset_colorization.sh
+++ b/demos/dataset_colorization.sh
@@ -1,23 +1,21 @@
 #!/bin/bash
 # demos/dataset_colorization.sh
 
-pushd data/filipino/tagalog_filipino_eng_translation
-bash get_dataset.sh
-popd
+set -euo pipefail
 
-python train.py \
-  --dataset filipino/tagalog_filipino_eng_translation \
-  --compile \
-  --colorize_output \
-  --colorize_mode all \
-  --max_iters 10000
+output_dir="${1:?Usage: $0 <out_dir> [dataset]}"
+dataset="${2:-minipile}"
+
+run_name="$(basename "$output_dir")"
+results_dir="results"
+mkdir -p "$results_dir"
 
 python analyze_with_dataset.py \
-  --out_dir        out \
-  --dataset        filipino/tagalog_filipino_eng_translation  \
-  --split          val \
-  --num_tokens     2048 \
-  --device         cuda:0 \
-  --block_size     256 \
-  --mode           minmax  \
-  --output_file    kulay_ng_dataset_minmax.txt
+  --out_dir "$output_dir" \
+  --dataset "$dataset" \
+  --display topk \
+  --activation_heatmap \
+  --activation_heatmap_file "$results_dir/${run_name}_activation_heatmap.html" \
+  --activation_hist_file "$results_dir/${run_name}_activation_hist.html" \
+  --attention_head_heatmap_file "$results_dir/${run_name}_attn_head_heatmap.html" \
+  --attention_head_hist_file "$results_dir/${run_name}_attn_head_hist.html"


### PR DESCRIPTION
### Motivation
- Provide a way to visualise where per-layer MLP activations (including `swiglu` and dual-path variants) "hit" during dataset colouring so researchers can inspect per-layer activation patterns. 
- Allow exporting interactive heatmaps and raw arrays for offline analysis of activation traces across tokens and layers.

### Description
- Add CLI options `--activation_heatmap/--no-activation_heatmap` and `--activation_heatmap_file` to `colorize_dataset.py` to enable and name the heatmap export file. 
- Allocate `heatmap_traces` and register forward hooks on each block's `blk.mlp.activation_variant` to capture the last-token activation vector per layer for each inference step. 
- Handle multi-call activation modules (e.g., `Swiglu`, `DualPath*`) by counting calls per layer and recording only the first activation call per token to produce a stable per-token "hit" trace. 
- Export collected traces as an interactive Plotly HTML file (one subplot per layer) and a `.npz` file containing per-layer arrays named `layer_{i}` with shape `[num_steps, activation_dim]`, and include a small import/initialisation adjustment for `numpy`.

### Testing
- Ran `python -m py_compile colorize_dataset.py`, which succeeded with no syntax errors. 
- No additional automated unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a013d4f9a408326892f60b83c14a5ec)