### PR TITLE
Make Muon optimizer configurable: routing, Newton‑Schulz steps, and Nesterov

### DIFF
--- a/explorations/muon_norm_explore.yaml
+++ b/explorations/muon_norm_explore.yaml
@@ -1,0 +1,150 @@
+# muon_norm_explore.yaml
+# Based on explorations/default_inf.yaml, extended to sweep Muon routing/update knobs
+# and compare HyperSphereNorm vs RMSNorm.
+---
+
+named_static_groups:
+  # QK Norm
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  # Norm Type
+  - named_group: "peri_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [true]
+    use_post_ln: [false]
+
+  # Position Embeddings
+  - named_group: "rotary"
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+  # MLP Activation
+  - named_group: "squared_relu"
+    activation_variant: ["squared_relu"]
+
+  # Softmax family
+  - named_group: "relu2max"
+    softmax_variant_attn: ["relu2max"]
+  - named_group: "softmax"
+    softmax_variant_attn: ["softmax"]
+
+  # Infinite Attention
+  - named_group: "infinite"
+    attention_variant: ["infinite"]
+    use_concat_heads: [true]
+
+  # MQA
+  - named_group: "mqa"
+    n_kv_group: [1]
+
+  # Head Dimension
+  - named_group: "hd_100"
+    n_qk_head_dim: [100]
+    n_v_head_dim: [100]
+  - named_group: "hd_150"
+    n_qk_head_dim: [150]
+    n_v_head_dim: [150]
+  - named_group: "hd_200"
+    n_qk_head_dim: [200]
+    n_v_head_dim: [200]
+
+  # Optimizer
+  - named_group: "muon_default"
+    optimizer: ["muon"]
+    muon_momentum: [0.95]
+    muon_ns_steps: [5]
+    muon_nesterov: [true]
+    muon_include_all_weights: [false]
+    muon_min_ndim: [2]
+    muon_exclude_substrings: ["embed", "wte", "wpe", "lm_head"]
+
+  # Norm alternates for comparison
+  - named_group: "rmsnorm_pair"
+    norm_variant_attn: ["rmsnorm"]
+    norm_variant_output: ["rmsnorm"]
+  - named_group: "hypersphere_pair"
+    norm_variant_attn: ["hyperspherenorm"]
+    norm_variant_output: ["hyperspherenorm"]
+    hsnorm_scale: [1.0]
+    hsnorm_gain: [false]
+    hsnorm_radius_learning: [false]
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [2500]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+  compile: [true]
+  log_rankme: [true]
+  log_areq: [true]
+
+parameter_groups:
+  # relu2max + RMSNorm
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "relu2max"
+      - "infinite"
+      - "mqa"
+      - "muon_default"
+      - "rmsnorm_pair"
+    n_head:
+      range:
+        start: 1
+        end: 12
+        step: 1
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]
+
+  # relu2max + HyperSphereNorm
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "relu2max"
+      - "infinite"
+      - "mqa"
+      - "muon_default"
+      - "hypersphere_pair"
+    n_head:
+      range:
+        start: 1
+        end: 12
+        step: 1
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]
+
+  # softmax + RMSNorm
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "softmax"
+      - "infinite"
+      - "mqa"
+      - "muon_default"
+      - "rmsnorm_pair"
+    n_head:
+      range:
+        start: 1
+        end: 12
+        step: 1
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]
+
+  # softmax + HyperSphereNorm
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "softmax"
+      - "infinite"
+      - "mqa"
+      - "muon_default"
+      - "hypersphere_pair"
+    n_head:
+      range:
+        start: 1
+        end: 12
+        step: 1
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]

--- a/train.py
+++ b/train.py
@@ -548,9 +548,23 @@ class Trainer:
 
         if optimizer_key == "muon":
             named = list(self.model.named_parameters())
-            exclude = ("embed", "wte", "wpe", "lm_head")
-            hidden = [p for n, p in named if p.ndim >= 2 and all(e not in n for e in exclude)]
-            other = [p for n, p in named if not (p.ndim >= 2 and all(e not in n for e in exclude))]
+            exclude = tuple(self.args.muon_exclude_substrings)
+            force_include = tuple(self.args.muon_force_include_substrings)
+            muon_min_ndim = self.args.muon_min_ndim
+
+            def _use_muon_for_param(name, param):
+                if self.args.muon_include_all_weights:
+                    return True
+                if force_include and any(token in name for token in force_include):
+                    return True
+                if param.ndim < muon_min_ndim:
+                    return False
+                if exclude and any(token in name for token in exclude):
+                    return False
+                return True
+
+            hidden = [p for n, p in named if _use_muon_for_param(n, p)]
+            other = [p for n, p in named if not _use_muon_for_param(n, p)]
             param_groups = [
                 {"params": other, "use_muon": False},
                 {"params": hidden, "use_muon": True},

--- a/train_args.py
+++ b/train_args.py
@@ -406,6 +406,18 @@ def parse_args():
     # --------  MUON --------------------------------------------------
     training_group.add_argument("--muon_momentum", type=float, default=0.95,
                                 help="Momentum for the Muon optimizer.")
+    training_group.add_argument("--muon_ns_steps", type=int, default=5,
+                                help="Newton-Schulz iteration steps for Muon orthogonalization.")
+    training_group.add_argument("--muon_nesterov", type=bool, default=True, action=argparse.BooleanOptionalAction,
+                                help="Use Nesterov momentum in Muon update.")
+    training_group.add_argument("--muon_include_all_weights", type=bool, default=False, action=argparse.BooleanOptionalAction,
+                                help="If enabled, route all parameters to Muon (instead of the default hidden-layer-only routing).")
+    training_group.add_argument("--muon_min_ndim", type=int, default=2,
+                                help="Minimum tensor ndim eligible for Muon routing (default preserves current behavior).")
+    training_group.add_argument("--muon_exclude_substrings", type=str, nargs="*", default=["embed", "wte", "wpe", "lm_head"],
+                                help="Parameter-name substrings excluded from Muon routing unless force-included.")
+    training_group.add_argument("--muon_force_include_substrings", type=str, nargs="*", default=[],
+                                help="Parameter-name substrings force-included into Muon routing, even if excluded.")
     # --------  ADAMW --------------------------------------------------
     training_group.add_argument("--adamw_betas", type=float, nargs=2, default=[0.9, 0.999], help="Betas for AdamW optimizer.")
     training_group.add_argument("--adamw_eps", type=float, default=1e-8, help="Epsilon for AdamW optimizer.")

--- a/train_variations/muon.py
+++ b/train_variations/muon.py
@@ -69,7 +69,13 @@ class Muon(torch.optim.Optimizer):
                     state = self.state[p]
                     if not state:
                         state["momentum_buffer"] = torch.zeros_like(p)
-                    upd = muon_update(p.grad, state["momentum_buffer"], beta=group["momentum"])
+                    upd = muon_update(
+                        p.grad,
+                        state["momentum_buffer"],
+                        beta=group["momentum"],
+                        ns_steps=group.get("ns_steps", 5),
+                        nesterov=group.get("nesterov", True),
+                    )
                     p.mul_(1 - group["lr"] * group["weight_decay"])
                     p.add_(upd.reshape(p.shape), alpha=-group["lr"])
                 dist.all_gather(pad[base:base + dist.get_world_size()], pad[base + dist.get_rank()])
@@ -95,7 +101,13 @@ class SingleDeviceMuon(torch.optim.Optimizer):
                 state = self.state[p]
                 if not state:
                     state["momentum_buffer"] = torch.zeros_like(p)
-                upd = muon_update(p.grad, state["momentum_buffer"], beta=group["momentum"])
+                upd = muon_update(
+                    p.grad,
+                    state["momentum_buffer"],
+                    beta=group["momentum"],
+                    ns_steps=group.get("ns_steps", 5),
+                    nesterov=group.get("nesterov", True),
+                )
                 p.mul_(1 - group["lr"] * group["weight_decay"])
                 p.add_(upd.reshape(p.shape), alpha=-group["lr"])
         return loss
@@ -145,7 +157,13 @@ class MuonWithAuxAdam(torch.optim.Optimizer):
                         state = self.state[p]
                         if not state:
                             state["momentum_buffer"] = torch.zeros_like(p)
-                        upd = muon_update(p.grad, state["momentum_buffer"], beta=group["momentum"])
+                        upd = muon_update(
+                            p.grad,
+                            state["momentum_buffer"],
+                            beta=group["momentum"],
+                            ns_steps=group.get("ns_steps", 5),
+                            nesterov=group.get("nesterov", True),
+                        )
                         p.mul_(1 - group["lr"] * group["weight_decay"])
                         p.add_(upd.reshape(p.shape), alpha=-group["lr"])
                     dist.all_gather(pad[base:base + dist.get_world_size()], pad[base + dist.get_rank()])
@@ -195,7 +213,13 @@ class SingleDeviceMuonWithAuxAdam(torch.optim.Optimizer):
                     state = self.state[p]
                     if not state:
                         state["momentum_buffer"] = torch.zeros_like(p)
-                    upd = muon_update(p.grad, state["momentum_buffer"], beta=group["momentum"])
+                    upd = muon_update(
+                        p.grad,
+                        state["momentum_buffer"],
+                        beta=group["momentum"],
+                        ns_steps=group.get("ns_steps", 5),
+                        nesterov=group.get("nesterov", True),
+                    )
                     p.mul_(1 - group["lr"] * group["weight_decay"])
                     p.add_(upd.reshape(p.shape), alpha=-group["lr"])
             else:

--- a/train_variations/optimizer_variants.py
+++ b/train_variations/optimizer_variants.py
@@ -1565,6 +1565,8 @@ def _muon(param_groups, args):
             group.update(
                 lr=args.learning_rate,
                 momentum=getattr(args, "muon_momentum", 0.95),
+                ns_steps=getattr(args, "muon_ns_steps", 5),
+                nesterov=getattr(args, "muon_nesterov", True),
                 weight_decay=args.weight_decay,
                 use_muon=True,
             )


### PR DESCRIPTION
### Motivation
- Make the Muon optimizer behavior configurable to allow tuning orthogonalization iterations and momentum behavior via CLI flags. 
- Allow flexible routing of parameters to Muon by enabling substring-based exclusions, force-inclusions, minimum tensor dimensionality, and an opt-in to include all weights. 

### Description
- Added new training arguments: `--muon_ns_steps`, `--muon_nesterov`, `--muon_include_all_weights`, `--muon_min_ndim`, `--muon_exclude_substrings`, and `--muon_force_include_substrings` in `train_args.py`. 
- Reworked parameter grouping logic in `Trainer.create_optimizer` to use the new routing options and a helper `_use_muon_for_param` that respects `muon_min_ndim`, exclusion and force-inclusion substrings, and `muon_include_all_weights`. 
- Propagated `ns_steps` and `nesterov` settings into Muon implementations by updating calls to `muon_update` in `train_variations/muon.py` and by adding `ns_steps`/`nesterov` to optimizer group configuration in `train_variations/optimizer_variants.py`. 
- Preserved previous defaults so existing behavior remains unchanged when the new flags are not set. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13d965e0c48326a60f3cb6a23e166b)