### PR TITLE
Add cached multicontext generation with KV-cache support

### DIFF
--- a/model.py
+++ b/model.py
@@ -634,6 +634,129 @@ class GPT(nn.Module):
                 loss = None
 
             return logits, loss
+
+    @torch.no_grad()
+    def generate_multicontext_step(self, token_dict, caches=None, position=None, iter_num=None):
+        """Run one cached multicontext generation step.
+
+        When ``caches`` is ``None`` this performs the prompt prefill over the full
+        per-context tensors in ``token_dict``.  Subsequent calls should pass the
+        returned caches and may pass either full histories or one-token tensors;
+        only the newest token for each context is embedded and evaluated.
+        """
+        if token_dict is None:
+            raise ValueError("generate_multicontext_step requires token_dict")
+
+        token_list = list(token_dict.values())
+        if len(token_list) == 0:
+            raise ValueError("generate_multicontext_step requires at least one context")
+
+        device = token_list[0].device
+        is_prefill = caches is None
+        if position is None:
+            position = 0 if is_prefill else caches[0][0].size(2)
+
+        x = None
+        for i, tokens in enumerate(token_list):
+            step_tokens = tokens if is_prefill else tokens[:, [-1]]
+            if self.uses_numerical_multicontext:
+                module = self.numerical_embeddings[str(i)]
+                param = next(module.parameters())
+                if self.config.numerical_multicontext_input_format == "fp16_bits":
+                    numeric_tokens = self._fp16bits_to_fp32(step_tokens).to(param.dtype)
+                else:
+                    numeric_tokens = step_tokens.to(param.dtype)
+                token_repr = module(numeric_tokens.unsqueeze(-1))
+            else:
+                token_repr = self.transformer[f'wte_{i}'](step_tokens)
+
+            token_repr = self.add_embedding_gaussian_noise(token_repr, iter_num=iter_num)
+            x = token_repr if x is None else x + token_repr
+
+        if self.config.norm_variant_wte is not None:
+            x = self.transformer.post_embedding_norm(x)
+
+        if self.config.use_embedding_scale:
+            x = x * self.embedding_scale
+
+        if self.config.use_abs_pos_embeddings:
+            t = x.size(1)
+            try:
+                pos_emb = self.transformer.wpe(
+                    t,
+                    device=device,
+                    training=self.training,
+                    start_index=position,
+                )
+            except TypeError:
+                # Backward compatibility for custom absolute-position modules
+                # that have not adopted the optional start_index argument.
+                if position != 0:
+                    raise
+                pos_emb = self.transformer.wpe(t, device=device, training=self.training)
+            x = x + pos_emb
+            if self.config.norm_variant_abs is not None:
+                x = self.transformer.post_abs_norm(x)
+            x = self.transformer.drop(x)
+        else:
+            x = self.transformer.drop(x)
+
+        if self.use_lsv and self.config.apply_lsv_at_layer_idx == 0:
+            x = self.lsv_matrix(x)
+
+        if self.use_ln_f_input_mixer:
+            if not is_prefill:
+                raise NotImplementedError("Cached multicontext generation does not support ln_f input mixing")
+            layer_outputs = [x]
+
+        next_caches = []
+        layer_idx = 1
+        for cache, block in zip(caches or [None] * len(self.transformer.h), self.transformer.h):
+            x, present = block(
+                x,
+                iter_num,
+                kv_cache=cache,
+                use_cache=True,
+                position_offset=position,
+            )
+            next_caches.append(present)
+
+            if self.use_lsv and layer_idx == self.config.apply_lsv_at_layer_idx:
+                x = self.lsv_matrix(x)
+            if (self.config.apply_vector_at_layer_idx is not None
+                    and layer_idx == self.config.apply_vector_at_layer_idx):
+                x = self.apply_vector_to_layer_output(x)
+            if (self.config.obtain_vector_at_layer_idx is not None
+                    and layer_idx == self.config.obtain_vector_at_layer_idx):
+                x = self.obtain_vector_from_layer_output(x)
+
+            if self.use_ln_f_input_mixer:
+                layer_outputs.append(x)
+
+            layer_idx += 1
+
+        if self.use_ln_f_input_mixer:
+            x = self.ln_f_mixer(layer_outputs)
+
+        x = self.transformer.ln_f(x)
+
+        if self.n_embd_wte:
+            x = F.linear(x, self.transformer.scale_down.weight.t())
+
+        x_last = x[:, [-1], :]
+        if self.uses_numerical_multicontext:
+            logits = [self.numerical_output_mlps[str(i)](x_last) for i in range(len(token_list))]
+        else:
+            logits = [self.transformer[f'lm_head_{i}'](x_last) for i in range(len(token_list))]
+            if self.config.final_logit_softcapping is not None:
+                logits = [
+                    torch.tanh(logit_var / self.config.final_logit_softcapping)
+                    * self.config.final_logit_softcapping
+                    for logit_var in logits
+                ]
+
+        return logits, next_caches
+
     # ------------------------------------------------------------------
     #  LATENT-CHAINING
     # ------------------------------------------------------------------

--- a/sample.py
+++ b/sample.py
@@ -1803,14 +1803,16 @@ def main():
                         model.set_lsv_mode(1)
 
                 token_state = {name: tensor.clone() for name, tensor in initial_tokens.items()}
+                idx_cond_dict = {}
+                for name in dataset_names:
+                    tokens = token_state[name]
+                    idx_cond_dict[name] = tokens if tokens.size(1) <= block_size else tokens[:, -block_size:]
 
-                for _ in range(args.max_new_tokens):
-                    idx_cond_dict = {}
-                    for name in dataset_names:
-                        tokens = token_state[name]
-                        idx_cond_dict[name] = tokens if tokens.size(1) <= block_size else tokens[:, -block_size:]
+                logits_list, caches = model.generate_multicontext_step(idx_cond_dict)
+                cache_position = next(iter(idx_cond_dict.values())).size(1)
 
-                    logits_list, _ = model(None, token_dict=idx_cond_dict, target_dict=None)
+                for step_idx in range(args.max_new_tokens):
+                    next_token_dict = {}
 
                     for i, name in enumerate(dataset_names):
                         if model.config.numerical_multicontext:
@@ -1850,6 +1852,15 @@ def main():
                             idx_next = torch.multinomial(probs, num_samples=1)
 
                         token_state[name] = torch.cat((token_state[name], idx_next), dim=1)
+                        next_token_dict[name] = idx_next
+
+                    if step_idx + 1 < args.max_new_tokens:
+                        logits_list, caches = model.generate_multicontext_step(
+                            next_token_dict,
+                            caches=caches,
+                            position=cache_position,
+                        )
+                        cache_position += 1
 
                 output_dict: Dict[str, str] = {}
                 for name in dataset_names:

--- a/variations/absolute_position_variations.py
+++ b/variations/absolute_position_variations.py
@@ -19,9 +19,9 @@ class LearnedAbsolutePositionEmbedding(nn.Module):
         else:
             self.embedding = nn.Embedding(config.block_size, config.n_embd)
 
-    def forward(self, seq_len, device, training=False):
+    def forward(self, seq_len, device, training=False, start_index=0):
         del training  # unused, kept for interface compatibility
-        pos = torch.arange(0, seq_len, dtype=torch.long, device=device)
+        pos = torch.arange(start_index, start_index + seq_len, dtype=torch.long, device=device)
         return self.embedding(pos)
 
     def update_block_size(self, new_block_size):
@@ -73,8 +73,8 @@ class CyclicAbsolutePositionEmbedding(nn.Module):
             nn.Embedding(cycle_len, config.n_embd) for cycle_len in self.cycle_lengths
         ])
 
-    def forward(self, seq_len, device, training=False):
-        pos = torch.arange(0, seq_len, dtype=torch.long, device=device)
+    def forward(self, seq_len, device, training=False, start_index=0):
+        pos = torch.arange(start_index, start_index + seq_len, dtype=torch.long, device=device)
         out = None
 
         for cycle_len, emb in zip(self.cycle_lengths, self.embeddings):

--- a/variations/attention_variations.py
+++ b/variations/attention_variations.py
@@ -278,7 +278,7 @@ class CausalSelfAttention(nn.Module):
             return tensor
         return tensor.index_select(1, self.head_to_kv)
 
-    def forward(self, x, iter_num):
+    def forward(self, x, iter_num, kv_cache=None, use_cache=False, position_offset=0):
         B, T, C = x.size() # batch size, sequence length, embedding dimensionality (n_embd)
 
         if self.quantization_attn_dict["quantize_attn_act_input"]:
@@ -290,13 +290,26 @@ class CausalSelfAttention(nn.Module):
         k = self.c_attn_k(x)
         v = self.c_attn_v(x)
 
+        past_k = past_v = None
+        past_len = 0
+        if kv_cache is not None:
+            past_k, past_v = kv_cache
+            past_len = past_k.size(2)
+
+        if position_offset is None:
+            position_offset = past_len
+
+        total_len = past_len + T
+
         if self.window_size is not None:
             if self.use_flex_attn is not None:
                 self.block_masks = {}
             else:
-                self.window_mask = torch.ones((1, 1, T, T), device=x.device)
-                self.window_mask = torch.triu(self.window_mask, diagonal=-self.window_size)
-                self.window_mask = self.bias[:,:,:T,:T] * self.window_mask
+                q_pos = torch.arange(position_offset, position_offset + T, device=x.device)[:, None]
+                kv_pos = torch.arange(total_len, device=x.device)[None, :]
+                causal_mask = q_pos >= kv_pos
+                window_mask = (q_pos - kv_pos) <= self.window_size
+                self.window_mask = (causal_mask & window_mask).view(1, 1, T, total_len)
 
         if self.gate:
             if self.n_kv_group == self.n_head:
@@ -323,8 +336,8 @@ class CausalSelfAttention(nn.Module):
 
         # rotate q and k before evaluating with the heads
         if (self.rotary_emb_q is not None) and (self.rotary_emb_k is not None):
-            q = self.rotary_emb_q(q)
-            k = self.rotary_emb_k(k)
+            q = self.rotary_emb_q(q, start_index=position_offset)
+            k = self.rotary_emb_k(k, start_index=position_offset)
 
         y = None
 
@@ -334,6 +347,13 @@ class CausalSelfAttention(nn.Module):
 
         if self.use_v_norm:
             v = v / (v.norm(dim=-1, keepdim=True) + 1e-6)
+
+        present = None
+        if past_k is not None:
+            k = torch.cat((past_k, k), dim=2)
+            v = torch.cat((past_v, v), dim=2)
+        if use_cache:
+            present = (k, v)
 
         # causal self-attention; Self-attend: (B, nh, T, hs) x (B, nh, hs, T) -> (B, nh, T, T)
         if self.flash:
@@ -367,15 +387,25 @@ class CausalSelfAttention(nn.Module):
 
 
             # Efficient attention using Flash Attention CUDA kernels
+            is_causal = past_len == 0 and position_offset == 0
+            if not is_causal:
+                q_pos = torch.arange(position_offset, position_offset + T, device=x.device)[:, None]
+                kv_pos = torch.arange(k_attn.size(2), device=x.device)[None, :]
+                causal_mask = (q_pos >= kv_pos).view(1, 1, T, k_attn.size(2))
+                if attn_bias is None:
+                    attn_bias = causal_mask
+                else:
+                    attn_bias = attn_bias.masked_fill(~causal_mask, float("-inf"))
+
             y = torch.nn.functional.scaled_dot_product_attention(
                 q,
                 k_attn,
                 v_attn,
                 attn_mask=attn_bias,
                 dropout_p=self.dropout if self.training else 0,
-                is_causal=True,
+                is_causal=is_causal,
             )
-        elif self.use_flex_attn and self.window_size is not None:
+        elif self.use_flex_attn and self.window_size is not None and past_len == 0 and position_offset == 0:
             block_mask = self.get_block_mask(T, x.device)
             y = torch.nn.attention.flex_attention.flex_attention(q, k, v, block_mask=block_mask)
         else:
@@ -409,12 +439,19 @@ class CausalSelfAttention(nn.Module):
             if self.window_size is not None:
                 # add mask for sliding window attention
                 att = att.masked_fill(self.window_mask == 0, float('-inf'))
+            elif past_len != 0 or position_offset != 0:
+                q_pos = torch.arange(position_offset, position_offset + T, device=x.device)[:, None]
+                kv_pos = torch.arange(k_attn.size(-2), device=x.device)[None, :]
+                causal_mask = (q_pos >= kv_pos).view(1, 1, T, k_attn.size(-2))
+                att = att.masked_fill(causal_mask == 0, float('-inf'))
             else:
                 # regular lower triangle attention
                 att = att.masked_fill(self.bias[:,:,:T,:T].to(x.device) == 0, float('-inf'))
 
             # fire position embeddings
             if self.use_fire_embeddings is not None:
+                if past_len != 0 or position_offset != 0:
+                    raise NotImplementedError("Cached generation is not implemented for FIRE attention bias")
                 # add learned fire bias
                 att = att + self.fire_pos_enc(x)
 
@@ -458,6 +495,8 @@ class CausalSelfAttention(nn.Module):
             quant_method = self.quantization_attn_dict["activations_quant_method"]
             y = fake_quantize_act(self, "attn_act_output", y, num_bits, quant_method, iter_num)
 
+        if use_cache:
+            return y, present
         return y
 
 class EdgeLLMASICAttention(nn.Module):

--- a/variations/block_variations.py
+++ b/variations/block_variations.py
@@ -74,7 +74,7 @@ def make_alpha_fn(mode: str, init: float, param=None, vec=None):
 # Block Forward Variations
 # -----------------------
 
-def parallel_mlp_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor:
+def parallel_mlp_forward(block, x: torch.Tensor, iter_num: int, kv_cache=None, use_cache: bool = False, position_offset: int = 0) -> torch.Tensor:
     """Forward pass where attention and MLP run in parallel."""
 
     # Make sure not to override skip connection
@@ -85,7 +85,12 @@ def parallel_mlp_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor:
         x_in = block.pre_ln(x_in)
 
     # Perform Operations
-    attn_out = block.attn(x_in, iter_num)
+    attn_result = block.attn(x_in, iter_num, kv_cache=kv_cache, use_cache=use_cache, position_offset=position_offset)
+    if use_cache:
+        attn_out, present = attn_result
+    else:
+        attn_out = attn_result
+        present = None
     mlp_out = block.mlp(x_in, iter_num)
 
     # Peri-LN
@@ -108,10 +113,12 @@ def parallel_mlp_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor:
     if block.use_post_ln:
         x = block.post_ln(x)
 
+    if use_cache:
+        return x, present
     return x
 
 
-def attn_then_mlp_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor:
+def attn_then_mlp_forward(block, x: torch.Tensor, iter_num: int, kv_cache=None, use_cache: bool = False, position_offset: int = 0) -> torch.Tensor:
     """Attention followed by MLP."""
 
     # Make sure not to override skip connection
@@ -122,7 +129,12 @@ def attn_then_mlp_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor
         x_attn_in = block.pre_ln_attn(x_attn_in)
 
     # Attn Operation
-    attn_out = block.attn(x_attn_in, iter_num)
+    attn_result = block.attn(x_attn_in, iter_num, kv_cache=kv_cache, use_cache=use_cache, position_offset=position_offset)
+    if use_cache:
+        attn_out, present = attn_result
+    else:
+        attn_out = attn_result
+        present = None
 
     # Attn Peri-LN
     if block.use_peri_ln_attn:
@@ -164,10 +176,15 @@ def attn_then_mlp_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor
     if block.use_post_ln_mlp:
         x = block.post_ln_mlp(x)
 
+    if use_cache:
+        return x, present
     return x
 
 
-def edgellm_asic_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor:
+def edgellm_asic_forward(block, x: torch.Tensor, iter_num: int, kv_cache=None, use_cache: bool = False, position_offset: int = 0) -> torch.Tensor:
+    if use_cache or kv_cache is not None:
+        raise NotImplementedError("Cached generation is not implemented for EdgeLLM ASIC blocks")
+    del position_offset
     """EdgeLLM ASIC forward: Attention followed by MLP with skip connection accumulation between blocks."""
 
     # Separate Full Precision Residual 'x' from 'x_quantized_residual'
@@ -471,10 +488,16 @@ class Block(nn.Module):
         # Gradient checkpointing
         self.use_gradient_checkpointing = getattr(config, "use_gradient_checkpointing", False)
 
-    def forward(self, x: torch.Tensor, iter_num: int):
-        if self.use_gradient_checkpointing and x.requires_grad:
+    def forward(self, x: torch.Tensor, iter_num: int, kv_cache=None, use_cache: bool = False, position_offset: int = 0):
+        if self.use_gradient_checkpointing and x.requires_grad and not use_cache:
             return checkpoint.checkpoint(self.block_forward, x, iter_num, use_reentrant=False)
-        return self.block_forward(x, iter_num)
+        return self.block_forward(
+            x,
+            iter_num,
+            kv_cache=kv_cache,
+            use_cache=use_cache,
+            position_offset=position_offset,
+        )
 
     def _combine_resid(self, kind: str, x: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
         """Helper method to streamline forward block skip connections"""

--- a/variations/position_encoding_variations.py
+++ b/variations/position_encoding_variations.py
@@ -60,7 +60,7 @@ class RotaryEmbedding(nn.Module):
             assert rope_length <= self.dim, "New rotary length must less than or equal to embedding dim"
             self.rope_length = rope_length
 
-    def forward(self, x):
+    def forward(self, x, start_index=None):
         if self.first_pass:
             self.inv_freq = self._generate_inv_freq(x.device)
             self.first_pass = False
@@ -69,7 +69,8 @@ class RotaryEmbedding(nn.Module):
         device = x.device
 
         # Create position indices
-        pos_indices = torch.arange(self.start_index, self.start_index + seq_len, device=x.device).type_as(self.inv_freq)
+        offset = self.start_index if start_index is None else start_index
+        pos_indices = torch.arange(offset, offset + seq_len, device=x.device).type_as(self.inv_freq)
 
         # Compute the sinusoidal angles
         angles = torch.einsum('i,d->id', pos_indices, self.inv_freq)
@@ -137,7 +138,7 @@ class SymmetricalOverlapAngularPositions(nn.Module):
             assert rope_length <= self.dim, "New rotary length must less than or equal to embedding dim"
             self.rope_length = rope_length
 
-    def forward(self, x):
+    def forward(self, x, start_index=None):
         if self.first_pass:
             self.angles = self._generate_angles(self.num_angles, x.device)
             self.first_pass = False
@@ -148,7 +149,8 @@ class SymmetricalOverlapAngularPositions(nn.Module):
         self.angles = torch.roll(self.angles, shifts=1, dims=0)
 
         # Create index list, wrap around as necessary
-        angle_indices = torch.arange(seq_len, device=device) % self.num_angles
+        offset = 0 if start_index is None else start_index
+        angle_indices = torch.arange(offset, offset + seq_len, device=device) % self.num_angles
 
         # Assign angles
         selected_angles = self.angles[angle_indices]


### PR DESCRIPTION
### Motivation
- Enable efficient incremental multicontext generation by pre-filling prompts once and then running one-token cached steps per context to avoid reprocessing full histories.
- Thread per-layer KV cache state through the attention and block forward paths so cached generation uses previous key/value tensors and returns updated caches.
- Preserve existing full-context `forward(..., token_dict=...)` behavior for training and evaluation so existing loss computation is unchanged.

### Description
- Extended the default attention path in `variations/attention_variations.py` to accept `kv_cache`, `use_cache`, and `position_offset`, concatenate past `k`/`v`, apply correct causal/window masks for cached calls, and return `present` KV pairs when `use_cache=True`.
- Threaded cache inputs/outputs through block-level forward variants in `variations/block_variations.py` (updated `parallel_mlp_forward`, `attn_then_mlp_forward`, `edgellm_asic_forward` and `Block.forward`) so blocks accept `kv_cache`/`use_cache`/`position_offset` and return updated per-layer presents when requested.
- Added `GPT.generate_multicontext_step` in `model.py` to perform a prompt prefill when called with `caches=None` and to run one-token cached steps thereafter, embedding only the newest per-context token, applying positional offsets, and returning per-context next-token logits plus updated caches.
- Updated sampling loop in `sample.py` to perform a single prefill via `model.generate_multicontext_step(...)` and then iterate using one-token cached calls to generate continuations.
- Added optional `start_index`/`position` support to positional helpers in `variations/position_encoding_variations.py` and `variations/absolute_position_variations.py` so RoPE and absolute embeddings can be applied with an offset for cached steps.

### Testing
- Successfully ran `python3 -m compileall variations/attention_variations.py variations/block_variations.py variations/position_encoding_variations.py variations/absolute_position_variations.py model.py sample.py` which compiled the modified modules without syntax errors.
- Attempted a functional smoke test that builds a small `GPT` instance and exercises `generate_multicontext_step` (embedding/prefill + one-step cached call) but the runtime attempted inside the automation failed with `ModuleNotFoundError: No module named 'torch'` due to the test environment lacking PyTorch, so the smoke assertions could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a6ca848dc8326a9e6a02d28d55533)