### PR TITLE
Add rotation-target probing and nanoGPT checkpoint support; add modular_arithmetic dataset and demo

### DIFF
--- a/analysis/identity/head_special_matrix_probe.py
+++ b/analysis/identity/head_special_matrix_probe.py
@@ -11,7 +11,9 @@ Examples:
 
   python head_special_matrix_probe.py --preset qwen-0.5b --device cuda
 
-  python head_special_matrix_probe.py --preset gemma-3-270m --device cuda --dtype bfloat16
+  python head_special_matrix_probe.py --preset gemma-3-270m-it --device cuda --dtype bfloat16
+
+  python head_special_matrix_probe.py --preset smollm2-135m-instruct --device cuda --dtype bfloat16
 
   python head_special_matrix_probe.py \
     --model google/gemma-3-270m \
@@ -47,7 +49,12 @@ def parse_args():
     p.add_argument(
         "--preset",
         default=None,
-        choices=["qwen-0.5b", "gemma-3-270m"],
+        choices=[
+            "qwen-0.5b",
+            "gemma-3-270m",
+            "gemma-3-270m-it",
+            "smollm2-135m-instruct",
+        ],
     )
     p.add_argument("--device", default="cuda", choices=["cuda", "cpu", "mps"])
     p.add_argument("--dtype", default="float16",
@@ -82,6 +89,13 @@ def apply_preset(args):
     elif args.preset == "gemma-3-270m":
         args.model = "google/gemma-3-270m"
         args.trust_remote_code = True
+
+    elif args.preset == "gemma-3-270m-it":
+        args.model = "google/gemma-3-270m-it"
+        args.trust_remote_code = True
+
+    elif args.preset == "smollm2-135m-instruct":
+        args.model = "HuggingFaceTB/SmolLM2-135M-Instruct"
 
     return args
 
@@ -177,6 +191,34 @@ def frob(A, B):
     return torch.linalg.norm(A - B).item()
 
 
+def get_hf_decoder_layers(model):
+    layer_roots = [
+        getattr(model, "model", None),
+        getattr(getattr(model, "model", None), "language_model", None),
+        getattr(model, "language_model", None),
+        getattr(getattr(model, "transformer", None), "h", None),
+    ]
+    for root in layer_roots:
+        if root is None:
+            continue
+        if hasattr(root, "layers"):
+            return root.layers
+        if hasattr(root, "h"):
+            return root.h
+        if isinstance(root, (list, torch.nn.ModuleList)):
+            return root
+    raise ValueError("Could not find decoder layers on the HuggingFace model.")
+
+
+def get_hf_config_value(config, name, default=None):
+    if hasattr(config, name):
+        return getattr(config, name)
+    text_config = getattr(config, "text_config", None)
+    if text_config is not None and hasattr(text_config, name):
+        return getattr(text_config, name)
+    return default
+
+
 def load_hf_model(args, dtype):
     print(f"Loading model: {args.model}")
     model = AutoModelForCausalLM.from_pretrained(
@@ -188,10 +230,10 @@ def load_hf_model(args, dtype):
     model.eval()
 
     cfg = model.config
-    hidden = cfg.hidden_size
-    config_heads = getattr(cfg, "num_attention_heads", None)
-    config_kv_heads = getattr(cfg, "num_key_value_heads", None)
-    layers = model.model.layers
+    hidden = get_hf_config_value(cfg, "hidden_size")
+    config_heads = get_hf_config_value(cfg, "num_attention_heads")
+    config_kv_heads = get_hf_config_value(cfg, "num_key_value_heads")
+    layers = get_hf_decoder_layers(model)
     return model, layers, hidden, config_heads, config_kv_heads, "hf"
 
 

--- a/analysis/identity/head_special_matrix_probe.py
+++ b/analysis/identity/head_special_matrix_probe.py
@@ -3,7 +3,9 @@
 head_special_matrix_probe.py
 
 Only generates per-layer/per-head heatmaps for whether W_O^h W_V^h
-resembles identity, inverse/rotation-like, projection-like, etc.
+resembles identity, inverse/rotation-like, projection-like, etc. It also tests
+whether the equivalent head-space value/output map W_V^h W_O^h resembles
+specified block-diagonal 2D rotations.
 
 Examples:
 
@@ -16,6 +18,12 @@ Examples:
     --device cuda \
     --dtype bfloat16 \
     --trust-remote-code
+
+  python head_special_matrix_probe.py \
+    --preset qwen-0.5b \
+    --rotation-min-deg 5 \
+    --rotation-max-deg 45 \
+    --rotation-step-deg 5
 """
 
 import argparse
@@ -27,6 +35,9 @@ import torch.nn.functional as F
 import numpy as np
 import matplotlib.pyplot as plt
 from transformers import AutoModelForCausalLM
+
+from model import GPT
+from gpt_conf import GPTConfig
 
 
 def parse_args():
@@ -43,9 +54,23 @@ def parse_args():
                    choices=["float16", "bfloat16", "float32"])
     p.add_argument("--outdir", default="./head_special_matrix_out")
     p.add_argument("--trust-remote-code", action="store_true")
+    p.add_argument("--ckpt", default=None, help="Optional local nanoGPT checkpoint path to probe instead of a HuggingFace model.")
     p.add_argument("--max-layers", type=int, default=None)
     p.add_argument("--show", action="store_true")
     p.add_argument("--dpi", type=int, default=200)
+    p.add_argument(
+        "--rotation-degrees",
+        type=float,
+        nargs="*",
+        default=None,
+        help=(
+            "Explicit head-space rotation angles in degrees to test. "
+            "Overrides --rotation-min-deg/--rotation-max-deg/--rotation-step-deg."
+        ),
+    )
+    p.add_argument("--rotation-min-deg", type=float, default=10.0)
+    p.add_argument("--rotation-max-deg", type=float, default=35.0)
+    p.add_argument("--rotation-step-deg", type=float, default=5.0)
 
     return p.parse_args()
 
@@ -67,6 +92,57 @@ def get_dtype(name):
     if name == "bfloat16":
         return torch.bfloat16
     return torch.float32
+
+
+def format_degree_label(deg):
+    return f"{deg:g}".replace("-", "neg_").replace(".", "p")
+
+
+def get_rotation_degrees(args):
+    if args.rotation_degrees is not None:
+        degrees = args.rotation_degrees
+    else:
+        if args.rotation_step_deg <= 0:
+            raise ValueError("--rotation-step-deg must be positive.")
+        if args.rotation_min_deg > args.rotation_max_deg:
+            raise ValueError("--rotation-min-deg must be <= --rotation-max-deg.")
+
+        degrees = []
+        current = args.rotation_min_deg
+        # Include the max endpoint despite small floating-point accumulation error.
+        while current <= args.rotation_max_deg + (args.rotation_step_deg * 1e-9):
+            degrees.append(current)
+            current += args.rotation_step_deg
+
+    # Preserve order while removing duplicates from equivalent display labels.
+    seen = set()
+    unique = []
+    for degree in degrees:
+        label = format_degree_label(degree)
+        if label not in seen:
+            seen.add(label)
+            unique.append(float(degree))
+    return unique
+
+
+def rotation_matrix_2d_blocks(dim, degrees, device):
+    """Return a block-diagonal 2D rotation target for head-space matrices.
+
+    Each adjacent coordinate pair gets the same 2D rotation. If dim is odd, the
+    final unpaired coordinate is left as identity. This gives a concrete
+    same-dimensional target for V_hO_h that can detect whether the equivalent
+    value/output map acts like a specified rotation inside the head subspace.
+    """
+    theta = torch.tensor(np.deg2rad(degrees), dtype=torch.float32, device=device)
+    c = torch.cos(theta)
+    s = torch.sin(theta)
+    R = torch.eye(dim, dtype=torch.float32, device=device)
+    for i in range(0, dim - 1, 2):
+        R[i, i] = c
+        R[i, i + 1] = -s
+        R[i + 1, i] = s
+        R[i + 1, i + 1] = c
+    return R
 
 
 def save_heatmap(arr, title, xlabel, ylabel, cbar, path, dpi=200, show=False):
@@ -101,6 +177,73 @@ def frob(A, B):
     return torch.linalg.norm(A - B).item()
 
 
+def load_hf_model(args, dtype):
+    print(f"Loading model: {args.model}")
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model,
+        torch_dtype=dtype,
+        device_map=None,
+        trust_remote_code=args.trust_remote_code,
+    ).to(args.device)
+    model.eval()
+
+    cfg = model.config
+    hidden = cfg.hidden_size
+    config_heads = getattr(cfg, "num_attention_heads", None)
+    config_kv_heads = getattr(cfg, "num_key_value_heads", None)
+    layers = model.model.layers
+    return model, layers, hidden, config_heads, config_kv_heads, "hf"
+
+
+def load_nanogpt_checkpoint(args):
+    print(f"Loading nanoGPT checkpoint: {args.ckpt}")
+    checkpoint = torch.load(args.ckpt, map_location=args.device)
+    model_args = checkpoint["model_args"]
+    config = GPTConfig(**model_args)
+    model = GPT(config)
+
+    state_dict = checkpoint["model"]
+    for key in list(state_dict.keys()):
+        if key.startswith("_orig_mod."):
+            state_dict[key[len("_orig_mod."):]] = state_dict.pop(key)
+    model.load_state_dict(state_dict)
+    model.to(args.device)
+    model.eval()
+
+    hidden = config.n_embd
+    config_heads = config.n_head
+    config_kv_heads = config.n_kv_group if config.n_kv_group is not None else config.n_head
+    layers = model.transformer.h
+    return model, layers, hidden, config_heads, config_kv_heads, "nanogpt"
+
+
+def get_attention_weights(block, model_kind):
+    if model_kind == "hf":
+        attn = block.self_attn
+        return (
+            attn.q_proj.weight.detach().float(),
+            attn.k_proj.weight.detach().float(),
+            attn.v_proj.weight.detach().float(),
+            attn.o_proj.weight.detach().float(),
+        )
+
+    attn = block.attn
+    if not all(hasattr(attn, name) for name in ("c_attn_q", "c_attn_k", "c_attn_v", "c_proj")):
+        raise ValueError(
+            "Local checkpoint attention module must expose c_attn_q, c_attn_k, "
+            "c_attn_v, and c_proj weights for this probe."
+        )
+    if hasattr(attn, "c_proj_list"):
+        raise ValueError("c_proj_list attention variants are not supported by this probe yet.")
+
+    return (
+        attn.c_attn_q.weight.detach().float(),
+        attn.c_attn_k.weight.detach().float(),
+        attn.c_attn_v.weight.detach().float(),
+        attn.c_proj.weight.detach().float(),
+    )
+
+
 def infer_head_shapes(Wq, Wk, Wv, Wo, hidden, config_heads=None):
     if config_heads is not None and Wq.shape[0] % config_heads == 0:
         head_dim = Wq.shape[0] // config_heads
@@ -125,27 +268,18 @@ def main():
         print("CUDA not available; falling back to CPU.")
         args.device = "cpu"
 
-    print(f"Loading model: {args.model}")
+    rotation_degrees = get_rotation_degrees(args)
+    print("rotation degree targets:", rotation_degrees)
 
-    model = AutoModelForCausalLM.from_pretrained(
-        args.model,
-        torch_dtype=dtype,
-        device_map=None,
-        trust_remote_code=args.trust_remote_code,
-    ).to(args.device)
-
-    model.eval()
-
-    cfg = model.config
-    hidden = cfg.hidden_size
-    config_heads = getattr(cfg, "num_attention_heads", None)
-    config_kv_heads = getattr(cfg, "num_key_value_heads", None)
+    if args.ckpt:
+        model, layers, hidden, config_heads, config_kv_heads, model_kind = load_nanogpt_checkpoint(args)
+    else:
+        model, layers, hidden, config_heads, config_kv_heads, model_kind = load_hf_model(args, dtype)
 
     print("hidden:", hidden)
     print("config num_attention_heads:", config_heads)
     print("config num_key_value_heads:", config_kv_heads)
 
-    layers = model.model.layers
     if args.max_layers is not None:
         layers = layers[:args.max_layers]
 
@@ -176,17 +310,24 @@ def main():
         "cos_headspace_VO_I",
     ]
 
+    rotation_metric_names = []
+    rotation_metric_degrees = []
+    for degree in rotation_degrees:
+        label = format_degree_label(degree)
+        rotation_metric_names.extend([
+            f"rel_frob_headspace_VO_rotation_{label}deg",
+            f"cos_headspace_VO_rotation_{label}deg",
+        ])
+        rotation_metric_degrees.append((degree, label))
+
+    metric_names.extend(rotation_metric_names)
+
     scores = {m: [] for m in metric_names}
     rows = []
 
     with torch.no_grad():
         for layer_idx, block in enumerate(layers):
-            attn = block.self_attn
-
-            Wq = attn.q_proj.weight.detach().float()
-            Wk = attn.k_proj.weight.detach().float()
-            Wv = attn.v_proj.weight.detach().float()
-            Wo = attn.o_proj.weight.detach().float()
+            Wq, Wk, Wv, Wo = get_attention_weights(block, model_kind)
 
             head_dim, q_heads, k_heads, v_heads, o_heads = infer_head_shapes(
                 Wq, Wk, Wv, Wo, hidden, config_heads
@@ -212,6 +353,10 @@ def main():
             I_hidden = torch.eye(hidden, dtype=torch.float32, device=Wv.device)
             neg_I_hidden = -I_hidden
             I_head = torch.eye(head_dim, dtype=torch.float32, device=Wv.device)
+            rotation_targets = {
+                label: rotation_matrix_2d_blocks(head_dim, degree, Wv.device)
+                for degree, label in rotation_metric_degrees
+            }
 
             layer_metric_scores = {m: [] for m in metric_names}
 
@@ -258,6 +403,11 @@ def main():
 
                 values["rel_frob_headspace_VO_I"] = rel_frob(VO, I_head)
                 values["cos_headspace_VO_I"] = cosine_to(VO, I_head)
+
+                for degree, label in rotation_metric_degrees:
+                    R_head = rotation_targets[label]
+                    values[f"rel_frob_headspace_VO_rotation_{label}deg"] = rel_frob(VO, R_head)
+                    values[f"cos_headspace_VO_rotation_{label}deg"] = cosine_to(VO, R_head)
 
                 for m in metric_names:
                     layer_metric_scores[m].append(values[m])
@@ -326,6 +476,16 @@ def main():
         "rel_frob_headspace_VO_I": "V_hO_h relative distance to head identity, lower = more inverse-like in head space",
         "cos_headspace_VO_I": "V_hO_h cosine to head identity, higher = more inverse-like in head space",
     }
+
+    for degree, label in rotation_metric_degrees:
+        descriptions[f"rel_frob_headspace_VO_rotation_{label}deg"] = (
+            f"V_hO_h relative distance to a {degree:g}° block-diagonal head-space rotation, "
+            "lower = more like that equivalent Wv/Wo rotation"
+        )
+        descriptions[f"cos_headspace_VO_rotation_{label}deg"] = (
+            f"V_hO_h cosine to a {degree:g}° block-diagonal head-space rotation, "
+            "higher = more like that equivalent Wv/Wo rotation"
+        )
 
     for m in metric_names:
         arr = np.array(scores[m], dtype=float)

--- a/data/modular_arithmetic/README.md
+++ b/data/modular_arithmetic/README.md
@@ -1,0 +1,15 @@
+# Modular arithmetic grokking dataset
+
+This dataset recreates the modular addition setup used in classic grokking
+experiments: train on a random subset of all ordered pairs `(a, b)` for
+`a + b mod p`, hold out the remaining pairs for validation, and repeat the small
+training set many times so `train.py` sees a long token stream.
+
+```bash
+cd data/modular_arithmetic
+python3 prepare.py --modulus 113 --train-fraction 0.3 --train-repeats 200 --val-repeats 20
+```
+
+The script writes `train.bin`, `val.bin`, and `meta.pkl` in the same format used
+by `data/template/prepare.py` and consumed by `train.py`. It also writes
+`train.txt`, `val.txt`, and `manifest.json` for inspection.

--- a/data/modular_arithmetic/prepare.py
+++ b/data/modular_arithmetic/prepare.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Prepare modular arithmetic data for grokking experiments.
+
+This creates the standard nanoGPT train.bin/val.bin/meta.pkl artifacts from all
+ordered pairs (a, b) for modular addition: "a+b=c\n" where c=(a+b) mod p.
+The default train split is a random subset of equations, while validation holds
+out the remaining equations, matching the train/held-out split used in modular
+addition grokking demos.
+"""
+
+import argparse
+import json
+import pickle
+import random
+from pathlib import Path
+
+from array import array
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Create a modular addition grokking dataset.")
+    parser.add_argument("--modulus", type=int, default=113, help="Prime modulus p for a+b mod p.")
+    parser.add_argument("--train-fraction", type=float, default=0.3, help="Fraction of equations used for training.")
+    parser.add_argument("--train-repeats", type=int, default=200, help="How often to repeat the train equation set.")
+    parser.add_argument("--val-repeats", type=int, default=20, help="How often to repeat the held-out equation set.")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed for the train/val split and train order.")
+    parser.add_argument("--operator", default="+", choices=["+"], help="Operation to render; currently modular addition.")
+    parser.add_argument("--out-dir", default=".", help="Directory for train.bin, val.bin, and meta.pkl.")
+    parser.add_argument("--write-text", action=argparse.BooleanOptionalAction, default=True, help="Also write train.txt and val.txt.")
+    return parser.parse_args()
+
+
+def encode_examples(examples, stoi):
+    text = "".join(examples)
+    ids = array("H", (stoi[ch] for ch in text))
+    return ids, text
+
+
+def main():
+    args = parse_args()
+    if args.modulus <= 1:
+        raise ValueError("--modulus must be greater than 1")
+    if not 0 < args.train_fraction < 1:
+        raise ValueError("--train-fraction must be between 0 and 1")
+    if args.train_repeats < 1 or args.val_repeats < 1:
+        raise ValueError("repeat counts must be positive")
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    rng = random.Random(args.seed)
+
+    equations = [
+        f"{a}{args.operator}{b}={(a + b) % args.modulus}\n"
+        for a in range(args.modulus)
+        for b in range(args.modulus)
+    ]
+    rng.shuffle(equations)
+    split = int(len(equations) * args.train_fraction)
+    train_equations = equations[:split]
+    val_equations = equations[split:]
+
+    train_examples = train_equations * args.train_repeats
+    val_examples = val_equations * args.val_repeats
+    rng.shuffle(train_examples)
+
+    chars = sorted(set("".join(equations)))
+    stoi = {ch: i for i, ch in enumerate(chars)}
+    itos = {i: ch for ch, i in stoi.items()}
+
+    train_ids, train_text = encode_examples(train_examples, stoi)
+    val_ids, val_text = encode_examples(val_examples, stoi)
+    with open(out_dir / "train.bin", "wb") as f:
+        train_ids.tofile(f)
+    with open(out_dir / "val.bin", "wb") as f:
+        val_ids.tofile(f)
+
+    if args.write_text:
+        (out_dir / "train.txt").write_text(train_text, encoding="utf-8")
+        (out_dir / "val.txt").write_text(val_text, encoding="utf-8")
+
+    meta = {
+        "vocab_size": len(chars),
+        "itos": itos,
+        "stoi": stoi,
+        "tokenizer": "char",
+        "dataset": "modular_arithmetic",
+        "operation": "addition_mod_p",
+        "modulus": args.modulus,
+        "train_fraction": args.train_fraction,
+        "train_equations": len(train_equations),
+        "val_equations": len(val_equations),
+        "train_repeats": args.train_repeats,
+        "val_repeats": args.val_repeats,
+        "seed": args.seed,
+    }
+    with open(out_dir / "meta.pkl", "wb") as f:
+        pickle.dump(meta, f)
+    (out_dir / "manifest.json").write_text(json.dumps(meta, indent=2), encoding="utf-8")
+
+    print(f"Wrote {out_dir / 'train.bin'} ({len(train_ids):,} tokens)")
+    print(f"Wrote {out_dir / 'val.bin'} ({len(val_ids):,} tokens)")
+    print(f"Vocabulary size: {len(chars)}")
+    print(f"Train equations: {len(train_equations):,}; validation equations: {len(val_equations):,}")
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/huggingface_special_matrix_probe_demo.sh
+++ b/demos/huggingface_special_matrix_probe_demo.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Probe pretrained HuggingFace instruction models for special Wv/Wo head matrices.
+# Defaults target:
+#   - google/gemma-3-270m-it
+#   - HuggingFaceTB/SmolLM2-135M-Instruct (the SmolLM URL requested by the demo)
+# The Gemma repository may require accepting Google's Gemma license and having an
+# authenticated Hugging Face token available in the environment.
+
+set -euo pipefail
+
+DEVICE="${DEVICE:-cuda}"
+DTYPE="${DTYPE:-bfloat16}"
+OUT_ROOT="${OUT_ROOT:-out/huggingface_special_matrix_probe}"
+ROTATION_MIN_DEG="${ROTATION_MIN_DEG:-0}"
+ROTATION_MAX_DEG="${ROTATION_MAX_DEG:-180}"
+ROTATION_STEP_DEG="${ROTATION_STEP_DEG:-5}"
+MAX_LAYERS="${MAX_LAYERS:-}"
+MODEL_LIST="${MODELS:-google/gemma-3-270m-it HuggingFaceTB/SmolLM2-135M-Instruct}"
+read -r -a MODEL_ARRAY <<< "${MODEL_LIST}"
+
+mkdir -p "${OUT_ROOT}"
+
+for MODEL in "${MODEL_ARRAY[@]}"; do
+  SAFE_NAME="${MODEL//\//__}"
+  MODEL_OUT_DIR="${OUT_ROOT}/${SAFE_NAME}"
+  EXTRA_ARGS=()
+  if [ -n "${MAX_LAYERS}" ]; then
+    EXTRA_ARGS+=(--max-layers "${MAX_LAYERS}")
+  fi
+  if [[ "${MODEL}" == google/gemma-* ]]; then
+    EXTRA_ARGS+=(--trust-remote-code)
+  fi
+
+  echo "=== Probing ${MODEL} ==="
+  python3 analysis/identity/head_special_matrix_probe.py \
+    --model "${MODEL}" \
+    --device "${DEVICE}" \
+    --dtype "${DTYPE}" \
+    --outdir "${MODEL_OUT_DIR}" \
+    --rotation-min-deg "${ROTATION_MIN_DEG}" \
+    --rotation-max-deg "${ROTATION_MAX_DEG}" \
+    --rotation-step-deg "${ROTATION_STEP_DEG}" \
+    "${EXTRA_ARGS[@]}"
+done
+
+cat <<MSG
+Done.
+Reports are under ${OUT_ROOT}.
+Each model directory contains head_special_matrix_scores.csv plus heatmaps for
+identity, negative identity, orthogonal/involution/projection/symmetric/skew
+metrics, and ${ROTATION_MIN_DEG}..${ROTATION_MAX_DEG} degree rotation targets at
+${ROTATION_STEP_DEG} degree increments.
+MSG

--- a/demos/modular_arithmetic_grokking_demo.sh
+++ b/demos/modular_arithmetic_grokking_demo.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Train a small nanoGPT model on modular addition and probe learned attention
+# heads for identity/projection/skew/rotation-like Wv/Wo structure.
+
+set -euo pipefail
+
+MODULUS="${MODULUS:-113}"
+TRAIN_FRACTION="${TRAIN_FRACTION:-0.3}"
+TRAIN_REPEATS="${TRAIN_REPEATS:-200}"
+VAL_REPEATS="${VAL_REPEATS:-20}"
+MAX_ITERS="${MAX_ITERS:-20000}"
+DEVICE="${DEVICE:-cuda:0}"
+DTYPE="${DTYPE:-float16}"
+OUT_DIR="${OUT_DIR:-out/modular_arithmetic_grokking_p${MODULUS}}"
+PROBE_OUT_DIR="${PROBE_OUT_DIR:-${OUT_DIR}/head_special_matrix_probe}"
+DATA_DIR="data/modular_arithmetic"
+CKPT_PATH="${OUT_DIR}/ckpt.pt"
+
+mkdir -p "${DATA_DIR}" "${OUT_DIR}"
+
+echo "=== Step 1: Prepare modular addition dataset ==="
+python3 "${DATA_DIR}/prepare.py" \
+  --out-dir "${DATA_DIR}" \
+  --modulus "${MODULUS}" \
+  --train-fraction "${TRAIN_FRACTION}" \
+  --train-repeats "${TRAIN_REPEATS}" \
+  --val-repeats "${VAL_REPEATS}"
+
+echo "=== Step 2: Train grokking-sized nanoGPT model ==="
+python3 train.py \
+  --dataset modular_arithmetic \
+  --out_dir "${OUT_DIR}" \
+  --device "${DEVICE}" \
+  --dtype "${DTYPE}" \
+  --block_size 32 \
+  --batch_size 256 \
+  --n_layer 1 \
+  --n_head 4 \
+  --n_embd 128 \
+  --dropout 0.0 \
+  --bias \
+  --max_iters "${MAX_ITERS}" \
+  --eval_interval 500 \
+  --eval_iters 100 \
+  --learning_rate 1e-3 \
+  --weight_decay 1.0 \
+  --warmup_iters 100 \
+  --decay_lr \
+  --min_lr 1e-5 \
+  --always_save_checkpoint \
+  --only_save_checkpoint_at_end \
+  --no-compile
+
+if [ ! -f "${CKPT_PATH}" ]; then
+  echo "Expected checkpoint not found at ${CKPT_PATH}" >&2
+  exit 1
+fi
+
+echo "=== Step 3: Probe Wv/Wo special matrices, including 0..180 degree rotations ==="
+python3 analysis/identity/head_special_matrix_probe.py \
+  --ckpt "${CKPT_PATH}" \
+  --device "${DEVICE%%:*}" \
+  --dtype "float32" \
+  --outdir "${PROBE_OUT_DIR}" \
+  --rotation-min-deg 0 \
+  --rotation-max-deg 180 \
+  --rotation-step-deg 5
+
+cat <<MSG
+Done.
+Dataset artifacts: ${DATA_DIR}/train.bin, ${DATA_DIR}/val.bin, ${DATA_DIR}/meta.pkl
+Training output: ${OUT_DIR}
+Special matrix probe report: ${PROBE_OUT_DIR}
+MSG


### PR DESCRIPTION
### Motivation

- Provide richer probes for head-space structure by testing V_hO_h against explicit block-diagonal 2D rotations and make the probe usable with local nanoGPT checkpoints as well as HuggingFace models.
- Add a simple modular-addition grokking dataset and a demo script to train a small nanoGPT and run the probe end-to-end.

### Description

- Extended `analysis/identity/head_special_matrix_probe.py` with command-line flags for rotation targets (`--rotation-degrees`, `--rotation-min-deg`, `--rotation-max-deg`, `--rotation-step-deg`) and implemented `get_rotation_degrees`, `format_degree_label`, and `rotation_matrix_2d_blocks` to generate block-diagonal 2D rotation targets for head-space comparisons.
- Added support for loading either HuggingFace models (`load_hf_model`) or local nanoGPT checkpoints (`load_nanogpt_checkpoint`) and unified attention weight extraction via `get_attention_weights`, plus logic to infer head shapes and compute additional rotation metrics (`rel_frob_headspace_VO_rotation_*deg`, `cos_headspace_VO_rotation_*deg`).
- Updated metric list, CSV descriptions, and heatmap generation to include the new rotation metrics and added `--ckpt` option to probe a local `nanoGPT` checkpoint; preserved existing identity/projection/skew/involution metrics.
- Added a new dataset `data/modular_arithmetic` with `prepare.py` and `README.md`, and a demo script `demos/modular_arithmetic_grokking_demo.sh` that prepares data, trains a small nanoGPT, and runs the updated probe over a range of rotations.

### Testing

- No automated tests were added or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ee569a18c8326ba6cf67ef9dac5a9)