### PR TITLE
feat(hp-search): distribute candidate trials

### DIFF
--- a/hp_searches/README.md
+++ b/hp_searches/README.md
@@ -206,3 +206,43 @@ With the resulting data, we can try to find the curve of parametesr per mlp
 size, nad vest val loss vs different characteristics, and ratios of differnet
 ones via curve fitting. This could yield insights on balancing parameters
 especially towards small language models.
+
+## Distributed candidate evaluation
+
+`hyperparam_search.py` can now keep the greedy controller local while sending the
+expensive candidate seed trials for each outer iteration to multiple machines.
+This reuses the same `RemoteTrainer` machinery used by the existing NSGA/grid
+search code: the controller writes a YAML shard of trial configs, uploads one
+shard per host, launches a remote runner under `distributed_trials/`, polls the
+remote PIDs, fetches `hp_results.yaml`, and then applies the normal greedy
+selection logic locally.
+
+Example:
+
+```bash
+python3 hyperparam_search.py \
+  --orig_settings ./hp_searches/shakespeare_char.yaml \
+  --param_names n_layer n_head n_embd mlp_size \
+  --increments 1 1 32 32 \
+  --iterations 2 \
+  --random_iterations 3 \
+  --num_iterations 20 \
+  --results_file results.yaml \
+  --distributed_hosts 10.0.0.11 10.0.0.12 10.0.0.13 \
+  --distributed_user ubuntu \
+  --distributed_remote_work_dir /home/ubuntu/Evo_GPT \
+  --distributed_conda_env reallmforge \
+  --distributed_run_dir_name hp_search_shakespeare
+```
+
+Notes:
+
+- The baseline measurement still runs on the controller. Distribution starts
+  after candidates have been generated for an outer greedy step.
+- Every candidate/seed pair is a separate trial record, so `--random_iterations`
+  also parallelizes across machines.
+- Remote hosts must already have the repository checkout and matching data paths.
+  Use the same remote work directory convention as NSGA search, or override it
+  with `--distributed_remote_work_dir`.
+- Each remote trial gets an isolated `out_dir` under the remote shard directory
+  to avoid collisions when many candidates run on the same host.

--- a/hp_searches/distributed_shakespeare_char.sh
+++ b/hp_searches/distributed_shakespeare_char.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# hp_searches/distributed_shakespeare_char.sh
+# Example distributed hp_search invocation. Set HP_SEARCH_HOSTS to a whitespace
+# separated host list, e.g.:
+#   HP_SEARCH_HOSTS="10.0.0.11 10.0.0.12" bash hp_searches/distributed_shakespeare_char.sh
+
+read -r -a HP_SEARCH_HOST_ARRAY <<< "${HP_SEARCH_HOSTS:-}"
+
+python3 hyperparam_search.py \
+  --orig_settings ./hp_searches/shakespeare_char.yaml \
+  --param_names n_layer n_head n_embd mlp_size \
+  --increments 1 1 32 32 \
+  --iterations 1 \
+  --random_iterations 2 \
+  --num_iterations 10 \
+  --efficiency_target params \
+  --results_file distributed_results.yaml \
+  --distributed_hosts "${HP_SEARCH_HOST_ARRAY[@]}" \
+  --distributed_user "${HP_SEARCH_USER:-$USER}" \
+  --distributed_remote_work_dir "${HP_SEARCH_REMOTE_WORK_DIR:-/home/${HP_SEARCH_USER:-$USER}/Evo_GPT}" \
+  --distributed_conda_env "${HP_SEARCH_CONDA_ENV:-reallmforge}" \
+  --distributed_run_dir_name "${HP_SEARCH_RUN_DIR_NAME:-hp_search_shakespeare}"

--- a/hyperparam_search.py
+++ b/hyperparam_search.py
@@ -26,8 +26,10 @@ import sys
 from contextlib import contextmanager
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 import random
+import tempfile
+import uuid
 
 import torch
 import yaml
@@ -199,6 +201,60 @@ def save_log(path: Path, log: Dict[str, Any]) -> None:
     tmp.replace(path)
 
 
+def _remote_trial_seed_results(
+    trial_records: List[Dict[str, Any]],
+    hosts: List[str],
+    user: str,
+    key_filename: Optional[str],
+    remote_work_dir: str,
+    conda_env: str,
+    run_dir_name: str,
+    poll_interval: float,
+    timeout: Optional[float],
+) -> List[Dict[str, Any]]:
+    """Run seed trials on remote machines using the NSGA/grid remote framework."""
+    if not trial_records:
+        return []
+
+    # Import lazily so local hp_search usage does not require Fabric.
+    nsga_dir = Path(__file__).parent / "optimization_and_search" / "nsga_search"
+    if str(nsga_dir) not in sys.path:
+        sys.path.insert(0, str(nsga_dir))
+    from remote_trainer import RemoteTrainer  # type: ignore
+
+    run_token = f"hp_search_{uuid.uuid4().hex[:8]}"
+    with tempfile.TemporaryDirectory(prefix="hp_trials_") as td:
+        trials_path = Path(td) / f"{run_token}.yaml"
+        trials_path.write_text(yaml.safe_dump(trial_records, sort_keys=False, width=4096))
+
+        trainer = RemoteTrainer(hosts=hosts, user=user, key_filename=key_filename)
+        if not trainer.submit_trial_shards(
+            path_to_yaml=str(trials_path),
+            remote_work_dir=remote_work_dir,
+            dir_name=run_dir_name,
+            runner_script="optimization_and_search/run_hp_trials.py",
+            runner_yaml_arg="--trials_yaml",
+            runner_results_arg="--results_yaml",
+            result_filename="hp_results.yaml",
+            conda_env=conda_env,
+        ):
+            raise RuntimeError("failed to submit remote hp_search trial shards")
+        if not trainer.wait_for_all(
+            poll_interval=poll_interval, timeout=timeout, verbose=True
+        ):
+            raise TimeoutError("timed out waiting for remote hp_search trial shards")
+
+        fetched_dir = Path(td) / "fetched"
+        fetched = trainer.fetch_job_file("hp_results.yaml", str(fetched_dir))
+        results: List[Dict[str, Any]] = []
+        for result_file in fetched:
+            loaded = yaml.safe_load(result_file.read_text()) or []
+            if not isinstance(loaded, list):
+                raise RuntimeError(f"Unexpected remote result payload in {result_file}")
+            results.extend(loaded)
+    return results
+
+
 # ───────────────────────── search controller ─────────────────────────
 def main():
     ap = argparse.ArgumentParser(description="Greedy hyper-param search wrapper")
@@ -277,6 +333,56 @@ def main():
         "--randomize_seed",
         action="store_true",
         help="Whether to random seed for each separate train.py run, and prevent overfitting via hillclimbing on one section of the target dataset",
+    )
+    ap.add_argument(
+        "--distributed_hosts",
+        nargs="*",
+        default=[],
+        help=(
+            "Optional hostnames/IPs for distributed candidate evaluation. When set, "
+            "all candidate seed trials in each greedy iteration are sharded across "
+            "these machines using optimization_and_search/nsga_search/remote_trainer.py."
+        ),
+    )
+    ap.add_argument(
+        "--distributed_user",
+        default=os.environ.get("USER", ""),
+        help="SSH user for --distributed_hosts (defaults to $USER).",
+    )
+    ap.add_argument(
+        "--distributed_key_filename",
+        default=None,
+        help="Optional SSH private key file passed to Fabric for distributed hosts.",
+    )
+    ap.add_argument(
+        "--distributed_remote_work_dir",
+        default=None,
+        help=(
+            "Repository checkout path on each remote host. Defaults to "
+            "/home/<distributed_user>/Evo_GPT to match the existing NSGA search scripts."
+        ),
+    )
+    ap.add_argument(
+        "--distributed_conda_env",
+        default="reallmforge",
+        help="Conda environment to use on distributed hosts.",
+    )
+    ap.add_argument(
+        "--distributed_run_dir_name",
+        default="hp_search",
+        help="Remote run namespace under distributed_trials/.",
+    )
+    ap.add_argument(
+        "--distributed_poll_interval",
+        type=float,
+        default=120.0,
+        help="Seconds between distributed job polls.",
+    )
+    ap.add_argument(
+        "--distributed_timeout",
+        type=float,
+        default=None,
+        help="Optional timeout in seconds for one distributed candidate batch.",
     )
 
     args = ap.parse_args()
@@ -407,6 +513,7 @@ def main():
         print(f"========== Iteration {cur_iter} ==========")
         candidates: List[Dict[str, Any]] = []
         best_choice: Tuple[float, Dict[str, Any]] | None = None
+        pending_evals: List[Dict[str, Any]] = []
 
         for pname in args.param_names:
             if pname not in baseline_cfg:
@@ -422,7 +529,17 @@ def main():
             def _evaluate(
                 cfg_template: Dict[str, Any], label_for_log: str, value_for_log: Any
             ) -> None:
-                nonlocal best_choice, candidates
+                nonlocal best_choice, candidates, pending_evals
+
+                if args.distributed_hosts:
+                    pending_evals.append(
+                        {
+                            "cfg_template": deepcopy(cfg_template),
+                            "label_for_log": label_for_log,
+                            "value_for_log": value_for_log,
+                        }
+                    )
+                    return
 
                 seed0 = int(cfg_template.get("seed", 1337))
                 if args.randomize_seed:
@@ -642,6 +759,187 @@ def main():
                 continue
 
             print(f"[SKIP] '{pname}' is neither numeric nor list-numeric – ignored")
+
+        if args.distributed_hosts and pending_evals:
+            trial_records: List[Dict[str, Any]] = []
+            eval_meta: Dict[int, Dict[str, Any]] = {}
+            for eval_idx, pending in enumerate(pending_evals):
+                cfg_template = pending["cfg_template"]
+                seed0 = int(cfg_template.get("seed", 1337))
+                if args.randomize_seed:
+                    seed0 = random.randint(0, 2**31 - 1)
+                eval_meta[eval_idx] = {
+                    "label_for_log": pending["label_for_log"],
+                    "value_for_log": pending["value_for_log"],
+                }
+                for r in range(args.random_iterations):
+                    cfg_run = deepcopy(cfg_template)
+                    cfg_run["seed"] = seed0 + r
+                    trial_records.append(
+                        {
+                            "trial_id": f"iter{cur_iter}_cand{eval_idx}_seed{r}",
+                            "candidate_index": eval_idx,
+                            "seed_index": r,
+                            "seed": cfg_run["seed"],
+                            "param": pending["label_for_log"],
+                            "value": pending["value_for_log"],
+                            "config": cfg_run,
+                        }
+                    )
+
+            remote_work_dir = args.distributed_remote_work_dir or f"/home/{args.distributed_user}/Evo_GPT"
+            print(
+                f"[DISTRIBUTED] Dispatching {len(trial_records)} seed trials "
+                f"for {len(pending_evals)} candidates across {len(args.distributed_hosts)} hosts."
+            )
+            remote_results = _remote_trial_seed_results(
+                trial_records=trial_records,
+                hosts=args.distributed_hosts,
+                user=args.distributed_user,
+                key_filename=args.distributed_key_filename,
+                remote_work_dir=remote_work_dir,
+                conda_env=args.distributed_conda_env,
+                run_dir_name=args.distributed_run_dir_name,
+                poll_interval=args.distributed_poll_interval,
+                timeout=args.distributed_timeout,
+            )
+
+            by_candidate: Dict[int, List[Dict[str, Any]]] = {}
+            for result in remote_results:
+                if result.get("status") != "completed":
+                    print(
+                        f"   ⚠ remote trial {result.get('trial_id')} failed: "
+                        f"{result.get('error') or result.get('stderr_tail', '')}"
+                    )
+                    continue
+                by_candidate.setdefault(int(result["candidate_index"]), []).append(result)
+
+            for eval_idx, meta in eval_meta.items():
+                seed_results = sorted(
+                    by_candidate.get(eval_idx, []), key=lambda x: int(x.get("seed_index", 0))
+                )
+                if len(seed_results) != args.random_iterations:
+                    print(
+                        f"   ⚠ {meta['label_for_log']}={meta['value_for_log']} skipped: "
+                        f"only {len(seed_results)}/{args.random_iterations} remote seed trials completed"
+                    )
+                    continue
+
+                seed_runs: List[Dict[str, Any]] = []
+                scores: List[float] = []
+                for result in seed_results:
+                    loss = float(result["loss"])
+                    score = 1.0 / math.exp(loss)
+                    seed_runs.append(
+                        {
+                            "seed": result["seed"],
+                            "loss": loss,
+                            "score": score,
+                            "best_iter": int(result["best_iter"]),
+                            "peak_torch_allocated_mb": float(result["peak_torch_allocated_mb"]),
+                            "peak_torch_reserved_mb": float(result["peak_torch_reserved_mb"]),
+                            "peak_process_gpu_mb": float(result["peak_process_gpu_mb"]),
+                            "iter_latency_ms": float(result["iter_latency_ms"]),
+                            "rankme": float(result["rankme"]),
+                            "areq": float(result["areq"]),
+                        }
+                    )
+                    scores.append(score)
+
+                avg_score = sum(scores) / len(scores)
+                avg_torch_alloc = sum(s["peak_torch_allocated_mb"] for s in seed_runs) / len(seed_runs)
+                avg_torch_reserved = sum(s["peak_torch_reserved_mb"] for s in seed_runs) / len(seed_runs)
+                avg_process_gpu = sum(s["peak_process_gpu_mb"] for s in seed_runs) / len(seed_runs)
+                avg_iter = sum(s["iter_latency_ms"] for s in seed_runs) / len(seed_runs)
+                avg_rankme = _nanmean([s["rankme"] for s in seed_runs])
+                avg_areq = _nanmean([s["areq"] for s in seed_runs])
+                avg_loss = -math.log(avg_score)
+                nparam = float(seed_results[-1]["num_params"])
+
+                d_score = avg_score - base_score
+                d_rankme = avg_rankme - base_rankme if not math.isnan(avg_rankme) and not math.isnan(base_rankme) else float("nan")
+                d_areq = avg_areq - base_areq if not math.isnan(avg_areq) and not math.isnan(base_areq) else float("nan")
+                d_param = nparam - base_params
+                d_torch_alloc = avg_torch_alloc - base_torch_alloc
+                d_torch_reserved = avg_torch_reserved - base_torch_reserved
+                d_process_gpu = avg_process_gpu - base_process_gpu
+                d_iter = avg_iter - base_iter_ms
+
+                if args.efficiency_target == "params":
+                    d_cost = d_param
+                elif args.efficiency_target in ("vram", "torch_allocated"):
+                    d_cost = d_torch_alloc
+                elif args.efficiency_target == "torch_reserved":
+                    d_cost = d_torch_reserved
+                elif args.efficiency_target == "process_gpu":
+                    d_cost = d_process_gpu
+                elif args.efficiency_target == "iter":
+                    d_cost = d_iter
+                else:
+                    raise ValueError("Unknown efficiency target")
+
+                if args.optimize_target == "score":
+                    objective_value = avg_score
+                    baseline_objective = base_score
+                elif args.optimize_target == "rankme":
+                    objective_value = avg_rankme
+                    baseline_objective = base_rankme
+                elif args.optimize_target == "areq":
+                    objective_value = avg_areq
+                    baseline_objective = base_areq
+                else:
+                    raise ValueError("Unknown optimize target")
+
+                objective_delta = objective_value - baseline_objective
+                direction = 1.0 if args.optimize_mode == "max" else -1.0
+                objective_improvement = direction * objective_delta
+                if math.isnan(objective_improvement):
+                    continue
+
+                eff = (objective_improvement / d_cost) if d_cost != 0 else (math.inf if objective_improvement > 0 else 0.0)
+                cand = {
+                    "param": meta["label_for_log"],
+                    "value": meta["value_for_log"],
+                    "avg_loss": avg_loss,
+                    "avg_score": avg_score,
+                    "avg_rankme": avg_rankme,
+                    "avg_areq": avg_areq,
+                    "best_val_loss": avg_loss,
+                    "best_iter": max(s["best_iter"] for s in seed_runs),
+                    "num_params": nparam,
+                    "peak_torch_allocated_mb": avg_torch_alloc,
+                    "peak_torch_reserved_mb": avg_torch_reserved,
+                    "peak_process_gpu_mb": avg_process_gpu,
+                    "iter_latency_avg": avg_iter,
+                    "delta_score": d_score,
+                    "delta_rankme": d_rankme,
+                    "delta_areq": d_areq,
+                    "delta_params": d_param,
+                    "delta_torch_allocated_mb": d_torch_alloc,
+                    "delta_torch_reserved_mb": d_torch_reserved,
+                    "delta_process_gpu_mb": d_process_gpu,
+                    "delta_iter_latency": d_iter,
+                    "efficiency": eff,
+                    "target_metric": args.optimize_target,
+                    "target_mode": args.optimize_mode,
+                    "target_value": objective_value,
+                    "target_delta": objective_delta,
+                    "target_improvement": objective_improvement,
+                    "seeds": seed_runs,
+                    "distributed": True,
+                }
+                candidates.append(cand)
+                if eff > 0:
+                    if best_choice is None:
+                        best_choice = (eff, cand)
+                    else:
+                        old_eff, old_cand = best_choice
+                        if (eff > old_eff) or (
+                            math.isinf(eff)
+                            and eff == old_eff
+                            and cand["target_improvement"] > old_cand["target_improvement"]
+                        ):
+                            best_choice = (eff, cand)
 
         if best_choice is None:
             if args.max_iters_increase is not None and cur_iter < args.num_iterations:

--- a/optimization_and_search/nsga_search/remote_trainer.py
+++ b/optimization_and_search/nsga_search/remote_trainer.py
@@ -1,4 +1,4 @@
-import json, logging, threading, time, uuid, tempfile, math
+import json, logging, shlex, threading, time, uuid, tempfile, math
 import yaml
 import os
 from dataclasses import dataclass, field
@@ -638,3 +638,158 @@ fi
         except Exception as re:
             logging.error(f"\033[31mFailed to reorder gen CSV {gen_csv_path}: {re}\033[0m")
         return str(gen_csv_path)
+
+# Generic helpers used by search controllers that already have per-trial YAML
+# payloads. These are attached to RemoteTrainer to reuse the connection,
+# heartbeat, polling, and cleanup machinery built for NSGA/grid search.
+def _remote_trainer_submit_trial_shards(
+    self,
+    path_to_yaml: str,
+    remote_work_dir: str,
+    dir_name: str,
+    runner_script: str,
+    runner_yaml_arg: str,
+    runner_results_arg: str,
+    result_filename: str = "results.yaml",
+    conda_env: str = "reallmforge",
+) -> bool:
+    yaml_path = Path(path_to_yaml)
+    with yaml_path.open("r") as f:
+        data = yaml.safe_load(f) or []
+    if not isinstance(data, list):
+        raise ValueError(f"Expected a list of trial records in {yaml_path}, got {type(data)}")
+
+    n_hosts = max(1, self.num_hosts)
+    splits: List[List[dict]] = [[] for _ in range(n_hosts)]
+    for idx, cfg in enumerate(data):
+        splits[idx % n_hosts].append(cfg)
+
+    tmp_dir = Path(tempfile.mkdtemp(prefix="trial_shards_"))
+    local_slice_files: List[Optional[Path]] = [None] * n_hosts
+    base = yaml_path.stem
+    for i, split in enumerate(splits):
+        if not split:
+            continue
+        slice_path = tmp_dir / f"{base}.host{i}.yaml"
+        with slice_path.open("w") as f:
+            yaml.safe_dump(split, f, sort_keys=False, width=4096)
+        local_slice_files[i] = slice_path
+        logging.info(f"Prepared trial shard for host_{i}: {slice_path} ({len(split)} trials)")
+
+    timestamp = time.strftime("%Y%m%d_%H%M%S", time.localtime())
+    short_uuid = uuid.uuid4().hex[:4]
+    run_id = f"{timestamp}_{short_uuid}"
+    new_jobs: List[RemoteJob] = []
+    overall_ok = True
+
+    for i, host in enumerate(self.hosts):
+        slice_file = local_slice_files[i]
+        if slice_file is None:
+            logging.warning(f"\033[33mNo trials assigned to host_{i} ({host}); skipping upload.\033[0m")
+            continue
+
+        conn = Connection(host=host, user=self.user, connect_kwargs={"key_filename": self.key_filename} if self.key_filename else {})
+        try:
+            conn.open()
+            remote_run_dir = f"{remote_work_dir}/distributed_trials/{dir_name}/{base}-{run_id}-host{i}"
+            conn.run(f"mkdir -p {shlex.quote(remote_run_dir)}", hide=True)
+            remote_yaml_path = f"{remote_run_dir}/{slice_file.name}"
+            remote_results_path = f"{remote_run_dir}/{result_filename}"
+            remote_log_path = f"{remote_run_dir}/run.log"
+            remote_pid_path = f"{remote_run_dir}/run.pid"
+            lease_path = f"{remote_run_dir}/lease"
+            conn.put(str(slice_file), remote=remote_yaml_path)
+
+            runner_cmd = (
+                f"python -u {shlex.quote(runner_script)} "
+                f"{shlex.quote(runner_yaml_arg)} {shlex.quote(remote_yaml_path)} "
+                f"{shlex.quote(runner_results_arg)} {shlex.quote(remote_results_path)}"
+            )
+            cmd = (
+                f"cd {shlex.quote(remote_work_dir)} && "
+                f"setsid bash -lc '\n"
+                f"{{\n"
+                f"echo \"[launcher] $(date) starting on $(hostname)\";\n"
+                f"CONDA_BIN=$(command -v conda || true);\n"
+                f"if [ -n \"$CONDA_BIN\" ] && conda run -n {shlex.quote(conda_env)} python -V >/dev/null 2>&1; then\n"
+                f"  conda run -n {shlex.quote(conda_env)} {runner_cmd}; ec=$?;\n"
+                f"else\n"
+                f"  if [ -n \"$CONDA_BIN\" ]; then eval \"$(conda shell.bash hook)\" >/dev/null 2>&1 || true; fi;\n"
+                f"  if command -v conda >/dev/null 2>&1; then conda activate {shlex.quote(conda_env)} || true; fi;\n"
+                f"  {runner_cmd}; ec=$?;\n"
+                f"fi;\n"
+                f"echo $ec > {shlex.quote(remote_run_dir)}/exit_code\n"
+                f"}} >> {shlex.quote(remote_log_path)} 2>&1 < /dev/null &\n"
+                f"echo $! > {shlex.quote(remote_pid_path)}\n"
+                f"' </dev/null >/dev/null 2>&1 &"
+            )
+            conn.run(cmd, hide=True)
+            pid_out = conn.run(f"cat {shlex.quote(remote_pid_path)}", hide=True, warn=True)
+            pid: Optional[int] = None
+            if pid_out.ok and pid_out.stdout.strip().isdigit():
+                pid = int(pid_out.stdout.strip())
+            job = RemoteJob(
+                id=f"{base}-{run_id}-host{i}",
+                host=host,
+                remote_dir=remote_run_dir,
+                yaml_path=remote_yaml_path,
+                log_path=remote_log_path,
+                pid_path=remote_pid_path,
+                pid=pid,
+                status=JobStatus.RUNNING if pid else JobStatus.PENDING,
+                lease_path=lease_path,
+            )
+            self.jobs.append(job)
+            new_jobs.append(job)
+            logging.info(f"\033[32mLaunched trial shard on host_{i} ({host}), PID={pid}, log: {remote_log_path}\033[0m")
+        except Exception as e:
+            logging.error(f"\033[31mFailed to launch trial shard on host_{i} ({host}): {e}\033[0m")
+            overall_ok = False
+            for started in new_jobs:
+                if started.pid is not None:
+                    try:
+                        with Connection(host=started.host, user=self.user, connect_kwargs={"key_filename": self.key_filename} if self.key_filename else {}) as c2:
+                            c2.run(f"kill -9 {started.pid}", hide=True, warn=True)
+                    except Exception:
+                        pass
+                started.status = JobStatus.CANCELLED
+                started.finished_at = time.time()
+            break
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    if overall_ok:
+        for j in new_jobs:
+            self._start_heartbeat(j)
+
+    try:
+        for p in local_slice_files:
+            if p and p.exists():
+                p.unlink(missing_ok=True)
+        tmp_dir.rmdir()
+    except Exception:
+        pass
+    return overall_ok
+
+
+def _remote_trainer_fetch_job_file(self, remote_filename: str, local_dir: str) -> List[Path]:
+    out_dir = Path(local_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    fetched: List[Path] = []
+    for job in self.jobs:
+        local_path = out_dir / f"{job.id}.{Path(remote_filename).name}"
+        remote_path = f"{job.remote_dir}/{remote_filename}"
+        try:
+            with Connection(host=job.host, user=self.user, connect_kwargs={"key_filename": self.key_filename} if self.key_filename else {}) as conn:
+                conn.get(remote_path, local=str(local_path))
+            fetched.append(local_path)
+        except Exception as exc:
+            logging.error(f"\033[31mFailed to fetch {remote_path} from {job.host}: {exc}\033[0m")
+    return fetched
+
+
+RemoteTrainer.submit_trial_shards = _remote_trainer_submit_trial_shards
+RemoteTrainer.fetch_job_file = _remote_trainer_fetch_job_file

--- a/optimization_and_search/run_hp_trials.py
+++ b/optimization_and_search/run_hp_trials.py
@@ -1,0 +1,153 @@
+"""Run hyper-parameter search trial shards.
+
+This helper is intentionally small and generic: distributed search controllers write a
+YAML list of trial records, then remote workers execute this script to run each
+trial sequentially on the assigned machine and persist machine-readable results.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import traceback
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+TrialMetrics = Tuple[float, float, int, float, float, float, float, float, float]
+
+
+def dict_to_cli(config: Dict[str, Any]) -> List[str]:
+    cli: List[str] = []
+    for key, value in config.items():
+        if str(key).startswith("_"):
+            continue
+        if isinstance(value, bool):
+            if value:
+                cli.append(f"--{key}")
+        elif isinstance(value, list):
+            cli.append(f"--{key}")
+            cli.extend(map(str, value))
+        else:
+            cli.extend([f"--{key}", str(value)])
+    return cli
+
+
+def _parse_best_metrics_file(metrics_path: Path) -> TrialMetrics:
+    line = [x.strip() for x in metrics_path.read_text().strip().split(",")]
+    if len(line) < 21:
+        raise ValueError(
+            f"Unexpected metric layout in {metrics_path}: expected >=21 columns, got {len(line)}"
+        )
+    loss = float(line[0])
+    best_iter = int(line[1])
+    nparam = float(line[3])
+    torch_alloc_mb = float(line[6])
+    torch_resv_mb = float(line[7])
+    process_gpu_mb = float(line[8])
+    iter_latency_ms = float(line[9])
+    rankme_idx = 20 if len(line) > 21 else 19
+    areq_idx = rankme_idx + 1
+    rankme = float(line[rankme_idx])
+    areq = float(line[areq_idx])
+    return (
+        loss,
+        nparam,
+        best_iter,
+        torch_alloc_mb,
+        torch_resv_mb,
+        process_gpu_mb,
+        iter_latency_ms,
+        rankme,
+        areq,
+    )
+
+
+def _run_trial(config: Dict[str, Any], repo_root: Path) -> Dict[str, Any]:
+    script = repo_root / "train.py"
+    cmd = [sys.executable, str(script)] + dict_to_cli(config)
+    env = {k: v for k, v in os.environ.items() if k not in {"RANK", "WORLD_SIZE"}}
+    proc = subprocess.run(cmd, capture_output=True, text=True, env=env, cwd=repo_root)
+    result: Dict[str, Any] = {
+        "returncode": proc.returncode,
+        "stdout_tail": proc.stdout[-8000:],
+        "stderr_tail": proc.stderr[-8000:],
+    }
+    if proc.returncode != 0:
+        result["status"] = "failed"
+        return result
+
+    metrics_path = Path(config.get("out_dir", "out")) / "best_val_loss_and_iter.txt"
+    if not metrics_path.is_absolute():
+        metrics_path = repo_root / metrics_path
+    (
+        loss,
+        nparam,
+        best_iter,
+        torch_alloc_mb,
+        torch_resv_mb,
+        process_gpu_mb,
+        iter_latency_ms,
+        rankme,
+        areq,
+    ) = _parse_best_metrics_file(metrics_path)
+    result.update(
+        {
+            "status": "completed",
+            "loss": loss,
+            "num_params": nparam,
+            "best_iter": best_iter,
+            "peak_torch_allocated_mb": torch_alloc_mb,
+            "peak_torch_reserved_mb": torch_resv_mb,
+            "peak_process_gpu_mb": process_gpu_mb,
+            "iter_latency_ms": iter_latency_ms,
+            "rankme": rankme,
+            "areq": areq,
+        }
+    )
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a shard of hp_search trials")
+    parser.add_argument("--trials_yaml", required=True)
+    parser.add_argument("--results_yaml", required=True)
+    parser.add_argument("--repo_root", default=str(REPO_ROOT))
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    results_path = Path(args.results_yaml)
+    results_path.parent.mkdir(parents=True, exist_ok=True)
+    output_root = results_path.parent / "trial_outputs"
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    trials: List[Dict[str, Any]] = yaml.safe_load(Path(args.trials_yaml).read_text()) or []
+    results: List[Dict[str, Any]] = []
+    for trial in trials:
+        trial_id = str(trial["trial_id"])
+        cfg = dict(trial["config"])
+        cfg["out_dir"] = str(output_root / trial_id)
+        record = {k: v for k, v in trial.items() if k != "config"}
+        record["out_dir"] = cfg["out_dir"]
+        try:
+            record.update(_run_trial(cfg, repo_root))
+        except Exception as exc:  # keep workers alive for later trials in the shard
+            record.update(
+                {
+                    "status": "failed",
+                    "error": repr(exc),
+                    "traceback": traceback.format_exc(),
+                }
+            )
+        results.append(record)
+        results_path.write_text(yaml.safe_dump(results, sort_keys=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Enable scaling the greedy hyper-parameter search by dispatching expensive candidate/seed trials to multiple machines while keeping the greedy controller local. 
- Reuse the NSGA/grid `RemoteTrainer` framework so hp search can leverage existing upload/launch/poll/fetch machinery instead of reimplementing remote orchestration.

### Description
- Added distributed CLI options to `hyperparam_search.py` (`--distributed_*`) and queueing logic so candidate/seed trials are collected as trial records instead of run locally when `--distributed_hosts` is set. 
- Implemented `_remote_trial_seed_results` in `hyperparam_search.py` to shard trial records, call the existing `RemoteTrainer` helpers, wait for completion, and aggregate seed metrics back into the greedy selection path. 
- Extended `optimization_and_search/nsga_search/remote_trainer.py` with `submit_trial_shards` and `fetch_job_file` helpers that split trial YAMLs, upload per-host shards, launch remote runners, poll PIDs/exit codes, and fetch result files. 
- Added a lightweight remote runner `optimization_and_search/run_hp_trials.py` that remote hosts execute to run assigned trials sequentially (isolated `out_dir`s) and write machine-readable YAML results. 
- Documented the workflow and added an example script `hp_searches/distributed_shakespeare_char.sh` and README notes describing usage and assumptions about remote checkouts/conda environments.

### Testing
- Successfully syntax-checked the example runner script with `bash -n hp_searches/distributed_shakespeare_char.sh` (passed). 
- Byte-compiled the modified modules with `python3 -m py_compile hyperparam_search.py optimization_and_search/run_hp_trials.py optimization_and_search/nsga_search/remote_trainer.py` (passed). 
- Verified the new runner’s CLI with `python3 optimization_and_search/run_hp_trials.py --help` (passed). 
- Attempting `python3 hyperparam_search.py --help` on the local environment raised `ModuleNotFoundError: No module named 'torch'`, which is expected in environments without PyTorch and does not reflect the distributed logic correctness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ba0b715508326abb48dfc76863e36)