### PR TITLE
Refactor training progress metric formatting

### DIFF
--- a/train.py
+++ b/train.py
@@ -11,6 +11,7 @@ import sys
 import time
 from collections import deque
 from datetime import datetime, timedelta
+from typing import Any
 
 from rich.console import Group
 from rich.console import Console
@@ -27,6 +28,7 @@ from train_variations.loss_variants import build_loss_function
 from train_variations.distillation_loss_variants import build_distillation_loss
 
 from utils.gpu_monitoring import get_gpu_memory_info, get_process_gpu_memory_bytes
+from utils.progress_bar import format_progress_metrics
 from torch.cuda import reset_peak_memory_stats, max_memory_allocated, max_memory_reserved
 
 try:
@@ -1797,6 +1799,29 @@ class Trainer:
                 }
         torch.save(checkpoint, os.path.join(self.args.out_dir, filename))
 
+
+    def get_progress_metrics(self) -> dict[str, Any]:
+        """Return raw values backing all Rich progress-bar task fields."""
+        return {
+            "best_iter": self.best_iter,
+            "best_val_loss": self.best_val_loss,
+            "best_tokens": self.best_tokens,
+            "eta": self.formatted_completion_eta,
+            "time_remaining_ms": self.time_remaining_ms,
+            "total_time_est_ms": self.total_time_est_ms,
+            "iter_latency_avg": self.iter_latency_avg,
+            "peak_torch_allocated": self.peak_torch_allocated,
+            "latest_top1_prob": self.latest_top1_prob,
+            "latest_top1_correct": self.latest_top1_correct,
+            "latest_target_rank": self.latest_target_rank,
+            "latest_target_prob": self.latest_target_prob,
+            "latest_target_left_prob": self.latest_target_left_prob,
+            "latest_rank_95": self.latest_rank_95,
+            "latest_left_prob_95": self.latest_left_prob_95,
+            "latest_ln_f_cosine": self.latest_ln_f_cosine,
+            "latest_ln_f_cosine_95": self.latest_ln_f_cosine_95,
+        }
+
     def run_validation_step(self, running_mfu, current_epoch, current_dataset, num_steps_with_worse_loss, live=None):
         losses = self.estimate_loss()
 
@@ -2080,25 +2105,7 @@ class Trainer:
             task_id = progress.add_task(
                     "[green]Training...",
                     total=((self.args.max_iters - self.iter_num) + self.evaluations_remaining * self.args.eval_iters),
-                    eta=self.formatted_completion_eta,
-                    total_hour=f"{int(self.total_time_est_ms // 3_600_000)}",
-                    total_min=f"{int((self.total_time_est_ms // 60_000) % 60):02d}",
-                    hour=f"{int((self.time_remaining_ms // (1000*3600)) % 24):02d}",
-                    min=f"{int((self.time_remaining_ms // 60000) % 60):02d}",
-                    best_val_loss=f"{self.best_val_loss:.3f}",
-                    best_iter=f"{self.best_iter}",
-                    best_tokens=f"{self.best_tokens}",
-                    iter_latency=f"{self.iter_latency_avg:.1f}",
-                    peak_gpu_mb=f"{self.peak_torch_allocated / (1024 ** 2):.1f}",
-                    t1p=f"{self.latest_top1_prob:.6f}",
-                    t1c=f"{self.latest_top1_correct:.6f}",
-                    tr=f"{self.latest_target_rank:.2f}",
-                    tp=f"{self.latest_target_prob:.6f}",
-                    tlp=f"{self.latest_target_left_prob:.6f}",
-                    r95=f"{self.latest_rank_95:.2f}",
-                    p95=f"{self.latest_left_prob_95:.6f}",
-                    lnf_cos=f"{self.latest_ln_f_cosine:.6f}",
-                    lnf_cos95=f"{self.latest_ln_f_cosine_95:.6f}",
+                    **format_progress_metrics(self.get_progress_metrics()),
                     )
 
             if self.zeus_enabled:
@@ -2294,25 +2301,7 @@ class Trainer:
                 progress.update(
                         task_id,
                         advance=progress_advance,
-                        eta=self.formatted_completion_eta,
-                        total_hour=f"{int(self.total_time_est_ms // 3_600_000)}",
-                        total_min=f"{int((self.total_time_est_ms // 60_000) % 60):02d}",
-                        hour=f"{int((self.time_remaining_ms // 3_600_000) % 24):02d}",
-                        min=f"{int((self.time_remaining_ms // 60_000) % 60):02d}",
-                        best_val_loss=f"{self.best_val_loss:.3f}",
-                        best_iter=f"{self.best_iter}",
-                        best_tokens=f"{self.best_tokens}",
-                        iter_latency=f"{self.iter_latency_avg:.1f}",
-                        peak_gpu_mb=f"{self.peak_torch_allocated / (1024 ** 2):.1f}",
-                        t1p=f"{self.latest_top1_prob:.6f}",
-                        t1c=f"{self.latest_top1_correct:.6f}",
-                        tr=f"{self.latest_target_rank:.2f}",
-                        tp=f"{self.latest_target_prob:.6f}",
-                        tlp=f"{self.latest_target_left_prob:.6f}",
-                        r95=f"{self.latest_rank_95:.2f}",
-                        p95=f"{self.latest_left_prob_95:.6f}",
-                        lnf_cos=f"{self.latest_ln_f_cosine:.6f}",
-                        lnf_cos95=f"{self.latest_ln_f_cosine_95:.6f}",
+                        **format_progress_metrics(self.get_progress_metrics()),
                         )
                 live.update(Group(progress.get_renderable(), cli_text))
 

--- a/utils/progress_bar.py
+++ b/utils/progress_bar.py
@@ -1,0 +1,56 @@
+"""Formatting helpers for Rich training progress-bar task fields."""
+
+from typing import Any
+
+
+def _as_float(value: Any, default: float = float("nan")) -> float:
+    if value is None:
+        return default
+    item = getattr(value, "item", None)
+    if callable(item):
+        value = item()
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    if value is None:
+        return default
+    item = getattr(value, "item", None)
+    if callable(item):
+        value = item()
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def format_progress_metrics(metrics: dict[str, Any]) -> dict[str, str]:
+    """Convert raw Trainer progress metrics into Rich task field strings."""
+    time_remaining_ms = _as_float(metrics.get("time_remaining_ms"), 0.0)
+    total_time_est_ms = _as_float(metrics.get("total_time_est_ms"), 0.0)
+    peak_torch_allocated = _as_float(metrics.get("peak_torch_allocated"), 0.0)
+
+    return {
+        "eta": str(metrics.get("eta", "waiting for calculation")),
+        "total_hour": f"{int(total_time_est_ms // 3_600_000)}",
+        "total_min": f"{int((total_time_est_ms // 60_000) % 60):02d}",
+        "hour": f"{int((time_remaining_ms // 3_600_000) % 24):02d}",
+        "min": f"{int((time_remaining_ms // 60_000) % 60):02d}",
+        "best_val_loss": f"{_as_float(metrics.get('best_val_loss')):.3f}",
+        "best_iter": f"{_as_int(metrics.get('best_iter'))}",
+        "best_tokens": f"{_as_int(metrics.get('best_tokens'))}",
+        "iter_latency": f"{_as_float(metrics.get('iter_latency_avg'), 0.0):.1f}",
+        "peak_gpu_mb": f"{peak_torch_allocated / (1024 ** 2):.1f}",
+        "t1p": f"{_as_float(metrics.get('latest_top1_prob')):.6f}",
+        "t1c": f"{_as_float(metrics.get('latest_top1_correct')):.6f}",
+        "tr": f"{_as_float(metrics.get('latest_target_rank')):.2f}",
+        "tp": f"{_as_float(metrics.get('latest_target_prob')):.6f}",
+        "tlp": f"{_as_float(metrics.get('latest_target_left_prob')):.6f}",
+        "r95": f"{_as_float(metrics.get('latest_rank_95')):.2f}",
+        "p95": f"{_as_float(metrics.get('latest_left_prob_95')):.6f}",
+        "lnf_cos": f"{_as_float(metrics.get('latest_ln_f_cosine')):.6f}",
+        "lnf_cos95": f"{_as_float(metrics.get('latest_ln_f_cosine_95')):.6f}",
+    }


### PR DESCRIPTION
### Motivation
- Keep training state ownership inside `Trainer` while moving presentation/formatting logic out of the training loop to simplify responsibilities.
- Make progress-bar rendering easier to test and reuse by centralizing formatting logic for Rich task fields.

### Description
- Add `Trainer.get_progress_metrics(self) -> dict[str, Any]` which returns raw metric values used by the progress UI (e.g. `best_iter`, `best_val_loss`, `best_tokens`, `eta`, `time_remaining_ms`, `total_time_est_ms`, `iter_latency_avg`, `peak_torch_allocated`, `latest_top1_prob`, `latest_target_rank`, percentile metrics, etc.).
- Add `utils/progress_bar.py` with `format_progress_metrics(metrics: dict[str, Any]) -> dict[str, str]` and helper coercion functions to safely convert tensor-like or None values into formatted strings for Rich task fields.
- Replace inline Rich task-field formatting in the training loop with `**format_progress_metrics(self.get_progress_metrics())` for both task creation and updates, and add a small typing import (`Any`).

### Testing
- Ran `python -m py_compile train.py utils/progress_bar.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eef882bec8326b603f3e4276922d8)