### PR TITLE
Emit --no-<flag> for false booleans in hyperparam search CLI

### DIFF
--- a/hp_searches/test_dict_to_cli_bool_flags.py
+++ b/hp_searches/test_dict_to_cli_bool_flags.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Lightweight checks for hyperparameter-search boolean CLI serialization."""
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+from typing import Dict, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from hyperparam_search import dict_to_cli
+
+
+def _boolean_optional_defaults() -> Dict[str, Optional[bool]]:
+    """Read train_args.py without importing torch-dependent training modules."""
+    tree = ast.parse((REPO_ROOT / "train_args.py").read_text())
+    defaults: Dict[str, Optional[bool]] = {}
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Attribute) or node.func.attr != "add_argument":
+            continue
+        if not node.args or not isinstance(node.args[0], ast.Constant):
+            continue
+        option = node.args[0].value
+        if not isinstance(option, str) or not option.startswith("--"):
+            continue
+
+        uses_boolean_optional_action = False
+        default: bool | None = None
+        for keyword in node.keywords:
+            if keyword.arg == "action" and isinstance(keyword.value, ast.Attribute):
+                uses_boolean_optional_action = keyword.value.attr == "BooleanOptionalAction"
+            elif keyword.arg == "default" and isinstance(keyword.value, ast.Constant):
+                if isinstance(keyword.value.value, bool) or keyword.value.value is None:
+                    default = keyword.value.value
+
+        if uses_boolean_optional_action:
+            defaults[option.removeprefix("--")] = default
+
+    return defaults
+
+
+def _parser_for(flags: Dict[str, Optional[bool]]) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    for flag, default in flags.items():
+        parser.add_argument(
+            f"--{flag}", default=default, action=argparse.BooleanOptionalAction
+        )
+    return parser
+
+
+def test_false_booleans_emit_no_flags() -> None:
+    default_true_flags = [
+        "lr_decay_match_max_iters",
+        "csv_log",
+        "tensorboard_log",
+        "tensorboard_graph",
+        "log_rankme",
+        "log_areq",
+        "print_model_info",
+    ]
+    cfg = {"compile": False, **{flag: False for flag in default_true_flags}}
+
+    cli = dict_to_cli(cfg)
+
+    expected = ["--no-compile"] + [f"--no-{flag}" for flag in default_true_flags]
+    assert cli == expected, cli
+
+    train_arg_defaults = _boolean_optional_defaults()
+    assert train_arg_defaults["compile"] is False
+    for flag in default_true_flags:
+        assert train_arg_defaults[flag] is True, flag
+
+    args = _parser_for({flag: train_arg_defaults[flag] for flag in cfg}).parse_args(cli)
+    assert args.compile is False
+    for flag in default_true_flags:
+        assert getattr(args, flag) is False, flag
+
+
+def test_true_booleans_emit_positive_flags() -> None:
+    cli = dict_to_cli({"compile": True, "csv_log": True})
+
+    assert cli == ["--compile", "--csv_log"], cli
+
+    train_arg_defaults = _boolean_optional_defaults()
+    args = _parser_for(
+        {"compile": train_arg_defaults["compile"], "csv_log": train_arg_defaults["csv_log"]}
+    ).parse_args(cli)
+    assert args.compile is True
+    assert args.csv_log is True
+
+
+if __name__ == "__main__":
+    test_false_booleans_emit_no_flags()
+    test_true_booleans_emit_positive_flags()
+    print("dict_to_cli boolean flag checks passed")

--- a/hyperparam_search.py
+++ b/hyperparam_search.py
@@ -29,7 +29,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple
 import random
 
-import torch
 import yaml
 
 
@@ -51,8 +50,7 @@ def dict_to_cli(d: Dict[str, Any]) -> List[str]:
             continue
 
         if isinstance(v, bool):
-            if v:
-                cli.append(f"--{k}")
+            cli.append(f"--{k}" if v else f"--no-{k}")
         elif isinstance(v, list):
             cli.append(f"--{k}")
             cli.extend(map(str, v))
@@ -72,6 +70,8 @@ def patched_argv(argv: List[str]):
 
 
 def _cleanup_cuda() -> None:
+    import torch
+
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
     gc.collect()


### PR DESCRIPTION
### Motivation
- Ensure boolean options from YAML/config are faithfully represented on the `train.py` CLI so `False` values explicitly disable `BooleanOptionalAction` flags instead of being omitted.

### Description
- Updated `dict_to_cli()` in `hyperparam_search.py` so `True` booleans emit `--<flag>` and `False` booleans emit `--no-<flag>` (previously false booleans were omitted).
- Deferred importing `torch` into `_cleanup_cuda()` to allow lightweight tests to import `dict_to_cli` in environments without `torch` installed.
- Added `hp_searches/test_dict_to_cli_bool_flags.py`, a small script that inspects `train_args.py` for `BooleanOptionalAction` defaults (via AST), and verifies `dict_to_cli()` serializes `compile: false` and default-true flags such as `lr_decay_match_max_iters`, `csv_log`, `tensorboard_log`, `tensorboard_graph`, `log_rankme`, `log_areq`, and `print_model_info` as `--no-<flag>` when set to `False`, and emits positive flags when `True`.

### Testing
- Ran `python hp_searches/test_dict_to_cli_bool_flags.py` which passed and prints `dict_to_cli boolean flag checks passed`.
- Ran `python -m py_compile hyperparam_search.py hp_searches/test_dict_to_cli_bool_flags.py` which succeeded to verify syntax/compilation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2507640bd4832680318ba81ced1aa8)