### PR TITLE
Add HSNorm radius pre-LN MiniPile exploration

### DIFF
--- a/explorations/hsnorm_radius_preln_minipile.yaml
+++ b/explorations/hsnorm_radius_preln_minipile.yaml
@@ -1,0 +1,118 @@
+# hsnorm_radius_preln_minipile.yaml
+# Based on explorations/default_inf.yaml. Sweeps HyperSphereNorm radius
+# combinations for the token embedding norm (norm_variant_wte) and the
+# transformer pre-LN norms (norm_variant_attn/output) on MiniPile.
+---
+
+named_static_groups:
+  # QK Norm
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  # Norm Type: explicit pre-LN mode (not peri/post LN)
+  - named_group: "pre_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [false]
+    use_post_ln: [false]
+
+  # Position Embeddings
+  - named_group: "rotary"
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+  # MLP Activation
+  - named_group: "squared_relu"
+    activation_variant: ["squared_relu"]
+
+  # Relu2Max
+  - named_group: "relu2max"
+    softmax_variant_attn: ["relu2max"]
+
+  # Softmax
+  - named_group: "softmax"
+    softmax_variant_attn: ["softmax"]
+
+  # Infinite Attention
+  - named_group: "infinite"
+    attention_variant: ["infinite"]
+    use_concat_heads: [true]
+
+  # Head Dimension
+  - named_group: "hd_100"
+    n_qk_head_dim: [100]
+    n_v_head_dim: [100]
+
+  - named_group: "hd_150"
+    n_qk_head_dim: [150]
+    n_v_head_dim: [150]
+
+  - named_group: "hd_200"
+    n_qk_head_dim: [200]
+    n_v_head_dim: [200]
+
+  # MQA
+  - named_group: "mqa"
+    n_kv_group: [1]
+
+  # HyperSphereNorm architecture and fixed-radius settings.
+  - named_group: "hsnorm_arch"
+    norm_variant_wte: ["hyperspherenorm"]
+    norm_variant_attn: ["hyperspherenorm"]
+    norm_variant_output: ["hyperspherenorm"]
+    norm_wte_gain: [false]
+    hsnorm_gain: [false]
+    norm_wte_scale: [1.0]
+    hsnorm_scale: [1.0]
+    norm_wte_radius_learning: [false]
+    hsnorm_radius_learning: [false]
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [2500]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+  compile: [true]
+  log_rankme: [true]
+  log_areq: [true]
+
+parameter_groups:
+  - named_group_static:
+      - "qk_norm"
+      - "pre_ln"
+      - "rotary"
+      - "relu2max"
+      - "infinite"
+      - "mqa"
+      - "hsnorm_arch"
+    n_head:
+      range:
+        start: 1
+        end: 12
+        step: 1
+    # norm_wte_radius controls token embedding HSNorm; hsnorm_radius
+    # controls the transformer pre-LN/output HSNorm. The lists form
+    # a Cartesian sweep of radius combinations.
+    norm_wte_radius: [1.0, 20.0, 50.0]
+    hsnorm_radius: [1.0, 20.0, 50.0]
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]
+
+  - named_group_static:
+      - "qk_norm"
+      - "pre_ln"
+      - "rotary"
+      - "softmax"
+      - "infinite"
+      - "mqa"
+      - "hsnorm_arch"
+    n_head:
+      range:
+        start: 1
+        end: 12
+        step: 1
+    # norm_wte_radius controls token embedding HSNorm; hsnorm_radius
+    # controls the transformer pre-LN/output HSNorm. The lists form
+    # a Cartesian sweep of radius combinations.
+    norm_wte_radius: [1.0, 20.0, 50.0]
+    hsnorm_radius: [1.0, 20.0, 50.0]
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]


### PR DESCRIPTION
### Motivation
- Provide an exploration that sweeps HyperSphereNorm radius settings for token-embedding HSNorm (`norm_variant_wte`) and transformer HSNorm (`hyperspherenorm`) in explicit pre-LN mode on the `minipile` dataset. 
- Use the default infinite-attention baseline and vary radius combinations to study interaction between embedding and block-level HSNorm behavior.

### Description
- Add `explorations/hsnorm_radius_preln_minipile.yaml` which defines a `pre_ln` named static group and a `hsnorm_arch` group that sets `norm_variant_wte`, `norm_variant_attn`, and `norm_variant_output` to `hyperspherenorm` with `gain=false`, `scale=1.0`, and radius learning disabled. 
- Parameter groups sweep `norm_wte_radius` and `hsnorm_radius` over `[1.0, 20.0, 50.0]` (Cartesian product) across both `relu2max` and `softmax` attention families, `n_head` from 1 to 12, and head-dimension alternates `hd_100`, `hd_150`, and `hd_200`. 
- Keep training runtime defaults consistent with other explorations (`dataset=minipile`, `compile=true`, `never_save_checkpoint=true`, `max_iters=10000`, `eval_interval=2500`) so the YAML plugs into the existing experiment generation tooling.

### Testing
- Parsed the new YAML successfully with `yaml.safe_load` which returned no errors. 
- Loaded and expanded the configuration using `optimization_and_search.run_experiments.load_configurations` and `generate_combinations` which produced `648` experiment combinations and printed sample combos to validate expected keys such as `norm_wte_radius`, `hsnorm_radius`, `norm_variant_wte`, and `n_head`. 
- Attempted a CLI dry-run with `optimization_and_search/run_experiments.py --yaml explorations/hsnorm_radius_preln_minipile.yaml --dry-run --max-runs 1` but the script uses a different CLI signature and initially failed due to a missing dependency (`rich`) and required `-c/--config`, so a full CLI dry-run was not executed (configuration parsing and combination expansion were validated programmatically).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eeedf8c7c8326a9a3179e21c501f6)