### PR TITLE
Add robust lm_head vocab histogram logging

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -24,12 +24,13 @@ with AdamW, then compares their statistics using `view_model_stats.py`.
 
 ## lm_head Vocab Magnitude Histogram
 
-`lm_head_vocab_histogram_demo.sh` runs a short `shakespeare_char` training job
-with optional `lm_head` vocabulary-vector magnitude histogram logging enabled.
-It writes TensorBoard histogram/distribution data over time and exports an
-interactive HTML report with sortable vocab bars and frame navigation. The HTML
-export keeps a bounded number of snapshots by default to avoid very large files
-for large vocabularies.
+`lm_head_vocab_histogram_demo.sh` runs two short `shakespeare_char` training
+jobs with optional `lm_head` vocabulary-vector magnitude histogram logging
+enabled: a baseline run and a run with `--norm_variant_lm_head
+cappedhyperspherenorm`. It writes TensorBoard histogram/distribution data over
+time and exports an interactive HTML report with sortable vocab bars and frame
+navigation for each experiment. The HTML export keeps a bounded number of
+snapshots by default to avoid very large files for large vocabularies.
 
 ```bash
 bash demos/lm_head_vocab_histogram_demo.sh

--- a/demos/README.md
+++ b/demos/README.md
@@ -22,6 +22,19 @@ python3 demos/check_ckpt_for_gelu_shift.py \
 `adam_vs_adamw.sh` trains two tiny Shakespeare models, one with Adam and one
 with AdamW, then compares their statistics using `view_model_stats.py`.
 
+## lm_head Vocab Magnitude Histogram
+
+`lm_head_vocab_histogram_demo.sh` runs a short `shakespeare_char` training job
+with optional `lm_head` vocabulary-vector magnitude histogram logging enabled.
+It writes TensorBoard histogram/distribution data over time and exports an
+interactive HTML report with sortable vocab bars and frame navigation. The HTML
+export keeps a bounded number of snapshots by default to avoid very large files
+for large vocabularies.
+
+```bash
+bash demos/lm_head_vocab_histogram_demo.sh
+```
+
 ## Grouped Asymmetric Vector PTQ Comparison
 
 `fake_ptq_asymmetric_grouped_vector_eval_demo_shakespeare_char.sh` runs a

--- a/demos/lm_head_vocab_histogram_demo.sh
+++ b/demos/lm_head_vocab_histogram_demo.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Quick demo: train a tiny Shakespeare-char model while logging TensorBoard
+# histograms and an HTML animation of lm_head vocab-vector magnitudes.
+set -euo pipefail
+
+OUT_DIR="out/lm_head_vocab_hist_demo"
+RUN_NAME="lm_head_vocab_hist_demo"
+
+python3 train.py \
+  --dataset shakespeare_char \
+  --out_dir "${OUT_DIR}" \
+  --n_layer 2 \
+  --n_head 2 \
+  --n_embd 128 \
+  --block_size 128 \
+  --batch_size 32 \
+  --max_iters 200 \
+  --eval_interval 50 \
+  --eval_iters 20 \
+  --log_interval 10 \
+  --learning_rate 1e-3 \
+  --tensorboard_log \
+  --tensorboard_run_name "${RUN_NAME}" \
+  --log_lm_head_vocab_hist \
+  --log_lm_head_vocab_hist_interval 10 \
+  --export_lm_head_vocab_hist_html \
+  --lm_head_vocab_hist_max_snapshots 32 \
+  --lm_head_vocab_hist_html_path "${OUT_DIR}/lm_head_vocab_histogram.html"
+
+cat <<MSG
+Done.
+TensorBoard:
+  tensorboard --logdir logs
+  tag: shakespeare_char/lm_head_vocab_vector_magnitude
+HTML:
+  ${OUT_DIR}/lm_head_vocab_histogram.html
+MSG

--- a/demos/lm_head_vocab_histogram_demo.sh
+++ b/demos/lm_head_vocab_histogram_demo.sh
@@ -1,37 +1,58 @@
 #!/bin/bash
-# Quick demo: train a tiny Shakespeare-char model while logging TensorBoard
-# histograms and an HTML animation of lm_head vocab-vector magnitudes.
+# Quick demo: compare tiny Shakespeare-char runs while logging TensorBoard
+# histograms and HTML animations of lm_head vocab-vector magnitudes.
 set -euo pipefail
 
-OUT_DIR="out/lm_head_vocab_hist_demo"
-RUN_NAME="lm_head_vocab_hist_demo"
+BASE_OUT_DIR="out/lm_head_vocab_hist_demo"
+LOG_INTERVAL=10
+MAX_SNAPSHOTS=32
 
-python3 train.py \
-  --dataset shakespeare_char \
-  --out_dir "${OUT_DIR}" \
-  --n_layer 2 \
-  --n_head 2 \
-  --n_embd 128 \
-  --block_size 128 \
-  --batch_size 32 \
-  --max_iters 200 \
-  --eval_interval 50 \
-  --eval_iters 20 \
-  --log_interval 10 \
-  --learning_rate 1e-3 \
-  --tensorboard_log \
-  --tensorboard_run_name "${RUN_NAME}" \
-  --log_lm_head_vocab_hist \
-  --log_lm_head_vocab_hist_interval 10 \
-  --export_lm_head_vocab_hist_html \
-  --lm_head_vocab_hist_max_snapshots 32 \
-  --lm_head_vocab_hist_html_path "${OUT_DIR}/lm_head_vocab_histogram.html"
+COMMON_TRAIN_ARGS=(
+  --dataset shakespeare_char
+  --n_layer 2
+  --n_head 2
+  --n_embd 128
+  --block_size 128
+  --batch_size 32
+  --max_iters 200
+  --eval_interval 50
+  --eval_iters 20
+  --log_interval "${LOG_INTERVAL}"
+  --learning_rate 1e-3
+  --tensorboard_log
+  --log_lm_head_vocab_hist
+  --log_lm_head_vocab_hist_interval "${LOG_INTERVAL}"
+  --export_lm_head_vocab_hist_html
+  --lm_head_vocab_hist_max_snapshots "${MAX_SNAPSHOTS}"
+)
+
+run_experiment() {
+  local name="$1"
+  shift
+
+  local out_dir="${BASE_OUT_DIR}/${name}"
+  local run_name="lm_head_vocab_hist_${name}"
+
+  echo "=== Running ${name} ==="
+  python3 train.py \
+    "${COMMON_TRAIN_ARGS[@]}" \
+    --out_dir "${out_dir}" \
+    --tensorboard_run_name "${run_name}" \
+    --lm_head_vocab_hist_html_path "${out_dir}/lm_head_vocab_histogram.html" \
+    "$@"
+}
+
+run_experiment "baseline"
+run_experiment "capped_hyperspherenorm_lm_head" \
+  --norm_variant_lm_head cappedhyperspherenorm
 
 cat <<MSG
 Done.
 TensorBoard:
   tensorboard --logdir logs
-  tag: shakespeare_char/lm_head_vocab_vector_magnitude
-HTML:
-  ${OUT_DIR}/lm_head_vocab_histogram.html
+  tags:
+    shakespeare_char/lm_head_vocab_vector_magnitude
+HTML reports:
+  ${BASE_OUT_DIR}/baseline/lm_head_vocab_histogram.html
+  ${BASE_OUT_DIR}/capped_hyperspherenorm_lm_head/lm_head_vocab_histogram.html
 MSG

--- a/train.py
+++ b/train.py
@@ -112,6 +112,8 @@ class Trainer:
         self.zeus_enabled = False
         self.zeus_total_energy_j = 0.0
         self.zeus_total_time_s = 0.0
+        self.writer = None
+        self.lm_head_hist_snapshots = deque(maxlen=self.args.lm_head_vocab_hist_max_snapshots)
         self.zeus_train_step_energy_j = 0.0
         self.zeus_train_energy_j_total = 0.0
         self.zeus_best_train_step_energy_j = 0.0
@@ -1399,6 +1401,150 @@ class Trainer:
             return 0.0
         return vocab_size / math.exp(loss_value)
 
+    def _get_lm_head_for_dataset(self, target_dataset: str):
+        """Return the lm_head module for regular and multicontext models."""
+        model = getattr(self.raw_model, "_orig_mod", self.raw_model)
+        lm_head = getattr(model, "lm_head", None)
+        if self.args.training_mode == "multicontext" and hasattr(model, "transformer"):
+            dataset_idx = 0
+            if self.args.multicontext_datasets:
+                try:
+                    dataset_idx = self.args.multicontext_datasets.index(target_dataset)
+                except ValueError:
+                    dataset_idx = 0
+            lm_head_key = f"lm_head_{dataset_idx}"
+            if lm_head_key in model.transformer:
+                lm_head = model.transformer[lm_head_key]
+        return lm_head
+
+    def _lm_head_vocab_magnitudes(self, target_dataset: str):
+        lm_head = self._get_lm_head_for_dataset(target_dataset)
+        if lm_head is None or not hasattr(lm_head, "weight"):
+            return None
+        with torch.no_grad():
+            return lm_head.weight.detach().norm(dim=1).float().cpu()
+
+    def _should_sample_lm_head_hist(self) -> bool:
+        return self.iter_num % self.args.log_lm_head_vocab_hist_interval == 0
+
+    def _log_lm_head_vocab_magnitude_histogram(self, target_dataset: str) -> None:
+        if (
+            not self.args.tensorboard_log
+            or self.writer is None
+            or not self.args.log_lm_head_vocab_hist
+            or not self._should_sample_lm_head_hist()
+        ):
+            return
+        magnitudes = self._lm_head_vocab_magnitudes(target_dataset)
+        if magnitudes is None:
+            return
+        self.writer.add_histogram(
+            f"{target_dataset}/lm_head_vocab_vector_magnitude",
+            magnitudes,
+            self.iter_num,
+        )
+
+    def _get_vocab_label_parts(self, token_id: int) -> tuple[str, str]:
+        token_text = None
+        if hasattr(self, "itos") and self.itos is not None and token_id < len(self.itos):
+            token_text = self.itos[token_id]
+        elif hasattr(self, "decode") and callable(self.decode):
+            try:
+                token_text = self.decode([int(token_id)])
+            except Exception:
+                token_text = None
+        if token_text is None:
+            token_text = f"<id:{token_id}>"
+        raw = str(token_text)
+        human = raw.encode("unicode_escape").decode("utf-8")
+        return raw, human
+
+    def _capture_lm_head_hist_snapshot(self, target_dataset: str, tokens_trained: float) -> None:
+        if not self.args.export_lm_head_vocab_hist_html or not self._should_sample_lm_head_hist():
+            return
+        magnitudes = self._lm_head_vocab_magnitudes(target_dataset)
+        if magnitudes is None:
+            return
+        entries = [(i, float(m)) for i, m in enumerate(magnitudes.tolist())]
+        if self.args.lm_head_vocab_hist_top_k > 0:
+            entries = sorted(entries, key=lambda item: (-item[1], item[0]))[:self.args.lm_head_vocab_hist_top_k]
+        vocab_data = []
+        for i, magnitude in entries:
+            token_raw, token_display = self._get_vocab_label_parts(i)
+            vocab_data.append({"id": i, "magnitude": magnitude, "token_raw": token_raw, "token_display": token_display})
+        self.lm_head_hist_snapshots.append({
+            "iter_num": int(self.iter_num),
+            "tokens_trained": float(tokens_trained),
+            "dataset": target_dataset,
+            "vocab": vocab_data,
+        })
+
+    def _export_lm_head_vocab_histogram_html(self) -> None:
+        if not self.args.export_lm_head_vocab_hist_html:
+            return
+        if len(self.lm_head_hist_snapshots) == 0:
+            print("Skipping lm_head vocab histogram HTML export: no snapshots captured.")
+            return
+        out_path = self.args.lm_head_vocab_hist_html_path or os.path.join(
+            self.args.out_dir, "lm_head_vocab_histogram.html"
+        )
+        dirpath = os.path.dirname(out_path)
+        if dirpath:
+            os.makedirs(dirpath, exist_ok=True)
+        payload = json.dumps(list(self.lm_head_hist_snapshots)).replace("</", "<\\/")
+        html_text = f"""<!doctype html>
+<html><head><meta charset="utf-8"><title>lm_head vocab histogram</title></head>
+<body>
+<h2>lm_head vocabulary vector magnitudes over time</h2>
+<label for="sortBy">Sort by:</label>
+<select id="sortBy">
+  <option value="id_asc">Vocab ID (low to high)</option>
+  <option value="id_desc">Vocab ID (high to low)</option>
+  <option value="mag_desc">Magnitude (high to low)</option>
+  <option value="mag_asc">Magnitude (low to high)</option>
+</select>
+<button id="prevFrame" type="button">◀ Prev</button>
+<button id="nextFrame" type="button">Next ▶</button>
+<span id="frameInfo" style="margin-left:8px;"></span>
+<div style="margin-top:8px;">X-axis is token symbol; hover shows token id + symbol.</div>
+<div id="plot" style="width:100%;height:85vh;"></div>
+<script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+<script id="snapshots-data" type="application/json">{payload}</script>
+<script>
+const snapshots = JSON.parse(document.getElementById('snapshots-data').textContent);
+let frameIndex = snapshots.length - 1;
+function sortedData(mode, frame) {{
+  const d = [...frame.vocab];
+  if (mode === 'id_asc') d.sort((a,b)=>a.id-b.id);
+  if (mode === 'id_desc') d.sort((a,b)=>b.id-a.id);
+  if (mode === 'mag_desc') d.sort((a,b)=>b.magnitude-a.magnitude || a.id-b.id);
+  if (mode === 'mag_asc') d.sort((a,b)=>a.magnitude-b.magnitude || a.id-b.id);
+  return d;
+}}
+function render(mode) {{
+  const frame = snapshots[frameIndex];
+  const d = sortedData(mode, frame);
+  Plotly.react('plot', [{{
+    type: 'bar',
+    x: d.map(v => v.token_display),
+    y: d.map(v => v.magnitude),
+    customdata: d.map(v => [v.id, v.token_display]),
+    hovertemplate: 'id=%{{customdata[0]}}<br>token=%{{customdata[1]}}<br>Magnitude=%{{y:.6f}}<extra></extra>'
+  }}], {{xaxis: {{title: 'Token symbol'}}, yaxis: {{title: 'Vector magnitude (L2 norm)'}}, margin: {{t: 20, l: 60, r: 20, b: 60}}}}, {{responsive: true}});
+  document.getElementById('frameInfo').textContent =
+    `Frame ${{frameIndex + 1}}/${{snapshots.length}} | dataset=${{frame.dataset}} | iter=${{frame.iter_num}} | tokens=${{frame.tokens_trained}}`;
+}}
+const select = document.getElementById('sortBy');
+select.onchange = function() {{ render(this.value); }};
+document.getElementById('prevFrame').onclick = function() {{ frameIndex = Math.max(0, frameIndex - 1); render(select.value); }};
+document.getElementById('nextFrame').onclick = function() {{ frameIndex = Math.min(snapshots.length - 1, frameIndex + 1); render(select.value); }};
+document.addEventListener('keydown', function(e) {{ if (e.key === 'ArrowLeft') document.getElementById('prevFrame').click(); if (e.key === 'ArrowRight') document.getElementById('nextFrame').click(); }});
+render('id_asc');
+</script></body></html>"""
+        with open(out_path, "w", encoding="utf-8") as f:
+            f.write(html_text)
+        print(f"Exported lm_head vocab histogram HTML: {out_path}")
+
     def log_metrics(self, losses, running_mfu, epoch, tokens_trained, target_dataset, val_better_than_chance):
         compute_rankme = self.args.log_rankme or self.args.log_areq
 
@@ -1500,6 +1646,8 @@ class Trainer:
             self._log_zeus_tensorboard(target_dataset, tokens_trained)
             self._log_bit_metrics(target_dataset, tokens_trained)
 
+        self._log_lm_head_vocab_magnitude_histogram(target_dataset)
+        self._capture_lm_head_hist_snapshot(target_dataset, tokens_trained)
 
         if self.args.csv_log:
             # concise training metrics
@@ -1600,6 +1748,9 @@ class Trainer:
 
             self._log_zeus_tensorboard(target_dataset, tokens_trained)
             self._log_bit_metrics(target_dataset, tokens_trained)
+
+        self._log_lm_head_vocab_magnitude_histogram(target_dataset)
+        self._capture_lm_head_hist_snapshot(target_dataset, tokens_trained)
 
     def write_to_csv(self, *args, prefix=""):
         args = list(args)
@@ -2330,6 +2481,8 @@ class Trainer:
                             self.sample_and_print()
                             live.start()
                     break
+
+            self._export_lm_head_vocab_histogram_html()
 
             if self.args.plot_statistics:
                 plot_statistics(self.args, self.stats, graph_y_labels)

--- a/train_args.py
+++ b/train_args.py
@@ -12,6 +12,18 @@ def clean_dataset_path(dataset_name):
     """Removes leading './data/' or 'data/' from dataset paths."""
     return re.sub(r'^(?:\./)?data/', '', dataset_name)
 
+def positive_int(value):
+    ivalue = int(value)
+    if ivalue < 1:
+        raise argparse.ArgumentTypeError(f"{value!r} must be an integer >= 1")
+    return ivalue
+
+def non_negative_int(value):
+    ivalue = int(value)
+    if ivalue < 0:
+        raise argparse.ArgumentTypeError(f"{value!r} must be an integer >= 0")
+    return ivalue
+
 def parse_args():
 
     parser = argparse.ArgumentParser()
@@ -1479,6 +1491,12 @@ def parse_args():
     logging_group.add_argument('--log_all_metrics', default=False, action=argparse.BooleanOptionalAction, help='Enable logging of all metrics including gns')
     logging_group.add_argument('--log_rankme', default=True, action=argparse.BooleanOptionalAction, help='Log RankMe representation metric during validation')
     logging_group.add_argument('--log_areq', default=True, action=argparse.BooleanOptionalAction, help='Log aReQ representation metric during validation')
+    logging_group.add_argument('--log_lm_head_vocab_hist', default=False, action=argparse.BooleanOptionalAction, help='Log TensorBoard histograms of per-token lm_head vector magnitudes')
+    logging_group.add_argument('--log_lm_head_vocab_hist_interval', default=100, type=positive_int, help='Training-step interval for lm_head vocab magnitude histogram logging and HTML snapshot capture')
+    logging_group.add_argument('--export_lm_head_vocab_hist_html', default=False, action=argparse.BooleanOptionalAction, help='Export an interactive HTML report for captured lm_head vocab-vector magnitude snapshots')
+    logging_group.add_argument('--lm_head_vocab_hist_html_path', type=str, default=None, help='Optional output path for lm_head vocab histogram HTML (default: <out_dir>/lm_head_vocab_histogram.html)')
+    logging_group.add_argument('--lm_head_vocab_hist_max_snapshots', default=64, type=positive_int, help='Maximum number of lm_head histogram snapshots kept for HTML export')
+    logging_group.add_argument('--lm_head_vocab_hist_top_k', default=0, type=non_negative_int, help='If >0, store only the top-k tokens by lm_head vector magnitude per HTML snapshot')
 
     # Turn activation/weight statistics off to save CPU RAM and wall time.
     training_group.add_argument(


### PR DESCRIPTION
### Motivation
- Provide optional monitoring of per-token `lm_head` vector magnitudes during training for visibility and debugging. 
- Make the feature safe and performant for large vocabs and multicontext models by avoiding unbounded memory growth and by handling multicontext lm_head lookup correctly. 

### Description
- Add CLI options and validation helpers in `train_args.py` (`--log_lm_head_vocab_hist`, `--log_lm_head_vocab_hist_interval`, `--export_lm_head_vocab_hist_html`, `--lm_head_vocab_hist_html_path`, `--lm_head_vocab_hist_max_snapshots`, `--lm_head_vocab_hist_top_k`) with `positive_int` / `non_negative_int` types. 
- Initialize a bounded `deque` for HTML snapshots and a `writer` placeholder in `Trainer.__init__`, and add demo + README entries under `demos/`. 
- Implement multicontext-safe `lm_head` retrieval that unwraps compiled models and indexes the `ModuleDict` instead of using `.get()`, plus functions to compute magnitudes, decide sampling interval, log TensorBoard histograms, capture snapshots (with optional top-k trimming), and export a safe interactive HTML report with escaped/JSON-embedded snapshot data. 
- Wire histogram logging and snapshot capture into both validation and non-validation logging paths and export the HTML on normal training exit, and guard filesystem operations for filename-only paths. 

### Testing
- Ran Python byte-compile on the modified files with `python3 -m py_compile train.py train_args.py` which succeeded. 
- Ran a repository sanity check with `git diff --check` which reported no problems. 
- Attempted to exercise the parser with `python3 train_args.py --log_lm_head_vocab_hist_interval 0`, but the run was blocked by a missing runtime dependency (`torch`) in the environment so full execution could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e575c6c908326aca3d92d5812d3a3)