### PR TITLE
Add Android nanoGPT benchmark app and ckpt->bin converter

### DIFF
--- a/android_benchmark/.gitignore
+++ b/android_benchmark/.gitignore
@@ -1,0 +1,7 @@
+.gradle/
+build/
+app/build/
+app/src/main/assets/nanogpt.bin
+*.apk
+*.aab
+local.properties

--- a/android_benchmark/README.md
+++ b/android_benchmark/README.md
@@ -1,0 +1,114 @@
+# NanoGPT Android Hardware Benchmark
+
+This directory contains a minimal Android app source tree for strategic LLM
+performance benchmarking on Android hardware. It does **not** commit an APK or a
+model artifact. Instead, convert one of this repository's compatible `ckpt.pt`
+files into `app/src/main/assets/nanogpt.bin`, build the app, and run the native
+CPU benchmark on a device.
+
+The app is intentionally small and scriptable so it works well with Android CLI
+agent workflows:
+
+- `android create` is not required because the Gradle project is already checked
+  in.
+- `android sdk install ...` can provision SDK packages in CI or on a workstation.
+- `android run --apks=...` can install a built debug APK without Android Studio.
+- `android screen capture` and `android layout` can collect benchmark evidence
+  from a connected device.
+
+## What is measured?
+
+The included JNI implementation loads a converted fp32 checkpoint and performs a
+simple greedy decode loop. It reports elapsed time and tokens per second for a
+fixed 32-token generation run. This is a correctness-oriented baseline for
+comparing CPU paths across devices. For production-grade mobile inference,
+compare this against the existing ExecuTorch/XNNPACK path in `../exutorch/`.
+
+Supported checkpoints are the repository's default GPT path:
+
+- causal attention
+- RMSNorm pre-norm and output norm
+- absolute positional embeddings
+- GELU MLP
+- untied architectural experiments disabled (`use_moe=False`, no rotary, no
+  factorized embeddings, no parallel/ASIC block variants)
+
+The converter fails fast for unsupported variants so benchmark results are not
+silently invalid.
+
+## Convert a checkpoint
+
+From the repository root:
+
+```bash
+python android_benchmark/scripts/convert_ckpt_to_nanogpt_bin.py \
+  out/my_run/ckpt.pt \
+  --out android_benchmark/app/src/main/assets/nanogpt.bin
+```
+
+The generated `nanogpt.bin` is ignored by git. Keep it out of commits and upload
+it separately if you need to preserve a benchmark artifact.
+
+## Build the APK
+
+### Option A: Android CLI
+
+Install/update Android CLI, initialize agent skills, and install SDK packages:
+
+```bash
+android update
+android init
+android sdk install platforms/android-35 build-tools/35.0.0 platform-tools
+android sdk list 'cmake|ndk' --all
+android sdk install '<cmake-package-name>' '<ndk-package-name>'
+```
+
+Build with Gradle from this directory:
+
+```bash
+cd android_benchmark
+./gradlew :app:assembleDebug
+```
+
+If a Gradle wrapper is not present in your checkout, use a system Gradle install:
+
+```bash
+cd android_benchmark
+gradle :app:assembleDebug
+```
+
+### Option B: Android Studio
+
+Open `android_benchmark/` in Android Studio and run the `app` configuration. The
+`studio` Android CLI commands from Android Studio Quail 2 Canary 1+ can inspect
+or open files when Gemini in Android Studio is enabled.
+
+## Install and run on a device
+
+With Android CLI:
+
+```bash
+android run --apks=android_benchmark/app/build/outputs/apk/debug/app-debug.apk
+```
+
+Or with adb:
+
+```bash
+adb install -r android_benchmark/app/build/outputs/apk/debug/app-debug.apk
+adb shell am start -n com.nanogpt.benchmark/.MainActivity
+```
+
+Tap **Run 32-token benchmark**. To collect evidence in an automated run:
+
+```bash
+android screen capture --output=benchmark.png
+android layout --pretty --output=layout.json
+```
+
+## Notes for better benchmarking
+
+1. Run on battery and plugged-in modes if thermal policy matters.
+2. Reboot or cool the device between long runs.
+3. Record model dimensions, Android build, SoC, governor state, and app version.
+4. Repeat at least 5 times and compare median tokens/second.
+5. Use the same `nanogpt.bin` for all devices in a comparison.

--- a/android_benchmark/app/build.gradle
+++ b/android_benchmark/app/build.gradle
@@ -1,0 +1,17 @@
+plugins { id 'com.android.application' }
+
+android {
+    namespace 'com.nanogpt.benchmark'
+    compileSdk 35
+
+    defaultConfig {
+        applicationId 'com.nanogpt.benchmark'
+        minSdk 26
+        targetSdk 35
+        versionCode 1
+        versionName '0.1.0'
+        externalNativeBuild { cmake { cppFlags '-std=c++17 -O3 -ffast-math' } }
+    }
+
+    externalNativeBuild { cmake { path 'src/main/cpp/CMakeLists.txt' } }
+}

--- a/android_benchmark/app/src/main/AndroidManifest.xml
+++ b/android_benchmark/app/src/main/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application android:theme="@style/AppTheme" android:label="NanoGPT Benchmark" android:allowBackup="false" android:supportsRtl="true">
+        <activity android:name=".MainActivity" android:screenOrientation="portrait" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android_benchmark/app/src/main/assets/README.md
+++ b/android_benchmark/app/src/main/assets/README.md
@@ -1,0 +1,4 @@
+Place a converted `nanogpt.bin` here before building the APK.
+
+`nanogpt.bin` is intentionally ignored by git because it is generated from large
+training checkpoints.

--- a/android_benchmark/app/src/main/cpp/nanogpt_jni.cpp
+++ b/android_benchmark/app/src/main/cpp/nanogpt_jni.cpp
@@ -1,0 +1,162 @@
+#include <android/asset_manager.h>
+#include <android/asset_manager_jni.h>
+#include <jni.h>
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <numeric>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+constexpr uint32_t kMagic = 0x4e475054; // NGPT
+constexpr uint32_t kVersion = 1;
+
+struct Tensor { std::vector<float> v; };
+struct Layer {
+    Tensor ln1_g, ln2_g, q_w, k_w, v_w, proj_w, fc_w, fc_b, mlp_w;
+};
+struct Model {
+    int block_size{}, vocab_size{}, n_layer{}, n_head{}, n_embd{}, hidden{};
+    Tensor wte, wpe, lnf_g, lm_head;
+    std::vector<Layer> layers;
+};
+
+static int32_t read_i32(const std::vector<uint8_t>& b, size_t& p) {
+    if (p + 4 > b.size()) throw std::runtime_error("truncated int32");
+    int32_t x; std::memcpy(&x, b.data() + p, 4); p += 4; return x;
+}
+static uint32_t read_u32(const std::vector<uint8_t>& b, size_t& p) { return static_cast<uint32_t>(read_i32(b, p)); }
+static Tensor read_tensor(const std::vector<uint8_t>& b, size_t& p) {
+    int32_t n = read_i32(b, p);
+    if (n < 0 || p + static_cast<size_t>(n) * 4 > b.size()) throw std::runtime_error("truncated tensor");
+    Tensor t; t.v.resize(n);
+    std::memcpy(t.v.data(), b.data() + p, static_cast<size_t>(n) * 4); p += static_cast<size_t>(n) * 4;
+    return t;
+}
+
+static std::vector<uint8_t> read_asset(JNIEnv* env, jobject assetManager, const char* name) {
+    AAssetManager* mgr = AAssetManager_fromJava(env, assetManager);
+    if (!mgr) throw std::runtime_error("missing AssetManager");
+    AAsset* asset = AAssetManager_open(mgr, name, AASSET_MODE_BUFFER);
+    if (!asset) throw std::runtime_error("missing asset app/src/main/assets/nanogpt.bin");
+    off_t len = AAsset_getLength(asset);
+    std::vector<uint8_t> bytes(static_cast<size_t>(len));
+    int read = AAsset_read(asset, bytes.data(), bytes.size());
+    AAsset_close(asset);
+    if (read != len) throw std::runtime_error("could not read nanogpt.bin");
+    return bytes;
+}
+
+static Model load_model(JNIEnv* env, jobject activity) {
+    jclass cls = env->GetObjectClass(activity);
+    jmethodID mid = env->GetMethodID(cls, "getAssets", "()Landroid/content/res/AssetManager;");
+    jobject assets = env->CallObjectMethod(activity, mid);
+    auto bytes = read_asset(env, assets, "nanogpt.bin");
+    size_t p = 0;
+    if (read_u32(bytes, p) != kMagic || read_u32(bytes, p) != kVersion) throw std::runtime_error("bad nanogpt.bin header");
+    Model m;
+    m.block_size = read_i32(bytes, p); m.vocab_size = read_i32(bytes, p); m.n_layer = read_i32(bytes, p);
+    m.n_head = read_i32(bytes, p); m.n_embd = read_i32(bytes, p); m.hidden = read_i32(bytes, p);
+    m.wte = read_tensor(bytes, p); m.wpe = read_tensor(bytes, p);
+    m.layers.resize(m.n_layer);
+    for (auto& l : m.layers) {
+        l.ln1_g = read_tensor(bytes, p); l.ln2_g = read_tensor(bytes, p);
+        l.q_w = read_tensor(bytes, p); l.k_w = read_tensor(bytes, p); l.v_w = read_tensor(bytes, p); l.proj_w = read_tensor(bytes, p);
+        l.fc_w = read_tensor(bytes, p); l.fc_b = read_tensor(bytes, p); l.mlp_w = read_tensor(bytes, p);
+    }
+    m.lnf_g = read_tensor(bytes, p); m.lm_head = read_tensor(bytes, p);
+    return m;
+}
+
+static void rmsnorm(const float* x, const float* gain, float* y, int n) {
+    float ss = 0.f; for (int i = 0; i < n; ++i) ss += x[i] * x[i];
+    float scale = 1.f / std::sqrt(ss / n + 1e-5f);
+    for (int i = 0; i < n; ++i) y[i] = x[i] * scale * gain[i];
+}
+static void linear(const float* x, const float* w, float* y, int in, int out) {
+    for (int o = 0; o < out; ++o) {
+        const float* row = w + static_cast<size_t>(o) * in;
+        float s = 0.f; for (int i = 0; i < in; ++i) s += row[i] * x[i];
+        y[o] = s;
+    }
+}
+static float gelu(float x) { return 0.5f * x * (1.f + std::tanh(0.7978845608f * (x + 0.044715f * x * x * x))); }
+
+static int forward_next(const Model& m, const std::vector<int>& ids, std::vector<float>& x) {
+    const int T = std::min<int>(ids.size(), m.block_size), C = m.n_embd, H = m.n_head, HS = C / H;
+    x.assign(static_cast<size_t>(T) * C, 0.f);
+    int off = static_cast<int>(ids.size()) - T;
+    for (int t = 0; t < T; ++t) {
+        int id = ids[off + t] % m.vocab_size;
+        for (int c = 0; c < C; ++c) x[static_cast<size_t>(t) * C + c] = m.wte.v[static_cast<size_t>(id) * C + c] + m.wpe.v[static_cast<size_t>(t) * C + c];
+    }
+    std::vector<float> norm(C), q(static_cast<size_t>(T)*C), k(static_cast<size_t>(T)*C), v(static_cast<size_t>(T)*C), att(static_cast<size_t>(T)*C), tmp(std::max(m.hidden, C));
+    for (const auto& l : m.layers) {
+        std::fill(att.begin(), att.end(), 0.f);
+        for (int t = 0; t < T; ++t) {
+            rmsnorm(&x[static_cast<size_t>(t)*C], l.ln1_g.v.data(), norm.data(), C);
+            linear(norm.data(), l.q_w.v.data(), &q[static_cast<size_t>(t)*C], C, C);
+            linear(norm.data(), l.k_w.v.data(), &k[static_cast<size_t>(t)*C], C, C);
+            linear(norm.data(), l.v_w.v.data(), &v[static_cast<size_t>(t)*C], C, C);
+        }
+        std::vector<float> scores(T);
+        for (int t = 0; t < T; ++t) for (int h = 0; h < H; ++h) {
+            float maxv = -1e30f, sum = 0.f;
+            for (int s = 0; s <= t; ++s) {
+                float dot = 0.f;
+                for (int d = 0; d < HS; ++d) dot += q[(static_cast<size_t>(t)*C) + h*HS+d] * k[(static_cast<size_t>(s)*C) + h*HS+d];
+                scores[s] = dot / std::sqrt(static_cast<float>(HS)); maxv = std::max(maxv, scores[s]);
+            }
+            for (int s = 0; s <= t; ++s) { scores[s] = std::exp(scores[s] - maxv); sum += scores[s]; }
+            for (int d = 0; d < HS; ++d) {
+                float val = 0.f; for (int s = 0; s <= t; ++s) val += (scores[s] / sum) * v[(static_cast<size_t>(s)*C) + h*HS+d];
+                att[(static_cast<size_t>(t)*C) + h*HS+d] = val;
+            }
+        }
+        for (int t = 0; t < T; ++t) { linear(&att[static_cast<size_t>(t)*C], l.proj_w.v.data(), tmp.data(), C, C); for (int c = 0; c < C; ++c) x[static_cast<size_t>(t)*C+c] += tmp[c]; }
+        for (int t = 0; t < T; ++t) {
+            rmsnorm(&x[static_cast<size_t>(t)*C], l.ln2_g.v.data(), norm.data(), C);
+            linear(norm.data(), l.fc_w.v.data(), tmp.data(), C, m.hidden);
+            for (int i = 0; i < m.hidden; ++i) tmp[i] = gelu(tmp[i] + l.fc_b.v[i]);
+            std::vector<float> out(C); linear(tmp.data(), l.mlp_w.v.data(), out.data(), m.hidden, C);
+            for (int c = 0; c < C; ++c) x[static_cast<size_t>(t)*C+c] += out[c];
+        }
+    }
+    rmsnorm(&x[static_cast<size_t>(T-1)*C], m.lnf_g.v.data(), norm.data(), C);
+    int best = 0; float bestv = -1e30f;
+    for (int tok = 0; tok < m.vocab_size; ++tok) {
+        float s = 0.f; const float* row = m.lm_head.v.data() + static_cast<size_t>(tok) * C;
+        for (int c = 0; c < C; ++c) s += row[c] * norm[c];
+        if (s > bestv) { bestv = s; best = tok; }
+    }
+    return best;
+}
+}
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_nanogpt_benchmark_MainActivity_runBenchmark(JNIEnv* env, jobject thiz, jint promptTokens, jint generateTokens, jint threads) {
+    try {
+        auto t0 = std::chrono::steady_clock::now();
+        Model model = load_model(env, thiz);
+        std::vector<int> ids(promptTokens);
+        for (int i = 0; i < promptTokens; ++i) ids[i] = (i * 1103515245u + 12345u) % model.vocab_size;
+        std::vector<float> scratch;
+        for (int i = 0; i < generateTokens; ++i) ids.push_back(forward_next(model, ids, scratch));
+        double sec = std::chrono::duration<double>(std::chrono::steady_clock::now() - t0).count();
+        double toks = generateTokens / sec;
+        std::ostringstream os;
+        os << "model=" << model.n_layer << "L/" << model.n_head << "H/" << model.n_embd << "C vocab=" << model.vocab_size
+           << "\ngenerated=" << generateTokens << " threads_hint=" << threads
+           << "\ntime=" << sec << "s tokens_per_second=" << toks << "\nlast_token=" << ids.back();
+        return env->NewStringUTF(os.str().c_str());
+    } catch (const std::exception& e) {
+        std::string msg = std::string("Benchmark failed: ") + e.what();
+        return env->NewStringUTF(msg.c_str());
+    }
+}

--- a/android_benchmark/app/src/main/java/com/nanogpt/benchmark/MainActivity.java
+++ b/android_benchmark/app/src/main/java/com/nanogpt/benchmark/MainActivity.java
@@ -1,0 +1,59 @@
+package com.nanogpt.benchmark;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.TextView;
+import java.util.Locale;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class MainActivity extends Activity {
+    static { System.loadLibrary("nanogpt_benchmark"); }
+
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private TextView output;
+
+    private native String runBenchmark(int promptTokens, int generateTokens, int threads);
+
+    @Override public void onCreate(Bundle state) {
+        super.onCreate(state);
+        output = new TextView(this);
+        output.setTextSize(14f);
+        output.setPadding(24, 24, 24, 24);
+        output.setText("NanoGPT Android Benchmark\n\n" +
+                "Convert a checkpoint to app/src/main/assets/nanogpt.bin, build, install, then tap Run.\n" +
+                "This JNI path executes a simple fp32 CPU forward pass for repeatable hardware comparisons.\n");
+
+        Button run = new Button(this);
+        run.setText("Run 32-token benchmark");
+        run.setOnClickListener(v -> startBenchmark());
+
+        LinearLayout root = new LinearLayout(this);
+        root.setOrientation(LinearLayout.VERTICAL);
+        root.addView(run, new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT));
+        ScrollView scroller = new ScrollView(this);
+        scroller.addView(output);
+        root.addView(scroller, new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT, 0, 1f));
+        setContentView(root);
+    }
+
+    private void startBenchmark() {
+        output.append("\nRunning...\n");
+        executor.submit(() -> {
+            long start = System.nanoTime();
+            String result = runBenchmark(16, 32, Runtime.getRuntime().availableProcessors());
+            double wall = (System.nanoTime() - start) / 1_000_000_000.0;
+            runOnUiThread(() -> output.append(String.format(Locale.US, "%s\nWall time: %.3fs\n", result, wall)));
+        });
+    }
+
+    @Override protected void onDestroy() {
+        executor.shutdownNow();
+        super.onDestroy();
+    }
+}

--- a/android_benchmark/app/src/main/res/values/styles.xml
+++ b/android_benchmark/app/src/main/res/values/styles.xml
@@ -1,0 +1,7 @@
+<resources>
+    <style name="AppTheme" parent="android:style/Theme.Material.Light.NoActionBar">
+        <item name="android:fontFamily">monospace</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:colorAccent">#455A64</item>
+    </style>
+</resources>

--- a/android_benchmark/build.gradle
+++ b/android_benchmark/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'com.android.application' version '8.7.3' apply false
+}

--- a/android_benchmark/scripts/convert_ckpt_to_nanogpt_bin.py
+++ b/android_benchmark/scripts/convert_ckpt_to_nanogpt_bin.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Convert a compatible nanoGPT ckpt.pt to the tiny Android benchmark format.
+
+The JNI benchmark intentionally supports the repo's default GPT path only:
+RMSNorm, absolute positional embeddings, causal attention, GELU MLP, no bias in
+attention projections, and an optional bias on the MLP up projection. The script
+fails fast if a checkpoint uses unsupported architectural variations so benchmark
+numbers are not silently wrong.
+"""
+from __future__ import annotations
+
+import argparse
+import struct
+from pathlib import Path
+
+from typing import Any
+
+
+MAGIC = 0x4E475054  # NGPT
+VERSION = 1
+
+
+def require(args: dict, key: str, expected):
+    actual = args.get(key, expected)
+    if actual != expected:
+        raise SystemExit(f"Unsupported checkpoint option {key}={actual!r}; expected {expected!r}.")
+
+
+def tensor(sd: dict, name: str) -> Any:
+    if name not in sd:
+        raise SystemExit(f"Missing tensor {name!r}; this checkpoint is not supported by the Android benchmark exporter.")
+    return sd[name].detach().cpu().float().contiguous()
+
+
+def write_tensor(f, t: Any) -> None:
+    flat = t.detach().cpu().float().reshape(-1).contiguous()
+    f.write(struct.pack("<i", flat.numel()))
+    f.write(flat.numpy().astype("<f4", copy=False).tobytes())
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("ckpt", type=Path, help="Path to a repo training output checkpoint, e.g. out/run/ckpt.pt")
+    p.add_argument("--out", type=Path, default=Path("android_benchmark/app/src/main/assets/nanogpt.bin"))
+    p.add_argument("--allow-untied-head", action="store_true", help="Use lm_head.weight when it differs from transformer.wte.weight.")
+    args = p.parse_args()
+
+    import torch
+
+    ckpt = torch.load(args.ckpt, map_location="cpu", weights_only=False)
+    sd = ckpt.get("model", ckpt)
+    sd = {k.removeprefix("_orig_mod."): v for k, v in sd.items()}
+    model_args = dict(ckpt.get("model_args", {}))
+
+    for key, expected in {
+        "attention_variant": "causal",
+        "mlp_variant": "mlp",
+        "norm_variant_attn": "rmsnorm",
+        "norm_variant_output": "rmsnorm",
+        "use_abs_pos_embeddings": True,
+        "use_rotary_embeddings": False,
+        "bias": False,
+        "n_embd_wte": None,
+        "multicontext": False,
+        "use_moe": False,
+        "gate": False,
+        "use_parallel_mlp": False,
+        "use_edgellm_asic": False,
+    }.items():
+        require(model_args, key, expected)
+
+    n_layer = int(model_args["n_layer"])
+    n_head = int(model_args["n_head"])
+    n_embd = int(model_args["n_embd"])
+    block_size = int(model_args["block_size"])
+    vocab_size = int(model_args["vocab_size"])
+    hidden = int(model_args.get("mlp_size") or model_args.get("mlp_expansion_factor", 4) * n_embd)
+
+    wte = tensor(sd, "transformer.wte.weight")
+    lm_head = sd.get("lm_head.weight", wte).detach().cpu().float().contiguous()
+    if not torch.equal(lm_head, wte) and not args.allow_untied_head:
+        raise SystemExit("lm_head.weight differs from transformer.wte.weight; pass --allow-untied-head if intentional.")
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("wb") as f:
+        f.write(struct.pack("<8I", MAGIC, VERSION, block_size, vocab_size, n_layer, n_head, n_embd, hidden))
+        write_tensor(f, wte)
+        write_tensor(f, tensor(sd, "transformer.wpe.embedding.weight"))
+        for i in range(n_layer):
+            prefix = f"transformer.h.{i}"
+            write_tensor(f, tensor(sd, f"{prefix}.pre_ln_attn.gain"))
+            write_tensor(f, tensor(sd, f"{prefix}.pre_ln_mlp.gain"))
+            write_tensor(f, tensor(sd, f"{prefix}.attn.c_attn_q.weight"))
+            write_tensor(f, tensor(sd, f"{prefix}.attn.c_attn_k.weight"))
+            write_tensor(f, tensor(sd, f"{prefix}.attn.c_attn_v.weight"))
+            write_tensor(f, tensor(sd, f"{prefix}.attn.c_proj.weight"))
+            write_tensor(f, tensor(sd, f"{prefix}.mlp.c_fc.weight"))
+            fc_bias = sd.get(f"{prefix}.mlp.c_fc.bias")
+            write_tensor(f, torch.zeros(hidden) if fc_bias is None else fc_bias)
+            write_tensor(f, tensor(sd, f"{prefix}.mlp.c_proj.weight"))
+        write_tensor(f, tensor(sd, "transformer.ln_f.gain"))
+        write_tensor(f, lm_head)
+
+    print(f"Wrote {args.out} ({args.out.stat().st_size / (1024 * 1024):.2f} MiB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/android_benchmark/settings.gradle
+++ b/android_benchmark/settings.gradle
@@ -1,0 +1,10 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement { repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS); repositories { google(); mavenCentral() } }
+rootProject.name = 'NanoGPTAndroidBenchmark'
+include ':app'


### PR DESCRIPTION
### Motivation
- Provide a tiny, auditable Android app and native runtime for repeatable on-device fp32 CPU benchmarking of repository nanoGPT checkpoints while keeping large model artifacts out of source control.

### Description
- Add a minimal Android Gradle project under `android_benchmark/` including `MainActivity.java`, Gradle/CMake files, and UI to trigger a 32-token benchmark that calls a JNI native implementation.
- Add a compact JNI C++ runtime `nanogpt_jni.cpp` that loads a repository-specific `nanogpt.bin` asset, performs an fp32 greedy decode loop, and reports tokens/second and model dimensions.
- Add `scripts/convert_ckpt_to_nanogpt_bin.py` which validates compatible `ckpt.pt` files, extracts required tensors, and writes the packed `nanogpt.bin` used by the JNI runtime.
- Add `README.md` and `.gitignore` documenting conversion, Android CLI/Gradle build/run instructions, and guidelines for benchmark hygiene, while intentionally ignoring generated model and APK artifacts.

### Testing
- Successfully syntax-checked the converter with `python -m py_compile android_benchmark/scripts/convert_ckpt_to_nanogpt_bin.py` and confirmed the CLI help with `python android_benchmark/scripts/convert_ckpt_to_nanogpt_bin.py --help`.
- Ran repository checks (`git diff --cached --check`) with no issues reported.
- Attempted to run Gradle tasks (`gradle :app:tasks --all`), but the build configuration step failed due to no Android SDK/`ANDROID_HOME` in this environment; building the APK requires a machine/CI with the Android SDK configured (instructions included in the README).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ba029eaec8326afa7f0a6c84f678f)