### PR TITLE
Add checkpoint import option for WTE and LM head

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,31 @@ at each new saved checkpoint.
 python3 train.py --max_sample_tokens 100 --compile
 ```
 
+### Seed WTE and LM Head from a Checkpoint
+
+To initialize only the token embedding table (`transformer.wte.weight`) and the
+full language-modeling head (`lm_head.weight`) from a prior nanoGPT checkpoint
+while training the rest of the model from the current configuration, pass the
+checkpoint path with `--import_wte_lm_head_ckpt`:
+
+```bash
+python3 train.py --import_wte_lm_head_ckpt out_prior/ckpt.pt
+```
+
+To keep those imported matrices fixed during training, add
+`--import_wte_lm_head_freeze`:
+
+```bash
+python3 train.py --import_wte_lm_head_ckpt out_prior/ckpt.pt --import_wte_lm_head_freeze
+```
+
+If the source checkpoint has separate WTE and LM-head matrices, disable weight
+tying in the new run so both matrices can be imported independently:
+
+```bash
+python3 train.py --no-wte_weight_tying --import_wte_lm_head_ckpt out_prior/ckpt.pt
+```
+
 ### Train Model with MeZO (Forward-Only Updates)
 
 This repo also includes a zeroth-order optimizer script, `train_mezo.py`, that

--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ so only `lm_head.weight` is multiplied:
 python3 train.py --import_wte_lm_head_ckpt out_prior/ckpt.pt --import_lm_head_weight_scale 0.8
 ```
 
+To first L2-normalize each imported LM-head word vector and then apply the
+multiplier, add `--import_lm_head_weight_normalize`. This also clones a tied LM
+head so normalization and scaling do not modify the imported WTE:
+
+```bash
+python3 train.py --import_wte_lm_head_ckpt out_prior/ckpt.pt \
+  --import_lm_head_weight_normalize --import_lm_head_weight_scale 0.8
+```
+
 If the source checkpoint has separate WTE and LM-head matrices, disable weight
 tying in the new run so both matrices can be imported independently:
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,15 @@ To keep those imported matrices fixed during training, add
 python3 train.py --import_wte_lm_head_ckpt out_prior/ckpt.pt --import_wte_lm_head_freeze
 ```
 
+To ablate the decoder logit scale while keeping the imported embedding table unchanged,
+set `--import_lm_head_weight_scale`. When this multiplier is not `1.0` and
+WTE/LM-head weights would otherwise be tied, the LM head is cloned before scaling
+so only `lm_head.weight` is multiplied:
+
+```bash
+python3 train.py --import_wte_lm_head_ckpt out_prior/ckpt.pt --import_lm_head_weight_scale 0.8
+```
+
 If the source checkpoint has separate WTE and LM-head matrices, disable weight
 tying in the new run so both matrices can be imported independently:
 

--- a/explorations/default_inf_wte_lm_head_import_comparison.yaml
+++ b/explorations/default_inf_wte_lm_head_import_comparison.yaml
@@ -1,0 +1,114 @@
+# Compare default infinite-attention runs against runs seeded with WTE/lm_head
+# weights from a prior checkpoint. Update the checkpoint path below before
+# launching imported runs.
+---
+
+named_static_groups:
+  # QK Norm
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  # Norm Type
+  - named_group: "peri_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [true]
+    use_post_ln: [false]
+
+  # Position Embeddings
+  - named_group: "rotary"
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+  # Relu2Max
+  - named_group: "relu2max"
+    softmax_variant_attn: ["relu2max"]
+
+  # Softmax
+  - named_group: "softmax"
+    softmax_variant_attn: ["softmax"]
+
+  # Infinite Attention
+  - named_group: "infinite"
+    attention_variant: ["infinite"]
+    use_concat_heads: [true]
+
+  # Head Dimension
+  - named_group: "hd_100"
+    n_qk_head_dim: [100]
+    n_v_head_dim: [100]
+
+  - named_group: "hd_150"
+    n_qk_head_dim: [150]
+    n_v_head_dim: [150]
+
+  - named_group: "hd_200"
+    n_qk_head_dim: [200]
+    n_v_head_dim: [200]
+
+  # MQA
+  - named_group: "mqa"
+    n_kv_group: [1]
+
+  # WTE/lm_head import modes
+  - named_group: "default_wte_lm_head"
+
+  - named_group: "import_wte_lm_head"
+    import_wte_lm_head_ckpt: &prior_wte_lm_head_ckpt ["out/default_inf_prior/ckpt.pt"]
+    import_wte_lm_head_freeze: [false]
+
+  - named_group: "import_wte_lm_head_frozen"
+    import_wte_lm_head_ckpt: *prior_wte_lm_head_ckpt
+    import_wte_lm_head_freeze: [true]
+
+named_variation_groups:
+  - named_group: "head_dim"
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]
+
+  - named_group: "wte_lm_head_import_mode"
+    named_group_alternates:
+      - "default_wte_lm_head"
+      - "import_wte_lm_head"
+      - "import_wte_lm_head_frozen"
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [2500]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+  compile: [true]
+  log_rankme: [true]
+  log_areq: [true]
+
+parameter_groups:
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "relu2max"
+      - "infinite"
+      - "mqa"
+    named_group_variations:
+      - "head_dim"
+      - "wte_lm_head_import_mode"
+    n_head:
+      range:
+        start: 1
+        end: 12
+        step: 1
+
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "softmax"
+      - "infinite"
+      - "mqa"
+    named_group_variations:
+      - "head_dim"
+      - "wte_lm_head_import_mode"
+    n_head:
+      range:
+        start: 1
+        end: 12
+        step: 1

--- a/explorations/default_inf_wte_lm_head_import_comparison.yaml
+++ b/explorations/default_inf_wte_lm_head_import_comparison.yaml
@@ -1,5 +1,6 @@
 # Compare default infinite-attention runs against runs seeded with WTE/lm_head
-# weights from a prior checkpoint, including an imported-lm-head scale ablation.
+# weights from a prior checkpoint, including raw and row-normalized lm-head
+# scale ablations.
 ---
 
 named_static_groups:
@@ -44,6 +45,11 @@ named_static_groups:
     import_wte_lm_head_ckpt: *prior_wte_lm_head_ckpt
     import_wte_lm_head_freeze: [true]
 
+  - named_group: "import_wte_lm_head_normalized"
+    import_wte_lm_head_ckpt: *prior_wte_lm_head_ckpt
+    import_wte_lm_head_freeze: [false]
+    import_lm_head_weight_normalize: [true]
+
 named_variation_groups:
   - named_group: "head_dim"
     named_group_alternates: ["hd_100"]
@@ -78,6 +84,17 @@ parameter_groups:
       - "infinite"
       - "mqa"
       - "import_wte_lm_head"
+    named_group_variations:
+      - "head_dim"
+      - "lm_head_scale_ablation"
+
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "infinite"
+      - "mqa"
+      - "import_wte_lm_head_normalized"
     named_group_variations:
       - "head_dim"
       - "lm_head_scale_ablation"

--- a/explorations/default_inf_wte_lm_head_import_comparison.yaml
+++ b/explorations/default_inf_wte_lm_head_import_comparison.yaml
@@ -1,6 +1,5 @@
 # Compare default infinite-attention runs against runs seeded with WTE/lm_head
-# weights from a prior checkpoint. Update the checkpoint path below before
-# launching imported runs.
+# weights from a prior checkpoint, including an imported-lm-head scale ablation.
 ---
 
 named_static_groups:
@@ -20,14 +19,6 @@ named_static_groups:
     use_rotary_embeddings: [true]
     use_abs_pos_embeddings: [false]
 
-  # Relu2Max
-  - named_group: "relu2max"
-    softmax_variant_attn: ["relu2max"]
-
-  # Softmax
-  - named_group: "softmax"
-    softmax_variant_attn: ["softmax"]
-
   # Infinite Attention
   - named_group: "infinite"
     attention_variant: ["infinite"]
@@ -38,14 +29,6 @@ named_static_groups:
     n_qk_head_dim: [100]
     n_v_head_dim: [100]
 
-  - named_group: "hd_150"
-    n_qk_head_dim: [150]
-    n_v_head_dim: [150]
-
-  - named_group: "hd_200"
-    n_qk_head_dim: [200]
-    n_v_head_dim: [200]
-
   # MQA
   - named_group: "mqa"
     n_kv_group: [1]
@@ -54,7 +37,7 @@ named_static_groups:
   - named_group: "default_wte_lm_head"
 
   - named_group: "import_wte_lm_head"
-    import_wte_lm_head_ckpt: &prior_wte_lm_head_ckpt ["out/default_inf_prior/ckpt.pt"]
+    import_wte_lm_head_ckpt: &prior_wte_lm_head_ckpt ["out/default_inf_wte_lm_head_import_comparison-qk_norm-peri_ln-rotary-infinite-mqa-hd_100-default_wte_lm_head/ckpt.pt"]
     import_wte_lm_head_freeze: [false]
 
   - named_group: "import_wte_lm_head_frozen"
@@ -63,19 +46,16 @@ named_static_groups:
 
 named_variation_groups:
   - named_group: "head_dim"
-    named_group_alternates: ["hd_100", "hd_150", "hd_200"]
+    named_group_alternates: ["hd_100"]
 
-  - named_group: "wte_lm_head_import_mode"
-    named_group_alternates:
-      - "default_wte_lm_head"
-      - "import_wte_lm_head"
-      - "import_wte_lm_head_frozen"
+  - named_group: "lm_head_scale_ablation"
+    import_lm_head_weight_scale: [0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5]
 
 common_group:
-  dataset: ["minipile"]
-  eval_interval: [2500]
-  max_iters: [10000]
-  never_save_checkpoint: [true]
+  dataset: ["shakespeare_char"]
+  eval_interval: [50]
+  max_iters: [1000]
+  never_save_checkpoint: [false]
   compile: [true]
   log_rankme: [true]
   log_areq: [true]
@@ -85,30 +65,30 @@ parameter_groups:
       - "qk_norm"
       - "peri_ln"
       - "rotary"
-      - "relu2max"
       - "infinite"
       - "mqa"
+      - "default_wte_lm_head"
     named_group_variations:
       - "head_dim"
-      - "wte_lm_head_import_mode"
-    n_head:
-      range:
-        start: 1
-        end: 12
-        step: 1
 
   - named_group_static:
       - "qk_norm"
       - "peri_ln"
       - "rotary"
-      - "softmax"
       - "infinite"
       - "mqa"
+      - "import_wte_lm_head"
     named_group_variations:
       - "head_dim"
-      - "wte_lm_head_import_mode"
-    n_head:
-      range:
-        start: 1
-        end: 12
-        step: 1
+      - "lm_head_scale_ablation"
+
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "infinite"
+      - "mqa"
+      - "import_wte_lm_head_frozen"
+    named_group_variations:
+      - "head_dim"
+      - "lm_head_scale_ablation"

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -140,6 +140,8 @@ class GPTConfig:
     # wte import/export
     import_wte_freeze: bool = False
     import_wte_npy: str = None
+    import_wte_lm_head_ckpt: str = None
+    import_wte_lm_head_freeze: bool = False
     export_wte_npy: str = None
     export_wte_each_eval: bool = False
 

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -142,6 +142,7 @@ class GPTConfig:
     import_wte_npy: str = None
     import_wte_lm_head_ckpt: str = None
     import_wte_lm_head_freeze: bool = False
+    import_lm_head_weight_scale: float = 1.0
     export_wte_npy: str = None
     export_wte_each_eval: bool = False
 

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -142,6 +142,7 @@ class GPTConfig:
     import_wte_npy: str = None
     import_wte_lm_head_ckpt: str = None
     import_wte_lm_head_freeze: bool = False
+    import_lm_head_weight_normalize: bool = False
     import_lm_head_weight_scale: float = 1.0
     export_wte_npy: str = None
     export_wte_each_eval: bool = False

--- a/model.py
+++ b/model.py
@@ -202,6 +202,13 @@ class GPT(nn.Module):
             # Replace wte with values from numpy and retie weights
             self.import_wte(self.config.import_wte_npy)
 
+        # import full wte + lm_head from an existing nanoGPT checkpoint
+        if self.config.import_wte_lm_head_ckpt:
+            self.import_wte_lm_head_from_ckpt(
+                self.config.import_wte_lm_head_ckpt,
+                freeze=self.config.import_wte_lm_head_freeze,
+            )
+
         # import scale_matrices
         if config.import_scale_matrices_npz:
             self.import_scale_matrices(config.import_scale_matrices_npz, config.n_embd_wte_scale_tying)
@@ -320,6 +327,66 @@ class GPT(nn.Module):
         embedding_table = self.transformer.wte.weight.detach().cpu().numpy()
         np.save(file_path, embedding_table)
         print(f"Embedding table saved to {file_path}")
+
+    def _checkpoint_state_dict(self, checkpoint_path):
+        """Load a checkpoint and return a prefix-normalized model state dict."""
+        checkpoint_obj = torch.load(checkpoint_path, map_location="cpu")
+        state_dict = checkpoint_obj.get("model", checkpoint_obj)
+        state_dict = dict(state_dict)
+        for key in list(state_dict.keys()):
+            normalized_key = key
+            if normalized_key.startswith("_orig_mod."):
+                normalized_key = normalized_key[len("_orig_mod."):]
+            if normalized_key.startswith("module."):
+                normalized_key = normalized_key[len("module."):]
+            if normalized_key != key:
+                state_dict[normalized_key] = state_dict.pop(key)
+        return state_dict
+
+    def _copy_imported_weight(self, source_state_dict, target_key):
+        if target_key not in source_state_dict:
+            raise KeyError(f"Checkpoint is missing required weight '{target_key}'")
+        target_state_dict = self.state_dict()
+        if target_key not in target_state_dict:
+            raise KeyError(f"Current model does not have a '{target_key}' parameter to import into")
+        source_weight = source_state_dict[target_key].detach().float()
+        target_weight = target_state_dict[target_key]
+        if source_weight.shape != target_weight.shape:
+            raise ValueError(
+                f"Shape mismatch for {target_key}: checkpoint has {tuple(source_weight.shape)} "
+                f"but current model expects {tuple(target_weight.shape)}"
+            )
+        target_weight.copy_(source_weight.to(device=target_weight.device, dtype=target_weight.dtype))
+
+    def import_wte_lm_head_from_ckpt(self, checkpoint_path, freeze=False):
+        """Import the full token embedding table and lm_head from a checkpoint."""
+        if self.config.multicontext or self.config.multidataset_wte or self.uses_numerical_multicontext:
+            raise NotImplementedError(
+                "--import_wte_lm_head_ckpt currently supports the single shared wte/lm_head path only."
+            )
+
+        source_state_dict = self._checkpoint_state_dict(checkpoint_path)
+        wte_key = "transformer.wte.weight"
+        lm_head_key = "lm_head.weight"
+
+        with torch.no_grad():
+            self._copy_imported_weight(source_state_dict, wte_key)
+            if self.wte_weight_tying:
+                if lm_head_key in source_state_dict:
+                    imported_wte = source_state_dict[wte_key].detach().float()
+                    imported_lm_head = source_state_dict[lm_head_key].detach().float()
+                    if imported_wte.shape != imported_lm_head.shape or not torch.allclose(imported_wte, imported_lm_head):
+                        raise ValueError(
+                            "Checkpoint has distinct wte and lm_head weights, but the current model has "
+                            "--wte_weight_tying enabled. Re-run with --no-wte_weight_tying to import both matrices."
+                        )
+                self.lm_head.weight = self.transformer.wte.weight
+            else:
+                self._copy_imported_weight(source_state_dict, lm_head_key)
+
+        self.transformer.wte.weight.requires_grad = not freeze
+        self.lm_head.weight.requires_grad = not freeze
+        print(f"Imported wte and lm_head from {checkpoint_path}; freeze={freeze}")
 
     def import_scale_matrices(self, file_path, weight_tying=False):
         """Import scale_up and scale_down matrices from a numpy file."""

--- a/model.py
+++ b/model.py
@@ -207,6 +207,7 @@ class GPT(nn.Module):
             self.import_wte_lm_head_from_ckpt(
                 self.config.import_wte_lm_head_ckpt,
                 freeze=self.config.import_wte_lm_head_freeze,
+                normalize_lm_head=self.config.import_lm_head_weight_normalize,
                 lm_head_scale=self.config.import_lm_head_weight_scale,
             )
 
@@ -359,7 +360,9 @@ class GPT(nn.Module):
             )
         target_weight.copy_(source_weight.to(device=target_weight.device, dtype=target_weight.dtype))
 
-    def import_wte_lm_head_from_ckpt(self, checkpoint_path, freeze=False, lm_head_scale=1.0):
+    def import_wte_lm_head_from_ckpt(
+        self, checkpoint_path, freeze=False, normalize_lm_head=False, lm_head_scale=1.0
+    ):
         """Import the full token embedding table and lm_head from a checkpoint."""
         if self.config.multicontext or self.config.multidataset_wte or self.uses_numerical_multicontext:
             raise NotImplementedError(
@@ -386,17 +389,20 @@ class GPT(nn.Module):
                 self._copy_imported_weight(source_state_dict, lm_head_key)
 
             lm_head_scale = float(lm_head_scale)
-            if lm_head_scale != 1.0:
+            if normalize_lm_head or lm_head_scale != 1.0:
                 if self.lm_head.weight is self.transformer.wte.weight:
                     self.lm_head.weight = nn.Parameter(self.lm_head.weight.detach().clone())
                     self.wte_weight_tying = False
+            if normalize_lm_head:
+                self.lm_head.weight.copy_(F.normalize(self.lm_head.weight, p=2, dim=1))
+            if lm_head_scale != 1.0:
                 self.lm_head.weight.mul_(lm_head_scale)
 
         self.transformer.wte.weight.requires_grad = not freeze
         self.lm_head.weight.requires_grad = not freeze
         print(
             f"Imported wte and lm_head from {checkpoint_path}; "
-            f"freeze={freeze}; lm_head_scale={lm_head_scale}"
+            f"freeze={freeze}; normalize_lm_head={normalize_lm_head}; lm_head_scale={lm_head_scale}"
         )
 
     def import_scale_matrices(self, file_path, weight_tying=False):

--- a/model.py
+++ b/model.py
@@ -207,6 +207,7 @@ class GPT(nn.Module):
             self.import_wte_lm_head_from_ckpt(
                 self.config.import_wte_lm_head_ckpt,
                 freeze=self.config.import_wte_lm_head_freeze,
+                lm_head_scale=self.config.import_lm_head_weight_scale,
             )
 
         # import scale_matrices
@@ -358,7 +359,7 @@ class GPT(nn.Module):
             )
         target_weight.copy_(source_weight.to(device=target_weight.device, dtype=target_weight.dtype))
 
-    def import_wte_lm_head_from_ckpt(self, checkpoint_path, freeze=False):
+    def import_wte_lm_head_from_ckpt(self, checkpoint_path, freeze=False, lm_head_scale=1.0):
         """Import the full token embedding table and lm_head from a checkpoint."""
         if self.config.multicontext or self.config.multidataset_wte or self.uses_numerical_multicontext:
             raise NotImplementedError(
@@ -384,9 +385,19 @@ class GPT(nn.Module):
             else:
                 self._copy_imported_weight(source_state_dict, lm_head_key)
 
+            lm_head_scale = float(lm_head_scale)
+            if lm_head_scale != 1.0:
+                if self.lm_head.weight is self.transformer.wte.weight:
+                    self.lm_head.weight = nn.Parameter(self.lm_head.weight.detach().clone())
+                    self.wte_weight_tying = False
+                self.lm_head.weight.mul_(lm_head_scale)
+
         self.transformer.wte.weight.requires_grad = not freeze
         self.lm_head.weight.requires_grad = not freeze
-        print(f"Imported wte and lm_head from {checkpoint_path}; freeze={freeze}")
+        print(
+            f"Imported wte and lm_head from {checkpoint_path}; "
+            f"freeze={freeze}; lm_head_scale={lm_head_scale}"
+        )
 
     def import_scale_matrices(self, file_path, weight_tying=False):
         """Import scale_up and scale_down matrices from a numpy file."""

--- a/tests/test_import_wte_lm_head.py
+++ b/tests/test_import_wte_lm_head.py
@@ -1,0 +1,47 @@
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+
+from model import GPT
+
+
+class ImportWteLmHeadTest(unittest.TestCase):
+    def test_normalizes_each_lm_head_row_before_scaling(self):
+        model = GPT.__new__(GPT)
+        nn.Module.__init__(model)
+        model.config = SimpleNamespace(multicontext=False, multidataset_wte=False)
+        model.uses_numerical_multicontext = False
+        model.wte_weight_tying = True
+        model.transformer = nn.ModuleDict({"wte": nn.Embedding(3, 2)})
+        model.lm_head = nn.Linear(2, 3, bias=False)
+        model.lm_head.weight = model.transformer.wte.weight
+
+        imported_weight = torch.tensor([[3.0, 4.0], [0.0, 2.0], [-5.0, 0.0]])
+        checkpoint = {
+            "model": {
+                "transformer.wte.weight": imported_weight,
+                "lm_head.weight": imported_weight.clone(),
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            checkpoint_path = Path(temp_dir) / "ckpt.pt"
+            torch.save(checkpoint, checkpoint_path)
+            model.import_wte_lm_head_from_ckpt(
+                checkpoint_path, normalize_lm_head=True, lm_head_scale=0.8
+            )
+
+        torch.testing.assert_close(model.transformer.wte.weight, imported_weight)
+        torch.testing.assert_close(
+            model.lm_head.weight.norm(dim=1), torch.full((3,), 0.8)
+        )
+        self.assertIsNot(model.lm_head.weight, model.transformer.wte.weight)
+        self.assertFalse(model.wte_weight_tying)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/train_args.py
+++ b/train_args.py
@@ -64,6 +64,8 @@ def parse_args():
     # Export Args
     ## Factored WTE
     model_group.add_argument('--import_wte_npy', default=None, type=str, help='Path to import the embedding table as a .npy file')
+    model_group.add_argument('--import_wte_lm_head_ckpt', default=None, type=str, help='Path to a ckpt.pt file whose full token embedding (wte) and language modeling head weights should be imported into the current model')
+    model_group.add_argument('--import_wte_lm_head_freeze', default=False, action=argparse.BooleanOptionalAction, help='Whether to freeze the wte and lm_head weights imported from --import_wte_lm_head_ckpt')
     model_group.add_argument('--export_wte_npy', default=None, type=str, help='Path to export the embedding table as a .npy file')
     model_group.add_argument('--export_wte_each_eval', default=False, action=argparse.BooleanOptionalAction, help="Requires --export_wte is not None. If this is so, will always export embedding to numpy after evaluation")
     model_group.add_argument('--import_wte_freeze', default=False, action=argparse.BooleanOptionalAction, help="Whether to freeze an imported wte")

--- a/train_args.py
+++ b/train_args.py
@@ -66,6 +66,7 @@ def parse_args():
     model_group.add_argument('--import_wte_npy', default=None, type=str, help='Path to import the embedding table as a .npy file')
     model_group.add_argument('--import_wte_lm_head_ckpt', default=None, type=str, help='Path to a ckpt.pt file whose full token embedding (wte) and language modeling head weights should be imported into the current model')
     model_group.add_argument('--import_wte_lm_head_freeze', default=False, action=argparse.BooleanOptionalAction, help='Whether to freeze the wte and lm_head weights imported from --import_wte_lm_head_ckpt')
+    model_group.add_argument('--import_lm_head_weight_normalize', default=False, action=argparse.BooleanOptionalAction, help='L2-normalize each imported lm_head word vector before applying --import_lm_head_weight_scale')
     model_group.add_argument('--import_lm_head_weight_scale', default=1.0, type=float, help='Uniform multiplier applied to imported lm_head weights after --import_wte_lm_head_ckpt loads them')
     model_group.add_argument('--export_wte_npy', default=None, type=str, help='Path to export the embedding table as a .npy file')
     model_group.add_argument('--export_wte_each_eval', default=False, action=argparse.BooleanOptionalAction, help="Requires --export_wte is not None. If this is so, will always export embedding to numpy after evaluation")

--- a/train_args.py
+++ b/train_args.py
@@ -66,6 +66,7 @@ def parse_args():
     model_group.add_argument('--import_wte_npy', default=None, type=str, help='Path to import the embedding table as a .npy file')
     model_group.add_argument('--import_wte_lm_head_ckpt', default=None, type=str, help='Path to a ckpt.pt file whose full token embedding (wte) and language modeling head weights should be imported into the current model')
     model_group.add_argument('--import_wte_lm_head_freeze', default=False, action=argparse.BooleanOptionalAction, help='Whether to freeze the wte and lm_head weights imported from --import_wte_lm_head_ckpt')
+    model_group.add_argument('--import_lm_head_weight_scale', default=1.0, type=float, help='Uniform multiplier applied to imported lm_head weights after --import_wte_lm_head_ckpt loads them')
     model_group.add_argument('--export_wte_npy', default=None, type=str, help='Path to export the embedding table as a .npy file')
     model_group.add_argument('--export_wte_each_eval', default=False, action=argparse.BooleanOptionalAction, help="Requires --export_wte is not None. If this is so, will always export embedding to numpy after evaluation")
     model_group.add_argument('--import_wte_freeze', default=False, action=argparse.BooleanOptionalAction, help="Whether to freeze an imported wte")


### PR DESCRIPTION
### Motivation
- Provide an easy way to seed a new run with a prior checkpoint's full token embedding table (`transformer.wte.weight`) and language-modeling head (`lm_head.weight`) without importing the entire model state.
- Allow optional freezing of those imported matrices so they can be kept fixed while finetuning other parts of the model.
- Handle both tied and untied WTE/lm_head cases and fail fast on mismatches or unsupported multicontext variants.

### Description
- Added persistent config fields `import_wte_lm_head_ckpt` and `import_wte_lm_head_freeze` to `GPTConfig` and matching CLI flags `--import_wte_lm_head_ckpt` and `--import_wte_lm_head_freeze` in `train_args.py`.
- Invoked a new import path during model initialization so `GPT` will call `import_wte_lm_head_from_ckpt` after any existing `--import_wte_npy` handling.
- Implemented `_checkpoint_state_dict` to load and normalize state-dict keys, `_copy_imported_weight` to validate shapes and copy tensors safely, and `import_wte_lm_head_from_ckpt` to import the `wte` and `lm_head` weights while respecting `wte_weight_tying` and `freeze` semantics.
- Updated `README.md` with examples showing how to import and optionally freeze the WTE/lm_head and notes about disabling weight-tying when the source checkpoint contains distinct matrices.

### Testing
- Ran `python -m py_compile gpt_conf.py train_args.py model.py train.py` to ensure the modified modules are syntactically valid and compilation succeeded.
- Attempted `python -m pytest tests/test_bit_balanced_loss.py`, but collection failed due to the environment missing `torch` (automated tests could not run to completion for this reason).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2819b07db4832689ae9c1a11004e99)