### PR TITLE
feat(analysis): compare lm head pairwise angles

### DIFF
--- a/analysis/lm_head_pairwise_angles/README.md
+++ b/analysis/lm_head_pairwise_angles/README.md
@@ -1,0 +1,26 @@
+# LM Head Pairwise Angle Comparison
+
+Tools for comparing whether the geometry of `lm_head` vocabulary vectors is preserved between two nanoGPT checkpoints.
+
+The analysis computes all vocabulary-vector pairwise angles from each checkpoint's `lm_head.weight`, then compares the two angle matrices. For small vocabularies such as `shakespeare_char` this is easy to visualize directly.
+
+## CLI
+
+```bash
+python3 analysis/lm_head_pairwise_angles/compare_lm_head_pairwise_angles.py \
+  out_a/ckpt.pt out_b/ckpt.pt \
+  --meta data/shakespeare_char/meta.pkl \
+  --min-angle 0 --max-angle 180 \
+  --html out/lm_head_pairwise_angles/report.html \
+  --csv out/lm_head_pairwise_angles/pairs.csv
+```
+
+Use `--device cuda` for CUDA acceleration when available, or `--device auto` to prefer CUDA if `torch.cuda.is_available()`.
+
+## Webapp
+
+```bash
+python3 analysis/lm_head_pairwise_angles/app.py --ckpt-root . --host 127.0.0.1 --port 7860
+```
+
+The webapp scans for checkpoint files, lets you choose two checkpoints, set an angle window, and renders angle/difference histograms and heatmaps.

--- a/analysis/lm_head_pairwise_angles/README.md
+++ b/analysis/lm_head_pairwise_angles/README.md
@@ -23,7 +23,7 @@ Use `--device cuda` for CUDA acceleration when available, or `--device auto` to 
 python3 analysis/lm_head_pairwise_angles/app.py --ckpt-root . --host 127.0.0.1 --port 7860
 ```
 
-The webapp scans for checkpoint files, lets you choose two checkpoints, set an angle window, and renders A-sorted pair-angle plots, difference histograms, larger square A/B pairwise-angle heatmaps, difference heatmaps, and heatmap color/direction toggle menus.
+The webapp scans for checkpoint files, lets you choose two checkpoints, set an angle window, and renders A-sorted pair-angle plots, difference histograms, larger square A/B pairwise-angle heatmaps, difference heatmaps, a baseline-alignment scatter, metric cards, and heatmap color/direction toggle menus.
 
 ## Trend across training iterations
 

--- a/analysis/lm_head_pairwise_angles/README.md
+++ b/analysis/lm_head_pairwise_angles/README.md
@@ -23,7 +23,7 @@ Use `--device cuda` for CUDA acceleration when available, or `--device auto` to 
 python3 analysis/lm_head_pairwise_angles/app.py --ckpt-root . --host 127.0.0.1 --port 7860
 ```
 
-The webapp scans for checkpoint files, lets you choose two checkpoints, set an angle window, and renders angle/difference histograms and heatmaps.
+The webapp scans for checkpoint files, lets you choose two checkpoints, set an angle window, and renders A-sorted pair-angle plots, difference histograms, A/B pairwise-angle heatmaps, and difference heatmaps.
 
 ## Trend across training iterations
 

--- a/analysis/lm_head_pairwise_angles/README.md
+++ b/analysis/lm_head_pairwise_angles/README.md
@@ -23,7 +23,7 @@ Use `--device cuda` for CUDA acceleration when available, or `--device auto` to 
 python3 analysis/lm_head_pairwise_angles/app.py --ckpt-root . --host 127.0.0.1 --port 7860
 ```
 
-The webapp scans for checkpoint files, lets you choose two checkpoints, set an angle window, and renders A-sorted pair-angle plots, difference histograms, A/B pairwise-angle heatmaps, and difference heatmaps.
+The webapp scans for checkpoint files, lets you choose two checkpoints, set an angle window, and renders A-sorted pair-angle plots, difference histograms, larger square A/B pairwise-angle heatmaps, difference heatmaps, and heatmap color/direction toggle menus.
 
 ## Trend across training iterations
 

--- a/analysis/lm_head_pairwise_angles/README.md
+++ b/analysis/lm_head_pairwise_angles/README.md
@@ -24,3 +24,19 @@ python3 analysis/lm_head_pairwise_angles/app.py --ckpt-root . --host 127.0.0.1 -
 ```
 
 The webapp scans for checkpoint files, lets you choose two checkpoints, set an angle window, and renders angle/difference histograms and heatmaps.
+
+## Trend across training iterations
+
+The demo saves major checkpoints every 200 iterations, including the initial
+iteration-0 checkpoint when training starts. To plot how pairwise-angle
+preservation changes over time:
+
+```bash
+python3 analysis/lm_head_pairwise_angles/plot_lm_head_pairwise_angle_trend.py \
+  out/shakespeare_lm_head_pairwise_angles_demo/seed_1337 \
+  out/shakespeare_lm_head_pairwise_angles_demo/seed_2024 \
+  --iterations 0,200,400,600,800 \
+  --meta data/shakespeare_char/meta.pkl \
+  --csv out/shakespeare_lm_head_pairwise_angles_demo/analysis/trend.csv \
+  --html out/shakespeare_lm_head_pairwise_angles_demo/analysis/trend.html
+```

--- a/analysis/lm_head_pairwise_angles/app.py
+++ b/analysis/lm_head_pairwise_angles/app.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import argparse
-import os
+import html
 import sys
 from pathlib import Path
 
@@ -13,6 +13,15 @@ if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
 from compare_lm_head_pairwise_angles import compare_lm_head_pairwise_angles, plot_html
+
+
+HERO_METRICS = [
+    ("angle_alignment_score_pct", "Alignment", "%"),
+    ("pearson_r", "Pearson r", ""),
+    ("mae_deg", "MAE", "°"),
+    ("rmse_deg", "RMSE", "°"),
+    ("selected_pairs", "Selected pairs", ""),
+]
 
 
 def find_checkpoints(root: str, limit: int = 500) -> list[str]:
@@ -24,6 +33,18 @@ def find_checkpoints(root: str, limit: int = 500) -> list[str]:
             if len(paths) >= limit:
                 break
     return sorted(paths)
+
+
+def fmt_metric(value: float, suffix: str = "") -> str:
+    if value != value:  # NaN check without importing math
+        return "n/a"
+    if abs(value) >= 1000 and suffix != "%":
+        text = f"{value:,.0f}"
+    elif suffix == "%":
+        text = f"{value:.2f}"
+    else:
+        text = f"{value:.4g}"
+    return f"{text}{suffix}"
 
 
 def create_app(ckpt_root: str = "."):
@@ -51,27 +72,83 @@ def create_app(ckpt_root: str = "."):
         if request.method == "POST":
             try:
                 result = compare_lm_head_pairwise_angles(
-                    ckpt_a, ckpt_b, meta=meta or None, device=device,
-                    min_angle=min_angle, max_angle=max_angle,
+                    ckpt_a,
+                    ckpt_b,
+                    meta=meta or None,
+                    device=device,
+                    min_angle=min_angle,
+                    max_angle=max_angle,
                 )
-                metrics = "".join(f"<tr><th>{k}</th><td>{v:.6g}</td></tr>" for k, v in result.metrics.items())
-                result_html = f"<h2>Metrics</h2><table border='1' cellpadding='4'>{metrics}</table>" + plot_html(result)
+                metric_cards = "".join(
+                    f"<div class='metric-card'><span>{label}</span><strong>{fmt_metric(result.metrics.get(key, float('nan')), suffix)}</strong></div>"
+                    for key, label, suffix in HERO_METRICS
+                )
+                metrics = "".join(
+                    f"<tr><th>{html.escape(k)}</th><td>{fmt_metric(v)}</td></tr>"
+                    for k, v in result.metrics.items()
+                )
+                result_html = f"""
+                <section class='results'>
+                  <div class='section-heading'>
+                    <div>
+                      <p class='eyebrow'>Baseline alignment</p>
+                      <h2>Pairwise-angle preservation vs checkpoint A</h2>
+                    </div>
+                    <p class='hint'>The alignment scatter compares every selected pair's checkpoint-A angle to checkpoint-B angle. The dashed diagonal is perfect preservation.</p>
+                  </div>
+                  <div class='metrics'>{metric_cards}</div>
+                  <details class='metrics-table'>
+                    <summary>Show all metrics</summary>
+                    <table>{metrics}</table>
+                  </details>
+                  <div class='plot-shell'>{plot_html(result)}</div>
+                </section>
+                """
             except Exception as exc:  # render user-facing analysis errors in the page
-                error = f"<pre style='color:#b00'>{type(exc).__name__}: {exc}</pre>"
-        options = "".join(f"<option value='{p}' {'selected' if p == ckpt_a else ''}>{p}</option>" for p in ckpts)
-        options_b = "".join(f"<option value='{p}' {'selected' if p == ckpt_b else ''}>{p}</option>" for p in ckpts)
+                error = f"<pre class='error'>{html.escape(type(exc).__name__)}: {html.escape(str(exc))}</pre>"
+        options = "".join(
+            f"<option value='{html.escape(p, quote=True)}' {'selected' if p == ckpt_a else ''}>{html.escape(p)}</option>"
+            for p in ckpts
+        )
+        options_b = "".join(
+            f"<option value='{html.escape(p, quote=True)}' {'selected' if p == ckpt_b else ''}>{html.escape(p)}</option>"
+            for p in ckpts
+        )
+        meta_value = html.escape(meta or "data/shakespeare_char/meta.pkl", quote=True)
+        device_options = "".join(
+            f"<option {'selected' if device == item else ''}>{item}</option>" for item in ["cpu", "auto", "cuda"]
+        )
         return f"""<!doctype html><html><head><title>LM head pairwise angles</title>
-<style>body{{font-family:sans-serif;margin:2rem}} label{{display:block;margin:.5rem 0}} input,select{{min-width:28rem}}</style></head><body>
-<h1>LM head pairwise angle comparison</h1>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<style>
+:root{{color-scheme:dark;--bg:#070b1a;--panel:rgba(15,23,42,.82);--panel2:rgba(30,41,59,.72);--text:#e5eefc;--muted:#93a4bd;--accent:#7c3aed;--accent2:#06b6d4;--line:rgba(148,163,184,.25)}}
+*{{box-sizing:border-box}} body{{margin:0;font-family:Inter,ui-sans-serif,system-ui,-apple-system,Segoe UI,sans-serif;background:radial-gradient(circle at top left,#1e1b4b 0,#0f172a 34%,#030712 100%);color:var(--text)}}
+.hero{{padding:48px 56px 28px;background:linear-gradient(135deg,rgba(124,58,237,.24),rgba(6,182,212,.12));border-bottom:1px solid var(--line)}}
+.eyebrow{{margin:0 0 8px;color:#67e8f9;text-transform:uppercase;letter-spacing:.16em;font-size:12px;font-weight:800}} h1{{font-size:clamp(34px,5vw,64px);line-height:1;margin:0 0 14px}} h2{{margin:.1rem 0 .4rem;font-size:26px}} .hero p{{max-width:920px;color:var(--muted);font-size:18px}}
+.container{{padding:28px 56px 56px}} .control-card,.results{{background:var(--panel);border:1px solid var(--line);border-radius:24px;box-shadow:0 24px 80px rgba(0,0,0,.35);backdrop-filter:blur(16px);padding:24px;margin-bottom:28px}}
+.form-grid{{display:grid;grid-template-columns:repeat(2,minmax(260px,1fr));gap:18px}} label{{display:flex;flex-direction:column;gap:8px;color:#cbd5e1;font-weight:700}} input,select{{width:100%;border:1px solid var(--line);background:rgba(2,6,23,.78);color:var(--text);border-radius:14px;padding:12px 14px;outline:none}} input:focus,select:focus{{border-color:#22d3ee;box-shadow:0 0 0 3px rgba(34,211,238,.16)}}
+.actions{{display:flex;align-items:center;gap:14px;margin-top:20px}} button{{border:0;border-radius:999px;padding:13px 24px;font-weight:900;color:white;background:linear-gradient(135deg,var(--accent),var(--accent2));box-shadow:0 12px 36px rgba(6,182,212,.25);cursor:pointer}} .hint{{color:var(--muted);font-size:14px}}
+.section-heading{{display:flex;justify-content:space-between;gap:24px;align-items:end;margin-bottom:18px}} .metrics{{display:grid;grid-template-columns:repeat(5,minmax(140px,1fr));gap:14px;margin:18px 0}} .metric-card{{background:linear-gradient(180deg,rgba(30,41,59,.92),rgba(15,23,42,.92));border:1px solid var(--line);border-radius:18px;padding:18px}} .metric-card span{{display:block;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.08em}} .metric-card strong{{font-size:28px;line-height:1.3}}
+.metrics-table{{margin:16px 0;color:var(--muted)}} summary{{cursor:pointer;font-weight:800;color:#bfdbfe}} table{{border-collapse:collapse;margin-top:12px;width:100%;overflow:hidden;border-radius:12px}} th,td{{padding:10px 12px;border-bottom:1px solid var(--line);text-align:left}} th{{color:#cbd5e1}} .plot-shell{{background:#fff;border-radius:18px;padding:10px;overflow:auto}} .error{{white-space:pre-wrap;background:rgba(127,29,29,.28);border:1px solid rgba(248,113,113,.45);border-radius:16px;color:#fecaca;padding:16px}}
+@media (max-width:900px){{.hero,.container{{padding-left:22px;padding-right:22px}}.form-grid,.metrics{{grid-template-columns:1fr}}.section-heading{{display:block}}}}
+</style></head><body>
+<header class='hero'><p class='eyebrow'>nanoGPT geometry lab</p><h1>LM-head pairwise angle comparison</h1><p>Compare the vocabulary-vector geometry of two checkpoints, inspect preservation against checkpoint A as the baseline, and explore pairwise angles with CUDA acceleration when available.</p></header>
+<main class='container'>
+<section class='control-card'>
 <form method='post'>
-<label>Checkpoint A <select name='ckpt_a'>{options}</select></label>
-<label>Checkpoint B <select name='ckpt_b'>{options_b}</select></label>
-<label>Meta pickle for token labels <input name='meta' value='{meta or 'data/shakespeare_char/meta.pkl'}'></label>
-<label>Device <select name='device'><option {'selected' if device=='cpu' else ''}>cpu</option><option {'selected' if device=='auto' else ''}>auto</option><option {'selected' if device=='cuda' else ''}>cuda</option></select></label>
-<label>Minimum checkpoint-A pair angle in degrees <input type='number' step='0.1' name='min_angle' value='{min_angle}'></label>
-<label>Maximum checkpoint-A pair angle in degrees <input type='number' step='0.1' name='max_angle' value='{max_angle}'></label>
-<button type='submit'>Compare</button>
-</form>{error}{result_html}</body></html>"""
+<div class='form-grid'>
+<label>Baseline checkpoint A <select name='ckpt_a'>{options}</select></label>
+<label>Comparison checkpoint B <select name='ckpt_b'>{options_b}</select></label>
+<label>Meta pickle for token labels <input name='meta' value='{meta_value}'></label>
+<label>Device <select name='device'>{device_options}</select></label>
+<label>Minimum baseline-A pair angle in degrees <input type='number' step='0.1' name='min_angle' value='{min_angle}'></label>
+<label>Maximum baseline-A pair angle in degrees <input type='number' step='0.1' name='max_angle' value='{max_angle}'></label>
+</div>
+<div class='actions'><button type='submit'>Compare geometry</button><span class='hint'>Found {len(ckpts)} checkpoint file(s) under {html.escape(str(Path(ckpt_root).resolve()))}</span></div>
+</form>
+</section>
+{error}{result_html}
+</main></body></html>"""
 
     return app
 

--- a/analysis/lm_head_pairwise_angles/app.py
+++ b/analysis/lm_head_pairwise_angles/app.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Small Flask webapp for LM-head pairwise angle checkpoint comparisons."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from compare_lm_head_pairwise_angles import compare_lm_head_pairwise_angles, plot_html
+
+
+def find_checkpoints(root: str, limit: int = 500) -> list[str]:
+    root_path = Path(root).resolve()
+    paths = []
+    for path in root_path.rglob("*.pt"):
+        if path.is_file():
+            paths.append(str(path))
+            if len(paths) >= limit:
+                break
+    return sorted(paths)
+
+
+def create_app(ckpt_root: str = "."):
+    try:
+        from flask import Flask, request
+    except ImportError as exc:
+        raise SystemExit("Flask is required for the webapp. Install it with `pip install flask`.") from exc
+
+    app = Flask(__name__)
+
+    @app.route("/", methods=["GET", "POST"])
+    def index():
+        ckpts = find_checkpoints(ckpt_root)
+        default_a = ckpts[0] if ckpts else ""
+        default_b = ckpts[1] if len(ckpts) > 1 else default_a
+        result_html = ""
+        error = ""
+        form = request.form if request.method == "POST" else {}
+        ckpt_a = form.get("ckpt_a", default_a)
+        ckpt_b = form.get("ckpt_b", default_b)
+        meta = form.get("meta", "")
+        device = form.get("device", "cpu")
+        min_angle = float(form.get("min_angle", 0.0) or 0.0)
+        max_angle = float(form.get("max_angle", 180.0) or 180.0)
+        if request.method == "POST":
+            try:
+                result = compare_lm_head_pairwise_angles(
+                    ckpt_a, ckpt_b, meta=meta or None, device=device,
+                    min_angle=min_angle, max_angle=max_angle,
+                )
+                metrics = "".join(f"<tr><th>{k}</th><td>{v:.6g}</td></tr>" for k, v in result.metrics.items())
+                result_html = f"<h2>Metrics</h2><table border='1' cellpadding='4'>{metrics}</table>" + plot_html(result)
+            except Exception as exc:  # render user-facing analysis errors in the page
+                error = f"<pre style='color:#b00'>{type(exc).__name__}: {exc}</pre>"
+        options = "".join(f"<option value='{p}' {'selected' if p == ckpt_a else ''}>{p}</option>" for p in ckpts)
+        options_b = "".join(f"<option value='{p}' {'selected' if p == ckpt_b else ''}>{p}</option>" for p in ckpts)
+        return f"""<!doctype html><html><head><title>LM head pairwise angles</title>
+<style>body{{font-family:sans-serif;margin:2rem}} label{{display:block;margin:.5rem 0}} input,select{{min-width:28rem}}</style></head><body>
+<h1>LM head pairwise angle comparison</h1>
+<form method='post'>
+<label>Checkpoint A <select name='ckpt_a'>{options}</select></label>
+<label>Checkpoint B <select name='ckpt_b'>{options_b}</select></label>
+<label>Meta pickle for token labels <input name='meta' value='{meta or 'data/shakespeare_char/meta.pkl'}'></label>
+<label>Device <select name='device'><option {'selected' if device=='cpu' else ''}>cpu</option><option {'selected' if device=='auto' else ''}>auto</option><option {'selected' if device=='cuda' else ''}>cuda</option></select></label>
+<label>Minimum checkpoint-A pair angle in degrees <input type='number' step='0.1' name='min_angle' value='{min_angle}'></label>
+<label>Maximum checkpoint-A pair angle in degrees <input type='number' step='0.1' name='max_angle' value='{max_angle}'></label>
+<button type='submit'>Compare</button>
+</form>{error}{result_html}</body></html>"""
+
+    return app
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ckpt-root", default=".")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=7860)
+    args = parser.parse_args()
+    create_app(args.ckpt_root).run(host=args.host, port=args.port, debug=False)
+
+if __name__ == "__main__":
+    main()

--- a/analysis/lm_head_pairwise_angles/compare_lm_head_pairwise_angles.py
+++ b/analysis/lm_head_pairwise_angles/compare_lm_head_pairwise_angles.py
@@ -177,17 +177,80 @@ def write_csv(result: AngleComparison, path: str) -> None:
 def plot_html(result: AngleComparison) -> str:
     import plotly.graph_objects as go
     from plotly.subplots import make_subplots
-    rows = list(selected_pair_rows(result))
-    x = [f"{r['token_i']}-{r['token_j']}" for r in rows]
-    a = [r["angle_a_deg"] for r in rows]; b = [r["angle_b_deg"] for r in rows]; d = [r["diff_deg"] for r in rows]
-    fig = make_subplots(rows=2, cols=2, subplot_titles=("Selected pair angles by canonical vocab-pair order", "Difference histogram", "Checkpoint A pairwise angles", "Angle difference (B - A)"), specs=[[{}, {}], [{"type": "heatmap"}, {"type": "heatmap"}]])
-    fig.add_trace(go.Scatter(x=x, y=a, mode="markers", name="ckpt A", marker={"size": 5}), 1, 1)
-    fig.add_trace(go.Scatter(x=x, y=b, mode="markers", name="ckpt B", marker={"size": 5}), 1, 1)
+
+    rows = sorted(selected_pair_rows(result), key=lambda row: row["angle_a_deg"])
+    sorted_rank = list(range(len(rows)))
+    hover_labels = [
+        f"{r['token_i']}-{r['token_j']} ({r['label_i']!r}, {r['label_j']!r})"
+        for r in rows
+    ]
+    a = [r["angle_a_deg"] for r in rows]
+    b = [r["angle_b_deg"] for r in rows]
+    d = [r["diff_deg"] for r in rows]
+
+    fig = make_subplots(
+        rows=3,
+        cols=2,
+        subplot_titles=(
+            "Selected pair angles sorted by checkpoint A angle",
+            "Difference histogram",
+            "Checkpoint A pairwise angles",
+            "Checkpoint B pairwise angles",
+            "Angle difference (B - A)",
+            "",
+        ),
+        specs=[
+            [{}, {}],
+            [{"type": "heatmap"}, {"type": "heatmap"}],
+            [{"type": "heatmap"}, None],
+        ],
+    )
+    fig.add_trace(
+        go.Scatter(
+            x=sorted_rank,
+            y=a,
+            customdata=hover_labels,
+            mode="markers",
+            name="ckpt A",
+            marker={"size": 5},
+            hovertemplate="A-sorted rank=%{x}<br>pair=%{customdata}<br>angle=%{y:.4f}°<extra></extra>",
+        ),
+        1,
+        1,
+    )
+    fig.add_trace(
+        go.Scatter(
+            x=sorted_rank,
+            y=b,
+            customdata=hover_labels,
+            mode="markers",
+            name="ckpt B (A order)",
+            marker={"size": 5},
+            hovertemplate="A-sorted rank=%{x}<br>pair=%{customdata}<br>angle=%{y:.4f}°<extra></extra>",
+        ),
+        1,
+        1,
+    )
     fig.add_trace(go.Histogram(x=d, name="B - A diff"), 1, 2)
     labels = [f"{i}:{t}" for i, t in enumerate(result.tokens)]
-    fig.add_trace(go.Heatmap(z=result.angles_a.tolist(), x=labels, y=labels, colorscale="Viridis", colorbar={"title":"deg"}), 2, 1)
-    fig.add_trace(go.Heatmap(z=result.diff.tolist(), x=labels, y=labels, colorscale="RdBu", zmid=0, colorbar={"title":"deg"}), 2, 2)
-    fig.update_layout(height=1000, title="LM head pairwise angle comparison", bargap=0.05)
+    fig.add_trace(
+        go.Heatmap(z=result.angles_a.tolist(), x=labels, y=labels, colorscale="Viridis", colorbar={"title": "deg"}),
+        2,
+        1,
+    )
+    fig.add_trace(
+        go.Heatmap(z=result.angles_b.tolist(), x=labels, y=labels, colorscale="Viridis", colorbar={"title": "deg"}),
+        2,
+        2,
+    )
+    fig.add_trace(
+        go.Heatmap(z=result.diff.tolist(), x=labels, y=labels, colorscale="RdBu", zmid=0, colorbar={"title": "deg"}),
+        3,
+        1,
+    )
+    fig.update_xaxes(title_text="Rank after sorting selected pairs by checkpoint A angle", row=1, col=1)
+    fig.update_yaxes(title_text="Pairwise angle (degrees)", row=1, col=1)
+    fig.update_layout(height=1300, title="LM head pairwise angle comparison", bargap=0.05)
     return fig.to_html(full_html=False, include_plotlyjs="cdn")
 
 

--- a/analysis/lm_head_pairwise_angles/compare_lm_head_pairwise_angles.py
+++ b/analysis/lm_head_pairwise_angles/compare_lm_head_pairwise_angles.py
@@ -145,6 +145,7 @@ def compare_lm_head_pairwise_angles(
         metrics["stddev_abs_degrees_difference"] = float(selected_abs_diff.std(unbiased=False).item())
         metrics["median_abs_degrees_difference"] = float(selected_abs_diff.median().item())
         metrics["rmse_deg"] = float(torch.sqrt((selected_diff ** 2).mean()).item())
+        metrics["angle_alignment_score_pct"] = max(0.0, 100.0 * (1.0 - metrics["mae_deg"] / 180.0))
         if selected_a.numel() > 1 and selected_a.std() > 0 and selected_b.std() > 0:
             metrics["pearson_r"] = float(torch.corrcoef(torch.stack([selected_a, selected_b]))[0, 1].item())
         else:
@@ -197,12 +198,12 @@ def plot_html(result: AngleComparison) -> str:
             "Checkpoint A pairwise angles",
             "Checkpoint B pairwise angles",
             "Angle difference (B - A)",
-            "",
+            "Alignment vs baseline A",
         ),
         specs=[
             [{}, {}],
             [{"type": "heatmap"}, {"type": "heatmap"}],
-            [{"type": "heatmap"}, None],
+            [{"type": "heatmap"}, {}],
         ],
     )
     fig.add_trace(
@@ -276,11 +277,40 @@ def plot_html(result: AngleComparison) -> str:
         3,
         1,
     )
+    alignment_min = min(a + b) if a and b else 0.0
+    alignment_max = max(a + b) if a and b else 180.0
+    fig.add_trace(
+        go.Scatter(
+            x=a,
+            y=b,
+            customdata=hover_labels,
+            mode="markers",
+            name="B vs baseline A",
+            marker={"size": 5, "opacity": 0.65, "color": d, "colorscale": "RdBu", "cmid": 0, "showscale": False},
+            hovertemplate="pair=%{customdata}<br>A=%{x:.4f}°<br>B=%{y:.4f}°<extra></extra>",
+        ),
+        3,
+        2,
+    )
+    fig.add_trace(
+        go.Scatter(
+            x=[alignment_min, alignment_max],
+            y=[alignment_min, alignment_max],
+            mode="lines",
+            name="perfect alignment",
+            line={"dash": "dash", "color": "#111827"},
+            hoverinfo="skip",
+        ),
+        3,
+        2,
+    )
     fig.update_xaxes(title_text="Rank after sorting selected pairs by checkpoint A angle", row=1, col=1)
     fig.update_yaxes(title_text="Pairwise angle (degrees)", row=1, col=1)
     for row, col in [(2, 1), (2, 2), (3, 1)]:
         fig.update_xaxes(tickangle=90, row=row, col=col)
         fig.update_yaxes(autorange="reversed", scaleanchor=f"x{(row - 1) * 2 + col}", scaleratio=1, row=row, col=col)
+    fig.update_xaxes(title_text="Baseline A pairwise angle (degrees)", row=3, col=2)
+    fig.update_yaxes(title_text="Checkpoint B pairwise angle (degrees)", scaleanchor="x6", scaleratio=1, row=3, col=2)
     fig.update_layout(
         height=1750,
         width=1800,

--- a/analysis/lm_head_pairwise_angles/compare_lm_head_pairwise_angles.py
+++ b/analysis/lm_head_pairwise_angles/compare_lm_head_pairwise_angles.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Compare pairwise lm_head vocabulary-vector angles between two checkpoints."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import html
+import math
+import os
+import pickle
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+
+@dataclass
+class AngleComparison:
+    ckpt_a: str
+    ckpt_b: str
+    lm_head_key_a: str
+    lm_head_key_b: str
+    tokens: List[str]
+    angles_a: torch.Tensor
+    angles_b: torch.Tensor
+    diff: torch.Tensor
+    mask: torch.Tensor
+    pair_indices: torch.Tensor
+    metrics: Dict[str, float]
+
+
+def resolve_device(device: str) -> str:
+    if device == "auto":
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("--device cuda requested but CUDA is not available")
+    return device
+
+
+def load_checkpoint(path: str, device: str) -> Dict[str, object]:
+    return torch.load(path, map_location=device, weights_only=False)
+
+
+def clean_state_dict(ckpt: Dict[str, object]) -> Dict[str, torch.Tensor]:
+    return {k.removeprefix("_orig_mod."): v for k, v in ckpt["model"].items()}
+
+
+def find_lm_head_weight(sd: Dict[str, torch.Tensor], key: Optional[str] = None) -> Tuple[str, torch.Tensor]:
+    candidates = [key] if key else [
+        "lm_head.weight",
+        "transformer.lm_head_0.weight",
+        "transformer.wte.weight",  # tied-weight checkpoints may carry only the embedding copy
+    ]
+    for name in candidates:
+        if name and name in sd and sd[name].ndim == 2:
+            return name, sd[name]
+    suffix_matches = [name for name, value in sd.items() if name.endswith("lm_head.weight") and value.ndim == 2]
+    suffix_matches += [name for name, value in sd.items() if "lm_head_" in name and name.endswith(".weight") and value.ndim == 2]
+    if suffix_matches:
+        name = sorted(suffix_matches)[0]
+        return name, sd[name]
+    raise KeyError("Could not locate a 2D lm_head weight in checkpoint state_dict")
+
+
+def load_tokens(meta_path: Optional[str], vocab_size: int) -> List[str]:
+    if not meta_path:
+        return [str(i) for i in range(vocab_size)]
+    with open(meta_path, "rb") as f:
+        meta = pickle.load(f)
+    itos = meta.get("itos")
+    if isinstance(itos, dict):
+        return [str(itos.get(i, i)) for i in range(vocab_size)]
+    if isinstance(itos, list):
+        return [str(itos[i]) if i < len(itos) else str(i) for i in range(vocab_size)]
+    return [str(i) for i in range(vocab_size)]
+
+
+def pairwise_angles_deg(weight: torch.Tensor) -> torch.Tensor:
+    vecs = F.normalize(weight.float(), p=2, dim=1, eps=1e-12)
+    cosine = (vecs @ vecs.T).clamp(-1.0, 1.0)
+    return torch.rad2deg(torch.acos(cosine))
+
+
+def summarize(values: torch.Tensor, prefix: str) -> Dict[str, float]:
+    if values.numel() == 0:
+        return {f"{prefix}_{k}": math.nan for k in ["mean", "median", "std", "min", "max"]}
+    return {
+        f"{prefix}_mean": float(values.mean().item()),
+        f"{prefix}_median": float(values.median().item()),
+        f"{prefix}_std": float(values.std(unbiased=False).item()),
+        f"{prefix}_min": float(values.min().item()),
+        f"{prefix}_max": float(values.max().item()),
+    }
+
+
+def compare_lm_head_pairwise_angles(
+    ckpt_a: str,
+    ckpt_b: str,
+    *,
+    meta: Optional[str] = None,
+    device: str = "cpu",
+    lm_head_key_a: Optional[str] = None,
+    lm_head_key_b: Optional[str] = None,
+    min_angle: float = 0.0,
+    max_angle: float = 180.0,
+) -> AngleComparison:
+    device = resolve_device(device)
+    sd_a = clean_state_dict(load_checkpoint(ckpt_a, device))
+    sd_b = clean_state_dict(load_checkpoint(ckpt_b, device))
+    key_a, weight_a = find_lm_head_weight(sd_a, lm_head_key_a)
+    key_b, weight_b = find_lm_head_weight(sd_b, lm_head_key_b)
+    if weight_a.shape != weight_b.shape:
+        raise ValueError(f"lm_head shapes differ: {tuple(weight_a.shape)} vs {tuple(weight_b.shape)}")
+
+    angles_a = pairwise_angles_deg(weight_a)
+    angles_b = pairwise_angles_deg(weight_b)
+    diff = angles_b - angles_a
+    vocab_size = weight_a.shape[0]
+    pair_indices = torch.triu_indices(vocab_size, vocab_size, offset=1, device=angles_a.device)
+    a_pairs = angles_a[pair_indices[0], pair_indices[1]]
+    b_pairs = angles_b[pair_indices[0], pair_indices[1]]
+    diff_pairs = diff[pair_indices[0], pair_indices[1]]
+    mask = (a_pairs >= min_angle) & (a_pairs <= max_angle)
+    selected_a = a_pairs[mask]
+    selected_b = b_pairs[mask]
+    selected_diff = diff_pairs[mask]
+
+    metrics: Dict[str, float] = {
+        "vocab_size": float(vocab_size),
+        "embedding_dim": float(weight_a.shape[1]),
+        "total_pairs": float(a_pairs.numel()),
+        "selected_pairs": float(selected_a.numel()),
+        "angle_window_min": float(min_angle),
+        "angle_window_max": float(max_angle),
+    }
+    metrics.update(summarize(selected_a, "ckpt_a_angle_deg"))
+    metrics.update(summarize(selected_b, "ckpt_b_angle_deg"))
+    metrics.update(summarize(selected_diff, "diff_deg"))
+    if selected_diff.numel():
+        metrics["mae_deg"] = float(selected_diff.abs().mean().item())
+        metrics["rmse_deg"] = float(torch.sqrt((selected_diff ** 2).mean()).item())
+        if selected_a.numel() > 1 and selected_a.std() > 0 and selected_b.std() > 0:
+            metrics["pearson_r"] = float(torch.corrcoef(torch.stack([selected_a, selected_b]))[0, 1].item())
+        else:
+            metrics["pearson_r"] = math.nan
+    return AngleComparison(ckpt_a, ckpt_b, key_a, key_b, load_tokens(meta, vocab_size), angles_a.cpu(), angles_b.cpu(), diff.cpu(), mask.cpu(), pair_indices.cpu(), metrics)
+
+
+def selected_pair_rows(result: AngleComparison) -> Iterable[Dict[str, object]]:
+    rows, cols = result.pair_indices
+    selected = result.mask.nonzero(as_tuple=False).flatten()
+    for order, idx in enumerate(selected.tolist()):
+        i, j = int(rows[idx]), int(cols[idx])
+        yield {
+            "pair_order": order, "token_i": i, "token_j": j,
+            "label_i": result.tokens[i], "label_j": result.tokens[j],
+            "angle_a_deg": float(result.angles_a[i, j]),
+            "angle_b_deg": float(result.angles_b[i, j]),
+            "diff_deg": float(result.diff[i, j]),
+        }
+
+
+def write_csv(result: AngleComparison, path: str) -> None:
+    os.makedirs(os.path.dirname(os.path.abspath(path)) or ".", exist_ok=True)
+    rows = list(selected_pair_rows(result))
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()) if rows else ["pair_order", "token_i", "token_j", "label_i", "label_j", "angle_a_deg", "angle_b_deg", "diff_deg"])
+        writer.writeheader(); writer.writerows(rows)
+
+
+def plot_html(result: AngleComparison) -> str:
+    import plotly.graph_objects as go
+    from plotly.subplots import make_subplots
+    rows = list(selected_pair_rows(result))
+    x = [f"{r['token_i']}-{r['token_j']}" for r in rows]
+    a = [r["angle_a_deg"] for r in rows]; b = [r["angle_b_deg"] for r in rows]; d = [r["diff_deg"] for r in rows]
+    fig = make_subplots(rows=2, cols=2, subplot_titles=("Selected pair angles by canonical vocab-pair order", "Difference histogram", "Checkpoint A pairwise angles", "Angle difference (B - A)"), specs=[[{}, {}], [{"type": "heatmap"}, {"type": "heatmap"}]])
+    fig.add_trace(go.Scatter(x=x, y=a, mode="markers", name="ckpt A", marker={"size": 5}), 1, 1)
+    fig.add_trace(go.Scatter(x=x, y=b, mode="markers", name="ckpt B", marker={"size": 5}), 1, 1)
+    fig.add_trace(go.Histogram(x=d, name="B - A diff"), 1, 2)
+    labels = [f"{i}:{t}" for i, t in enumerate(result.tokens)]
+    fig.add_trace(go.Heatmap(z=result.angles_a.tolist(), x=labels, y=labels, colorscale="Viridis", colorbar={"title":"deg"}), 2, 1)
+    fig.add_trace(go.Heatmap(z=result.diff.tolist(), x=labels, y=labels, colorscale="RdBu", zmid=0, colorbar={"title":"deg"}), 2, 2)
+    fig.update_layout(height=1000, title="LM head pairwise angle comparison", bargap=0.05)
+    return fig.to_html(full_html=False, include_plotlyjs="cdn")
+
+
+def write_html(result: AngleComparison, path: str) -> None:
+    metrics = "".join(f"<tr><th>{html.escape(k)}</th><td>{v:.6g}</td></tr>" for k, v in result.metrics.items())
+    body = f"""<!doctype html><html><head><meta charset='utf-8'><title>LM head pairwise angle comparison</title></head><body>
+<h1>LM head pairwise angle comparison</h1>
+<p><b>A:</b> {html.escape(result.ckpt_a)} ({html.escape(result.lm_head_key_a)})<br><b>B:</b> {html.escape(result.ckpt_b)} ({html.escape(result.lm_head_key_b)})</p>
+<table border='1' cellpadding='4'>{metrics}</table>{plot_html(result)}</body></html>"""
+    os.makedirs(os.path.dirname(os.path.abspath(path)) or ".", exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f: f.write(body)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("ckpt_a"); p.add_argument("ckpt_b")
+    p.add_argument("--meta", default=None); p.add_argument("--device", default="cpu", choices=["cpu", "cuda", "auto"])
+    p.add_argument("--lm-head-key-a", default=None); p.add_argument("--lm-head-key-b", default=None)
+    p.add_argument("--min-angle", type=float, default=0.0); p.add_argument("--max-angle", type=float, default=180.0)
+    p.add_argument("--csv", default=None); p.add_argument("--html", default=None)
+    args = p.parse_args()
+    result = compare_lm_head_pairwise_angles(args.ckpt_a, args.ckpt_b, meta=args.meta, device=args.device, lm_head_key_a=args.lm_head_key_a, lm_head_key_b=args.lm_head_key_b, min_angle=args.min_angle, max_angle=args.max_angle)
+    for k, v in result.metrics.items(): print(f"{k}: {v:.6g}")
+    if args.csv: write_csv(result, args.csv); print(f"wrote CSV: {args.csv}")
+    if args.html: write_html(result, args.html); print(f"wrote HTML: {args.html}")
+
+if __name__ == "__main__":
+    main()

--- a/analysis/lm_head_pairwise_angles/compare_lm_head_pairwise_angles.py
+++ b/analysis/lm_head_pairwise_angles/compare_lm_head_pairwise_angles.py
@@ -139,7 +139,11 @@ def compare_lm_head_pairwise_angles(
     metrics.update(summarize(selected_b, "ckpt_b_angle_deg"))
     metrics.update(summarize(selected_diff, "diff_deg"))
     if selected_diff.numel():
-        metrics["mae_deg"] = float(selected_diff.abs().mean().item())
+        selected_abs_diff = selected_diff.abs()
+        metrics["mae_deg"] = float(selected_abs_diff.mean().item())
+        metrics["avg_abs_degrees_difference"] = metrics["mae_deg"]
+        metrics["stddev_abs_degrees_difference"] = float(selected_abs_diff.std(unbiased=False).item())
+        metrics["median_abs_degrees_difference"] = float(selected_abs_diff.median().item())
         metrics["rmse_deg"] = float(torch.sqrt((selected_diff ** 2).mean()).item())
         if selected_a.numel() > 1 and selected_a.std() > 0 and selected_b.std() > 0:
             metrics["pearson_r"] = float(torch.corrcoef(torch.stack([selected_a, selected_b]))[0, 1].item())

--- a/analysis/lm_head_pairwise_angles/compare_lm_head_pairwise_angles.py
+++ b/analysis/lm_head_pairwise_angles/compare_lm_head_pairwise_angles.py
@@ -233,24 +233,109 @@ def plot_html(result: AngleComparison) -> str:
     )
     fig.add_trace(go.Histogram(x=d, name="B - A diff"), 1, 2)
     labels = [f"{i}:{t}" for i, t in enumerate(result.tokens)]
+    angle_colorbar = {"title": "angle deg", "len": 0.26, "thickness": 14}
+    diff_colorbar = {"title": "diff deg", "len": 0.26, "thickness": 14}
     fig.add_trace(
-        go.Heatmap(z=result.angles_a.tolist(), x=labels, y=labels, colorscale="Viridis", colorbar={"title": "deg"}),
+        go.Heatmap(
+            z=result.angles_a.tolist(),
+            x=labels,
+            y=labels,
+            colorscale="Viridis",
+            zmin=0,
+            zmax=180,
+            colorbar={**angle_colorbar, "x": 0.455, "y": 0.50},
+        ),
         2,
         1,
     )
     fig.add_trace(
-        go.Heatmap(z=result.angles_b.tolist(), x=labels, y=labels, colorscale="Viridis", colorbar={"title": "deg"}),
+        go.Heatmap(
+            z=result.angles_b.tolist(),
+            x=labels,
+            y=labels,
+            colorscale="Viridis",
+            zmin=0,
+            zmax=180,
+            colorbar={**angle_colorbar, "x": 1.0, "y": 0.50},
+        ),
         2,
         2,
     )
+    max_abs_diff = max(abs(float(result.diff.min())), abs(float(result.diff.max())), 1e-12)
     fig.add_trace(
-        go.Heatmap(z=result.diff.tolist(), x=labels, y=labels, colorscale="RdBu", zmid=0, colorbar={"title": "deg"}),
+        go.Heatmap(
+            z=result.diff.tolist(),
+            x=labels,
+            y=labels,
+            colorscale="RdBu",
+            zmid=0,
+            zmin=-max_abs_diff,
+            zmax=max_abs_diff,
+            colorbar={**diff_colorbar, "x": 0.455, "y": 0.16},
+        ),
         3,
         1,
     )
     fig.update_xaxes(title_text="Rank after sorting selected pairs by checkpoint A angle", row=1, col=1)
     fig.update_yaxes(title_text="Pairwise angle (degrees)", row=1, col=1)
-    fig.update_layout(height=1300, title="LM head pairwise angle comparison", bargap=0.05)
+    for row, col in [(2, 1), (2, 2), (3, 1)]:
+        fig.update_xaxes(tickangle=90, row=row, col=col)
+        fig.update_yaxes(autorange="reversed", scaleanchor=f"x{(row - 1) * 2 + col}", scaleratio=1, row=row, col=col)
+    fig.update_layout(
+        height=1750,
+        width=1800,
+        title="LM head pairwise angle comparison",
+        bargap=0.05,
+        margin={"l": 80, "r": 160, "t": 130, "b": 80},
+        updatemenus=[
+            {
+                "buttons": [
+                    {"label": "Viridis", "method": "restyle", "args": [{"colorscale": ["Viridis", "Viridis"]}, [3, 4]]},
+                    {"label": "Cividis", "method": "restyle", "args": [{"colorscale": ["Cividis", "Cividis"]}, [3, 4]]},
+                    {"label": "YlGnBu", "method": "restyle", "args": [{"colorscale": ["YlGnBu", "YlGnBu"]}, [3, 4]]},
+                    {"label": "Greens", "method": "restyle", "args": [{"colorscale": ["Greens", "Greens"]}, [3, 4]]},
+                    {"label": "Plasma", "method": "restyle", "args": [{"colorscale": ["Plasma", "Plasma"]}, [3, 4]]},
+                ],
+                "direction": "down",
+                "showactive": True,
+                "x": 0.00,
+                "xanchor": "left",
+                "y": 1.08,
+                "yanchor": "top",
+                "pad": {"r": 8, "t": 8},
+            },
+            {
+                "buttons": [
+                    {"label": "Angle high = bright", "method": "restyle", "args": [{"reversescale": [False, False]}, [3, 4]]},
+                    {"label": "Angle high = dark", "method": "restyle", "args": [{"reversescale": [True, True]}, [3, 4]]},
+                ],
+                "direction": "down",
+                "showactive": True,
+                "x": 0.12,
+                "xanchor": "left",
+                "y": 1.08,
+                "yanchor": "top",
+                "pad": {"r": 8, "t": 8},
+            },
+            {
+                "buttons": [
+                    {"label": "Diff red→blue", "method": "restyle", "args": [{"colorscale": ["RdBu"], "reversescale": [False]}, [5]]},
+                    {"label": "Diff blue→red", "method": "restyle", "args": [{"colorscale": ["RdBu"], "reversescale": [True]}, [5]]},
+                    {"label": "Diff balance", "method": "restyle", "args": [{"colorscale": ["Balance"], "reversescale": [False]}, [5]]},
+                ],
+                "direction": "down",
+                "showactive": True,
+                "x": 0.29,
+                "xanchor": "left",
+                "y": 1.08,
+                "yanchor": "top",
+                "pad": {"r": 8, "t": 8},
+            },
+        ],
+    )
+    fig.add_annotation(text="Angle colors", x=0.00, xref="paper", y=1.105, yref="paper", showarrow=False, xanchor="left")
+    fig.add_annotation(text="Angle direction", x=0.12, xref="paper", y=1.105, yref="paper", showarrow=False, xanchor="left")
+    fig.add_annotation(text="Difference colors", x=0.29, xref="paper", y=1.105, yref="paper", showarrow=False, xanchor="left")
     return fig.to_html(full_html=False, include_plotlyjs="cdn")
 
 

--- a/analysis/lm_head_pairwise_angles/plot_lm_head_pairwise_angle_trend.py
+++ b/analysis/lm_head_pairwise_angles/plot_lm_head_pairwise_angle_trend.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Plot LM-head pairwise angle-difference metrics across checkpoint iterations."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+from pathlib import Path
+from typing import Dict, List
+
+from compare_lm_head_pairwise_angles import compare_lm_head_pairwise_angles
+
+TREND_METRICS = [
+    "diff_deg_mean",
+    "diff_deg_median",
+    "diff_deg_std",
+    "rmse_deg",
+    "avg_abs_degrees_difference",
+    "median_abs_degrees_difference",
+    "stddev_abs_degrees_difference",
+]
+
+
+def checkpoint_for_iteration(run_dir: str, iteration: int) -> str:
+    return str(Path(run_dir) / f"{iteration}.pt")
+
+
+def build_trend(
+    run_a: str,
+    run_b: str,
+    iterations: List[int],
+    *,
+    meta: str | None,
+    device: str,
+    min_angle: float,
+    max_angle: float,
+) -> List[Dict[str, float]]:
+    rows: List[Dict[str, float]] = []
+    for iteration in iterations:
+        ckpt_a = checkpoint_for_iteration(run_a, iteration)
+        ckpt_b = checkpoint_for_iteration(run_b, iteration)
+        if not os.path.exists(ckpt_a) or not os.path.exists(ckpt_b):
+            missing = ckpt_a if not os.path.exists(ckpt_a) else ckpt_b
+            raise FileNotFoundError(f"Missing checkpoint for iteration {iteration}: {missing}")
+        result = compare_lm_head_pairwise_angles(
+            ckpt_a,
+            ckpt_b,
+            meta=meta,
+            device=device,
+            min_angle=min_angle,
+            max_angle=max_angle,
+        )
+        row: Dict[str, float] = {"iteration": float(iteration)}
+        row.update(result.metrics)
+        rows.append(row)
+    return rows
+
+
+def write_trend_csv(rows: List[Dict[str, float]], csv_path: str) -> None:
+    os.makedirs(os.path.dirname(os.path.abspath(csv_path)) or ".", exist_ok=True)
+    fieldnames = ["iteration"] + [key for key in rows[0] if key != "iteration"] if rows else ["iteration"]
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def trend_html(rows: List[Dict[str, float]]) -> str:
+    import plotly.graph_objects as go
+
+    iterations = [row["iteration"] for row in rows]
+    fig = go.Figure()
+    for metric in TREND_METRICS:
+        y = [row.get(metric) for row in rows]
+        if metric.startswith("diff_deg") or metric == "rmse_deg":
+            error = [row.get("diff_deg_std", 0.0) for row in rows]
+        else:
+            error = [row.get("stddev_abs_degrees_difference", 0.0) for row in rows]
+        fig.add_trace(
+            go.Scatter(
+                x=iterations,
+                y=y,
+                mode="lines+markers",
+                name=metric,
+                error_y={"type": "data", "array": error, "visible": True},
+            )
+        )
+    fig.update_layout(
+        title="LM-head pairwise angle-difference trend",
+        xaxis_title="Training iteration",
+        yaxis_title="Degrees",
+        hovermode="x unified",
+    )
+    return fig.to_html(full_html=True, include_plotlyjs="cdn")
+
+
+def write_trend_html(rows: List[Dict[str, float]], html_path: str) -> None:
+    os.makedirs(os.path.dirname(os.path.abspath(html_path)) or ".", exist_ok=True)
+    with open(html_path, "w", encoding="utf-8") as f:
+        f.write(trend_html(rows))
+
+
+def parse_iterations(value: str) -> List[int]:
+    return [int(item) for item in value.replace(",", " ").split()]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("run_a", help="Directory containing iteration checkpoints for run A")
+    parser.add_argument("run_b", help="Directory containing iteration checkpoints for run B")
+    parser.add_argument("--iterations", default="0,200,400,600,800")
+    parser.add_argument("--meta", default=None)
+    parser.add_argument("--device", default="cpu", choices=["cpu", "cuda", "auto"])
+    parser.add_argument("--min-angle", type=float, default=0.0)
+    parser.add_argument("--max-angle", type=float, default=180.0)
+    parser.add_argument("--csv", required=True)
+    parser.add_argument("--html", required=True)
+    args = parser.parse_args()
+
+    rows = build_trend(
+        args.run_a,
+        args.run_b,
+        parse_iterations(args.iterations),
+        meta=args.meta,
+        device=args.device,
+        min_angle=args.min_angle,
+        max_angle=args.max_angle,
+    )
+    write_trend_csv(rows, args.csv)
+    write_trend_html(rows, args.html)
+    print(f"wrote trend CSV: {args.csv}")
+    print(f"wrote trend HTML: {args.html}")
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/shakespeare_lm_head_pairwise_angles_demo.sh
+++ b/demos/shakespeare_lm_head_pairwise_angles_demo.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Train two tiny shakespeare_char models with different seeds, then compare
+# lm_head pairwise vocabulary-vector angles and emit an interactive HTML report.
+
+set -euo pipefail
+
+DATA_DIR="data/shakespeare_char"
+OUT_ROOT="out/shakespeare_lm_head_pairwise_angles_demo"
+RUN_A="${OUT_ROOT}/seed_1337"
+RUN_B="${OUT_ROOT}/seed_2024"
+REPORT_DIR="${OUT_ROOT}/analysis"
+
+mkdir -p "${REPORT_DIR}"
+
+pushd "${DATA_DIR}" > /dev/null
+bash get_dataset.sh
+if [[ ! -f train.bin || ! -f val.bin || ! -f meta.pkl ]]; then
+  python3 prepare.py -t input.txt --method char
+fi
+popd > /dev/null
+
+train_one() {
+  local seed="$1"
+  local out_dir="$2"
+  rm -rf "${out_dir}"
+  python3 train.py \
+    --dataset shakespeare_char \
+    --out_dir "${out_dir}" \
+    --init_from scratch \
+    --seed "${seed}" \
+    --max_iters 200 \
+    --eval_interval 100 \
+    --eval_iters 20 \
+    --log_interval 20 \
+    --always_save_checkpoint \
+    --block_size 64 \
+    --batch_size 32 \
+    --n_layer 4 \
+    --n_head 4 \
+    --n_embd 128 \
+    --learning_rate 1e-3 \
+    --device cuda \
+    --no-compile || \
+  python3 train.py \
+    --dataset shakespeare_char \
+    --out_dir "${out_dir}" \
+    --init_from scratch \
+    --seed "${seed}" \
+    --max_iters 200 \
+    --eval_interval 100 \
+    --eval_iters 20 \
+    --log_interval 20 \
+    --always_save_checkpoint \
+    --block_size 64 \
+    --batch_size 32 \
+    --n_layer 4 \
+    --n_head 4 \
+    --n_embd 128 \
+    --learning_rate 1e-3 \
+    --device cpu \
+    --no-compile
+}
+
+train_one 1337 "${RUN_A}"
+train_one 2024 "${RUN_B}"
+
+python3 analysis/lm_head_pairwise_angles/compare_lm_head_pairwise_angles.py \
+  "${RUN_A}/ckpt.pt" "${RUN_B}/ckpt.pt" \
+  --meta "${DATA_DIR}/meta.pkl" \
+  --device auto \
+  --min-angle 0 --max-angle 180 \
+  --csv "${REPORT_DIR}/lm_head_pairwise_pairs.csv" \
+  --html "${REPORT_DIR}/lm_head_pairwise_report.html"
+
+cat <<MSG
+Wrote ${REPORT_DIR}/lm_head_pairwise_report.html
+To launch the selector webapp for these and other checkpoints:
+  python3 analysis/lm_head_pairwise_angles/app.py --ckpt-root ${OUT_ROOT}
+MSG

--- a/demos/shakespeare_lm_head_pairwise_angles_demo.sh
+++ b/demos/shakespeare_lm_head_pairwise_angles_demo.sh
@@ -9,6 +9,7 @@ OUT_ROOT="out/shakespeare_lm_head_pairwise_angles_demo"
 RUN_A="${OUT_ROOT}/seed_1337"
 RUN_B="${OUT_ROOT}/seed_2024"
 REPORT_DIR="${OUT_ROOT}/analysis"
+ITERATIONS="0,200,400,600,800"
 
 mkdir -p "${REPORT_DIR}"
 
@@ -28,34 +29,41 @@ train_one() {
     --out_dir "${out_dir}" \
     --init_from scratch \
     --seed "${seed}" \
-    --max_iters 200 \
+    --max_iters 1000 \
     --eval_interval 100 \
     --eval_iters 20 \
     --log_interval 20 \
-    --always_save_checkpoint \
+    --save_major_ckpt_interval 200 \
     --block_size 64 \
     --batch_size 32 \
-    --n_layer 4 \
-    --n_head 4 \
-    --n_embd 128 \
+    --use_rotary_embeddings \
+    --no-use_abs_pos_embeddings \
+    --use_qk_norm \
+    --use_qk_norm_scale \
+    --n_layer 5 \
+    --n_head 3 \
+    --n_embd 384 \
     --learning_rate 1e-3 \
-    --device cuda \
     --no-compile || \
   python3 train.py \
     --dataset shakespeare_char \
     --out_dir "${out_dir}" \
     --init_from scratch \
     --seed "${seed}" \
-    --max_iters 200 \
+    --max_iters 1000 \
     --eval_interval 100 \
     --eval_iters 20 \
     --log_interval 20 \
-    --always_save_checkpoint \
+    --save_major_ckpt_interval 200 \
     --block_size 64 \
     --batch_size 32 \
-    --n_layer 4 \
-    --n_head 4 \
-    --n_embd 128 \
+    --use_rotary_embeddings \
+    --no-use_abs_pos_embeddings \
+    --use_qk_norm \
+    --use_qk_norm_scale \
+    --n_layer 5 \
+    --n_head 3 \
+    --n_embd 384 \
     --learning_rate 1e-3 \
     --device cpu \
     --no-compile
@@ -65,15 +73,25 @@ train_one 1337 "${RUN_A}"
 train_one 2024 "${RUN_B}"
 
 python3 analysis/lm_head_pairwise_angles/compare_lm_head_pairwise_angles.py \
-  "${RUN_A}/ckpt.pt" "${RUN_B}/ckpt.pt" \
+  "${RUN_A}/800.pt" "${RUN_B}/800.pt" \
   --meta "${DATA_DIR}/meta.pkl" \
   --device auto \
   --min-angle 0 --max-angle 180 \
   --csv "${REPORT_DIR}/lm_head_pairwise_pairs.csv" \
   --html "${REPORT_DIR}/lm_head_pairwise_report.html"
 
+python3 analysis/lm_head_pairwise_angles/plot_lm_head_pairwise_angle_trend.py \
+  "${RUN_A}" "${RUN_B}" \
+  --iterations "${ITERATIONS}" \
+  --meta "${DATA_DIR}/meta.pkl" \
+  --device auto \
+  --min-angle 0 --max-angle 180 \
+  --csv "${REPORT_DIR}/lm_head_pairwise_trend.csv" \
+  --html "${REPORT_DIR}/lm_head_pairwise_trend.html"
+
 cat <<MSG
 Wrote ${REPORT_DIR}/lm_head_pairwise_report.html
+Wrote ${REPORT_DIR}/lm_head_pairwise_trend.html
 To launch the selector webapp for these and other checkpoints:
   python3 analysis/lm_head_pairwise_angles/app.py --ckpt-root ${OUT_ROOT}
 MSG


### PR DESCRIPTION
### Motivation

- Provide an easy way to measure whether the geometric relationships of `lm_head` vocabulary vectors (pairwise angles) are preserved between two checkpoints. 
- Enable quick visual and numeric inspection of angle-preservation for small vocabularies (e.g., `shakespeare_char`) including focused analysis on an angle window. 
- Offer a lightweight web UI to select checkpoints and device, inspect results interactively, and export CSV/HTML reports.

### Description

- Add an analysis package `analysis/lm_head_pairwise_angles` with a CLI `compare_lm_head_pairwise_angles.py` that locates `lm_head` weights (with fallbacks), computes full pairwise angle matrices (degrees), filters pairs by a min/max angle window, computes summary metrics (mean/median/std/min/max, MAE, RMSE, Pearson r), and supports CSV/HTML export. 
- Add `plot_html` visualizations using Plotly producing: canonical-order pair scatter (angles), a difference histogram, an angles heatmap, and a difference heatmap. 
- Add a small Flask webapp `analysis/lm_head_pairwise_angles/app.py` that scans a checkpoint root for `.pt` files, lets users choose two checkpoints and device (`cpu|cuda|auto`), set angle-window parameters, and render metrics + Plotly results in-browser. 
- Add a demo script `demos/shakespeare_lm_head_pairwise_angles_demo.sh` that prepares `shakespeare_char`, trains two tiny seeded runs, runs the comparison to produce CSV/HTML artifacts, and prints how to launch the webapp.

### Testing

- Successfully type-checked/compiled the new Python modules with `python3 -m py_compile analysis/lm_head_pairwise_angles/compare_lm_head_pairwise_angles.py analysis/lm_head_pairwise_angles/app.py` (passed). 
- Verified the demo script syntax with `bash -n demos/shakespeare_lm_head_pairwise_angles_demo.sh` (passed). 
- Runtime smoke tests that execute the angle computations were not run here because PyTorch is not available in this environment, so GPU/torch execution was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eecb2c234832681e1565c42b4a2d1)