### PR TITLE
Improve multicontext compile sampling path

### DIFF
--- a/model.py
+++ b/model.py
@@ -948,6 +948,20 @@ class GPT(nn.Module):
         return mfu
 
     @torch.no_grad()
+    def generate_multicontext_step(self, token_dict, target_dict=None, iter_num=None):
+        """Run one multicontext decode step and return per-context logits.
+
+        This intentionally small wrapper exists so sampling can compile the
+        decode step without compiling every prefill/forward shape observed while
+        prompts grow. ``token_dict`` should contain the current per-context
+        conditioning tensors; callers that maintain a KV cache can pass only the
+        latest token, while callers without one can pass the cropped context.
+        """
+        if not self.config.multicontext:
+            raise ValueError("generate_multicontext_step requires a multicontext model")
+        return self(idx=None, token_dict=token_dict, target_dict=target_dict, iter_num=iter_num)
+
+    @torch.no_grad()
     def generate(self, idx, max_new_tokens, temperature=1.0, top_k=None):
         """
         Take a conditioning sequence of indices idx (LongTensor of shape (b,t)) and complete

--- a/sample.py
+++ b/sample.py
@@ -1622,7 +1622,8 @@ def main():
         print_module_structure(model)
 
 
-    if args.compile:
+    compiled_multicontext_step = None
+    if args.compile and not args.multicontext:
         model = torch.compile(model)
 
     # Inference with different block size (note: for this one cannot use abs pos embeddings)
@@ -1636,6 +1637,12 @@ def main():
     # Inference with different Rope Length
     if args.rope_length:
         model.update_rope_length(args.rope_length)
+
+    if args.compile and args.multicontext:
+        # Multicontext prompts commonly have prompt-dependent prefill shapes.
+        # Keep those uncompiled and compile only the small decode-step wrapper
+        # that sample generation calls from inside the loop.
+        compiled_multicontext_step = torch.compile(model.generate_multicontext_step)
 
     if args.eval_only:
         print("Running in eval_only mode...")
@@ -1810,7 +1817,8 @@ def main():
                         tokens = token_state[name]
                         idx_cond_dict[name] = tokens if tokens.size(1) <= block_size else tokens[:, -block_size:]
 
-                    logits_list, _ = model(None, token_dict=idx_cond_dict, target_dict=None)
+                    multicontext_step = compiled_multicontext_step or model.generate_multicontext_step
+                    logits_list, _ = multicontext_step(idx_cond_dict)
 
                     for i, name in enumerate(dataset_names):
                         if model.config.numerical_multicontext:

--- a/tests/test_multicontext_compile_step.py
+++ b/tests/test_multicontext_compile_step.py
@@ -1,0 +1,70 @@
+import unittest
+
+import torch
+
+from gpt_conf import GPTConfig
+from model import GPT
+
+
+class MulticontextCompileStepTest(unittest.TestCase):
+    def _build_model(self):
+        cfg = GPTConfig(
+            block_size=8,
+            vocab_size=16,
+            n_layer=1,
+            n_head=2,
+            n_kv_group=2,
+            n_embd=8,
+            dropout=0.0,
+            multicontext=True,
+            vocab_sizes=[11, 13],
+            use_abs_pos_embeddings=False,
+            disable_flash_attention=True,
+        )
+        model = GPT(cfg)
+        model.eval()
+        return model
+
+    def test_generate_multicontext_step_matches_forward_logits_list(self):
+        torch.manual_seed(1234)
+        model = self._build_model()
+        token_dict = {
+            "ctx_a": torch.tensor([[1, 2, 3]], dtype=torch.long),
+            "ctx_b": torch.tensor([[4, 5, 6]], dtype=torch.long),
+        }
+
+        forward_logits, forward_losses = model(None, token_dict=token_dict, target_dict=None)
+        step_logits, step_losses = model.generate_multicontext_step(token_dict)
+
+        self.assertIsNone(forward_losses)
+        self.assertIsNone(step_losses)
+        self.assertEqual(len(step_logits), len(forward_logits))
+        self.assertEqual([tuple(logits.shape) for logits in step_logits], [(1, 1, 11), (1, 1, 13)])
+        for expected, actual in zip(forward_logits, step_logits):
+            self.assertTrue(torch.allclose(expected, actual, atol=0.0, rtol=0.0))
+
+    def test_compiled_generate_multicontext_step_preserves_logits_list_shapes(self):
+        torch.manual_seed(5678)
+        model = self._build_model()
+        token_dict = {
+            "ctx_a": torch.tensor([[5]], dtype=torch.long),
+            "ctx_b": torch.tensor([[9]], dtype=torch.long),
+        }
+
+        eager_logits, eager_losses = model.generate_multicontext_step(token_dict)
+        compiled_step = torch.compile(model.generate_multicontext_step, backend="eager")
+        compiled_logits, compiled_losses = compiled_step(token_dict)
+
+        self.assertIsNone(eager_losses)
+        self.assertIsNone(compiled_losses)
+        self.assertEqual(len(compiled_logits), len(eager_logits))
+        self.assertEqual(
+            [tuple(logits.shape) for logits in compiled_logits],
+            [tuple(logits.shape) for logits in eager_logits],
+        )
+        for expected, actual in zip(eager_logits, compiled_logits):
+            self.assertTrue(torch.allclose(expected, actual, atol=1e-6, rtol=1e-6))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Multicontext sampling uses prompt-dependent prefill shapes which make compiling the entire forward path brittle and inefficient, so only the one-token decode step should be compiled.
- Keep the heavier prefill/encode path uncompiled (or separately compiled) because it runs once per prompt and has varying shapes.

### Description
- Add a small no-grad wrapper `GPT.generate_multicontext_step(token_dict, target_dict=None, iter_num=None)` that runs a single multicontext decode step and returns the per-context logits list for targeted compilation.
- Update `sample.py` to avoid compiling the full model when `--multicontext` is enabled and `--compile` is set, instead compiling only `model.generate_multicontext_step` and routing the generation loop through that compiled wrapper when available.
- Preserve the original compile behavior for non-multicontext usage by compiling the whole model when `--compile` and not `--multicontext`.
- Add `tests/test_multicontext_compile_step.py` which verifies that the wrapper reproduces the same logits list as a direct forward call and that compiling the wrapper preserves logits shapes and numeric compatibility.

### Testing
- Ran byte-compilation with `python -m py_compile model.py sample.py tests/test_multicontext_compile_step.py` which succeeded.
- Ran unit tests with `python -m unittest tests.test_multicontext_compile_step tests.test_numerical_multicontext_fp16` and both tests passed (new multicontext compile-step tests and existing numerical multicontext tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a6d1b47dc8326b4209ca4d2ce1327)