### PR TITLE
Add iteration & candidate status tracking with timestamps/ETA to hyperparam search and viewer

### DIFF
--- a/hyperparam_search.py
+++ b/hyperparam_search.py
@@ -199,6 +199,18 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def elapsed_since_iso(value: Any) -> float | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - dt.astimezone(timezone.utc)).total_seconds()
+
+
 def save_log(path: Path, log: Dict[str, Any]) -> None:
     tmp = path.with_suffix(".tmp")
     tmp.write_text(yaml.dump(log, sort_keys=False))
@@ -358,6 +370,28 @@ def main():
                 src = min(dup_idx, len(val) - 1)
                 val.insert(src + 1, deepcopy(val[src]))
 
+    def _expected_candidate_count(cfg: Dict[str, Any]) -> int:
+        total = 0
+        for pname in args.param_names:
+            if pname not in cfg:
+                continue
+            base_val = cfg[pname]
+            if pname == "n_layer":
+                total += int(cfg["n_layer"]) if args.nlayer_dup_mode == "dup_each" else 1
+            elif isinstance(base_val, (int, float)):
+                total += args.iterations
+            elif isinstance(base_val, list):
+                total += sum(
+                    args.iterations for elem in base_val if isinstance(elem, (int, float))
+                )
+        return total
+
+    def _completed_experiment_count(candidates: List[Dict[str, Any]]) -> int:
+        return sum(
+            int(candidate.get("completed_random_iterations", len(candidate.get("seeds", []))))
+            for candidate in candidates
+        )
+
     if log["iterations"]:
         last = log["iterations"][-1]
         resume_running_iter = (
@@ -438,6 +472,9 @@ def main():
         existing_iter_block = next(
             (it for it in log["iterations"] if it.get("iter") == cur_iter), None
         )
+        expected_experiments = (
+            _expected_candidate_count(baseline_cfg) * args.random_iterations
+        )
         iter_started_at = (
             existing_iter_block.get("started_at")
             if existing_iter_block and existing_iter_block.get("status") == "running"
@@ -462,6 +499,10 @@ def main():
             "status": "running",
             "started_at": iter_started_at,
             "last_updated_at": iter_started_at,
+            "elapsed_seconds": 0.0,
+            "estimated_remaining_seconds": None,
+            "completed_experiments": 0,
+            "expected_experiments": expected_experiments,
             "baseline_config_before": deepcopy(baseline_cfg),
             "baseline_config_after": deepcopy(baseline_cfg),
         }
@@ -477,6 +518,20 @@ def main():
                     candidates[idx] = candidate
                     return
             candidates.append(candidate)
+
+        def _refresh_iteration_progress() -> None:
+            completed = _completed_experiment_count(candidates)
+            elapsed = elapsed_since_iso(iter_block.get("started_at"))
+            iter_block["completed_experiments"] = completed
+            iter_block["expected_experiments"] = expected_experiments
+            if elapsed is not None:
+                iter_block["elapsed_seconds"] = elapsed
+                remaining_experiments = max(expected_experiments - completed, 0)
+                iter_block["estimated_remaining_seconds"] = (
+                    (elapsed / completed) * remaining_experiments if completed > 0 else None
+                )
+            if completed >= expected_experiments and expected_experiments > 0:
+                iter_block["estimated_remaining_seconds"] = 0.0
 
         for pname in args.param_names:
             if pname not in baseline_cfg:
@@ -523,6 +578,7 @@ def main():
                         }
                     )
                     iter_block["last_updated_at"] = utc_now_iso()
+                    _refresh_iteration_progress()
                     upsert_iteration(log, cur_iter, iter_block)
                     save_log(log_path, log)
 
@@ -583,6 +639,7 @@ def main():
                         }
                     )
                     iter_block["last_updated_at"] = utc_now_iso()
+                    _refresh_iteration_progress()
                     upsert_iteration(log, cur_iter, iter_block)
                     save_log(log_path, log)
 
@@ -695,6 +752,7 @@ def main():
                 }
                 _upsert_candidate(cand)
                 iter_block["last_updated_at"] = utc_now_iso()
+                _refresh_iteration_progress()
                 upsert_iteration(log, cur_iter, iter_block)
                 save_log(log_path, log)
 
@@ -790,6 +848,7 @@ def main():
                             "baseline_config_after": deepcopy(baseline_cfg),
                         }
                     )
+                    _refresh_iteration_progress()
                     upsert_iteration(log, cur_iter, iter_block)
                     log["baseline_config"] = deepcopy(baseline_cfg)
                     save_log(log_path, log)
@@ -806,6 +865,7 @@ def main():
             iter_block["last_updated_at"] = utc_now_iso()
             iter_block["chosen"] = None
             iter_block["baseline_config_after"] = deepcopy(baseline_cfg)
+            _refresh_iteration_progress()
             upsert_iteration(log, cur_iter, iter_block)
             log["stop_reason"] = "no_positive_efficiency"
             log["baseline_config"] = deepcopy(baseline_cfg)
@@ -869,6 +929,7 @@ def main():
                 "baseline_config_after": deepcopy(baseline_cfg),
             }
         )
+        _refresh_iteration_progress()
         upsert_iteration(log, cur_iter, iter_block)
         log["baseline_config"] = deepcopy(baseline_cfg)
         save_log(log_path, log)

--- a/hyperparam_search.py
+++ b/hyperparam_search.py
@@ -360,7 +360,18 @@ def main():
 
     if log["iterations"]:
         last = log["iterations"][-1]
-        baseline_cfg = deepcopy(last["baseline_config_after"])
+        resume_running_iter = (
+            last.get("iter", -1) >= 0 and last.get("status") == "running"
+        )
+        baseline_cfg_key = (
+            "baseline_config_before" if resume_running_iter else "baseline_config_after"
+        )
+        baseline_cfg = deepcopy(
+            last.get(
+                baseline_cfg_key,
+                last.get("baseline_config_after", log["baseline_config"]),
+            )
+        )
         base_loss = last["baseline_metrics"]["loss"]
         base_score = last["baseline_metrics"]["score"]
         base_rankme = last["baseline_metrics"].get("rankme", float("nan"))
@@ -373,7 +384,7 @@ def main():
         base_torch_reserved = last["baseline_metrics"].get("peak_torch_reserved_mb", 0.0)
         base_process_gpu = last["baseline_metrics"].get("peak_process_gpu_mb", 0.0)
         base_iter_ms = last["baseline_metrics"].get("iter_latency_avg", 0.0)
-        cur_iter = last["iter"] + 1
+        cur_iter = last["iter"] if resume_running_iter else last["iter"] + 1
         _apply_overrides_to_active_config(
             baseline_cfg, args.override_cfg, "resumed baseline_cfg"
         )
@@ -424,7 +435,14 @@ def main():
         candidates: List[Dict[str, Any]] = []
         best_choice: Tuple[float, Dict[str, Any]] | None = None
         previous_best_iter = log["iterations"][-1]["baseline_metrics"].get("best_iter")
-        iter_started_at = utc_now_iso()
+        existing_iter_block = next(
+            (it for it in log["iterations"] if it.get("iter") == cur_iter), None
+        )
+        iter_started_at = (
+            existing_iter_block.get("started_at")
+            if existing_iter_block and existing_iter_block.get("status") == "running"
+            else utc_now_iso()
+        )
         iter_block = {
             "iter": cur_iter,
             "baseline_metrics": {

--- a/hyperparam_search.py
+++ b/hyperparam_search.py
@@ -23,6 +23,8 @@ import os
 import re
 import subprocess
 import sys
+import time
+from datetime import datetime, timezone
 from contextlib import contextmanager
 from copy import deepcopy
 from pathlib import Path
@@ -193,10 +195,24 @@ def load_log(path: Path) -> Dict[str, Any]:
     return data or {}
 
 
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
 def save_log(path: Path, log: Dict[str, Any]) -> None:
     tmp = path.with_suffix(".tmp")
     tmp.write_text(yaml.dump(log, sort_keys=False))
     tmp.replace(path)
+
+
+def upsert_iteration(log: Dict[str, Any], iter_idx: int, block: Dict[str, Any]) -> None:
+    """Replace the iteration block for *iter_idx*, or append it if missing."""
+    iterations = log.setdefault("iterations", [])
+    for idx, existing in enumerate(iterations):
+        if existing.get("iter") == iter_idx:
+            iterations[idx] = block
+            return
+    iterations.append(block)
 
 
 # ───────────────────────── search controller ─────────────────────────
@@ -407,6 +423,42 @@ def main():
         print(f"========== Iteration {cur_iter} ==========")
         candidates: List[Dict[str, Any]] = []
         best_choice: Tuple[float, Dict[str, Any]] | None = None
+        previous_best_iter = log["iterations"][-1]["baseline_metrics"].get("best_iter")
+        iter_started_at = utc_now_iso()
+        iter_block = {
+            "iter": cur_iter,
+            "baseline_metrics": {
+                "loss": base_loss,
+                "score": base_score,
+                "params": base_params,
+                "peak_torch_allocated_mb": base_torch_alloc,
+                "peak_torch_reserved_mb": base_torch_reserved,
+                "peak_process_gpu_mb": base_process_gpu,
+                "iter_latency_avg": base_iter_ms,
+                "best_iter": previous_best_iter,
+                "rankme": base_rankme,
+                "areq": base_areq,
+            },
+            "candidates": candidates,
+            "chosen": None,
+            "status": "running",
+            "started_at": iter_started_at,
+            "last_updated_at": iter_started_at,
+            "baseline_config_before": deepcopy(baseline_cfg),
+            "baseline_config_after": deepcopy(baseline_cfg),
+        }
+        upsert_iteration(log, cur_iter, iter_block)
+        save_log(log_path, log)
+
+        def _upsert_candidate(candidate: Dict[str, Any]) -> None:
+            for idx, existing in enumerate(candidates):
+                if (
+                    existing.get("param") == candidate.get("param")
+                    and existing.get("value") == candidate.get("value")
+                ):
+                    candidates[idx] = candidate
+                    return
+            candidates.append(candidate)
 
         for pname in args.param_names:
             if pname not in baseline_cfg:
@@ -422,17 +474,39 @@ def main():
             def _evaluate(
                 cfg_template: Dict[str, Any], label_for_log: str, value_for_log: Any
             ) -> None:
-                nonlocal best_choice, candidates
+                nonlocal best_choice, candidates, iter_block
 
                 seed0 = int(cfg_template.get("seed", 1337))
                 if args.randomize_seed:
                     seed0 = random.randint(0, 2**31 - 1)
                 seed_runs: List[Dict[str, Any]] = []
                 scores: List[float] = []
+                candidate_started_at = utc_now_iso()
+                candidate_start_time = time.monotonic()
 
                 for r in range(args.random_iterations):
                     cfg_run = deepcopy(cfg_template)
                     cfg_run["seed"] = seed0 + r
+
+                    candidate_elapsed = time.monotonic() - candidate_start_time
+                    _upsert_candidate(
+                        {
+                            "param": label_for_log,
+                            "value": value_for_log,
+                            "status": "running",
+                            "started_at": candidate_started_at,
+                            "last_updated_at": utc_now_iso(),
+                            "elapsed_seconds": candidate_elapsed,
+                            "estimated_remaining_seconds": None,
+                            "current_seed": cfg_run["seed"],
+                            "seeds": seed_runs,
+                            "completed_random_iterations": len(seed_runs),
+                            "expected_random_iterations": args.random_iterations,
+                        }
+                    )
+                    iter_block["last_updated_at"] = utc_now_iso()
+                    upsert_iteration(log, cur_iter, iter_block)
+                    save_log(log_path, log)
 
                     print(f"[TEST] {label_for_log}={value_for_log}  seed={cfg_run['seed']}")
                     try:
@@ -467,6 +541,32 @@ def main():
                         }
                     )
                     scores.append(score)
+                    candidate_elapsed = time.monotonic() - candidate_start_time
+                    completed_runs = len(seed_runs)
+                    expected_runs = args.random_iterations
+                    estimated_remaining = (
+                        (candidate_elapsed / completed_runs) * (expected_runs - completed_runs)
+                        if completed_runs > 0
+                        else None
+                    )
+                    _upsert_candidate(
+                        {
+                            "param": label_for_log,
+                            "value": value_for_log,
+                            "status": "running",
+                            "started_at": candidate_started_at,
+                            "last_updated_at": utc_now_iso(),
+                            "elapsed_seconds": candidate_elapsed,
+                            "estimated_remaining_seconds": estimated_remaining,
+                            "current_seed": None,
+                            "seeds": seed_runs,
+                            "completed_random_iterations": completed_runs,
+                            "expected_random_iterations": expected_runs,
+                        }
+                    )
+                    iter_block["last_updated_at"] = utc_now_iso()
+                    upsert_iteration(log, cur_iter, iter_block)
+                    save_log(log_path, log)
 
                 avg_score = sum(scores) / len(scores)
                 avg_torch_alloc = (
@@ -567,8 +667,18 @@ def main():
                     "target_delta": objective_delta,
                     "target_improvement": objective_improvement,
                     "seeds": seed_runs,
+                    "completed_random_iterations": len(seed_runs),
+                    "expected_random_iterations": args.random_iterations,
+                    "status": "complete",
+                    "started_at": candidate_started_at,
+                    "last_updated_at": utc_now_iso(),
+                    "elapsed_seconds": time.monotonic() - candidate_start_time,
+                    "estimated_remaining_seconds": 0.0,
                 }
-                candidates.append(cand)
+                _upsert_candidate(cand)
+                iter_block["last_updated_at"] = utc_now_iso()
+                upsert_iteration(log, cur_iter, iter_block)
+                save_log(log_path, log)
 
                 if eff > 0:
                     if best_choice is None:
@@ -653,27 +763,16 @@ def main():
                         f"'max_iters' from {current_max_iters} to {new_max_iters}."
                     )
                     baseline_cfg["max_iters"] = new_max_iters
-                    log["iterations"].append(
+                    iter_block.update(
                         {
-                            "iter": cur_iter,
-                            "baseline_metrics": {
-                                "loss": base_loss,
-                                "score": base_score,
-                                "params": base_params,
-                                "peak_torch_allocated_mb": base_torch_alloc,
-                                "peak_torch_reserved_mb": base_torch_reserved,
-                                "peak_process_gpu_mb": base_process_gpu,
-                                "iter_latency_avg": base_iter_ms,
-                                "best_iter": log["iterations"][-1]["baseline_metrics"]["best_iter"],
-                                "rankme": base_rankme,
-                                "areq": base_areq,
-                            },
-                            "candidates": candidates,
+                            "status": "complete",
+                            "last_updated_at": utc_now_iso(),
                             "chosen": None,
                             "action": f"max_iters_increased_to_{new_max_iters}",
                             "baseline_config_after": deepcopy(baseline_cfg),
                         }
                     )
+                    upsert_iteration(log, cur_iter, iter_block)
                     log["baseline_config"] = deepcopy(baseline_cfg)
                     save_log(log_path, log)
                     cur_iter += 1
@@ -685,6 +784,11 @@ def main():
                     )
 
             print("No positive-efficiency candidate — stopping.")
+            iter_block["status"] = "complete"
+            iter_block["last_updated_at"] = utc_now_iso()
+            iter_block["chosen"] = None
+            iter_block["baseline_config_after"] = deepcopy(baseline_cfg)
+            upsert_iteration(log, cur_iter, iter_block)
             log["stop_reason"] = "no_positive_efficiency"
             log["baseline_config"] = deepcopy(baseline_cfg)
             save_log(log_path, log)
@@ -727,9 +831,11 @@ def main():
         base_rankme = chosen.get("avg_rankme", base_rankme)
         base_areq = chosen.get("avg_areq", base_areq)
 
-        log["iterations"].append(
+        iter_block.update(
             {
-                "iter": cur_iter,
+                "status": "complete",
+                "last_updated_at": utc_now_iso(),
+                "chosen": chosen,
                 "baseline_metrics": {
                     "loss": base_loss,
                     "score": base_score,
@@ -742,11 +848,10 @@ def main():
                     "rankme": base_rankme,
                     "areq": base_areq,
                 },
-                "candidates": candidates,
-                "chosen": chosen,
                 "baseline_config_after": deepcopy(baseline_cfg),
             }
         )
+        upsert_iteration(log, cur_iter, iter_block)
         log["baseline_config"] = deepcopy(baseline_cfg)
         save_log(log_path, log)
         cur_iter += 1

--- a/hyperparam_search.py
+++ b/hyperparam_search.py
@@ -466,12 +466,20 @@ def main():
 
     while cur_iter < args.num_iterations:
         print(f"========== Iteration {cur_iter} ==========")
-        candidates: List[Dict[str, Any]] = []
-        best_choice: Tuple[float, Dict[str, Any]] | None = None
-        previous_best_iter = log["iterations"][-1]["baseline_metrics"].get("best_iter")
         existing_iter_block = next(
             (it for it in log["iterations"] if it.get("iter") == cur_iter), None
         )
+        resume_iteration = (
+            existing_iter_block is not None
+            and existing_iter_block.get("status") == "running"
+        )
+        candidates: List[Dict[str, Any]] = (
+            deepcopy(existing_iter_block.get("candidates", []))
+            if resume_iteration
+            else []
+        )
+        best_choice: Tuple[float, Dict[str, Any]] | None = None
+        previous_best_iter = log["iterations"][-1]["baseline_metrics"].get("best_iter")
         expected_experiments = (
             _expected_candidate_count(baseline_cfg) * args.random_iterations
         )
@@ -479,6 +487,17 @@ def main():
             existing_iter_block.get("started_at")
             if existing_iter_block and existing_iter_block.get("status") == "running"
             else utc_now_iso()
+        )
+        initial_completed_experiments = _completed_experiment_count(candidates)
+        initial_elapsed_seconds = elapsed_since_iso(iter_started_at) or 0.0
+        initial_remaining_experiments = max(
+            expected_experiments - initial_completed_experiments, 0
+        )
+        initial_estimated_remaining = (
+            (initial_elapsed_seconds / initial_completed_experiments)
+            * initial_remaining_experiments
+            if initial_completed_experiments > 0
+            else None
         )
         iter_block = {
             "iter": cur_iter,
@@ -499,9 +518,9 @@ def main():
             "status": "running",
             "started_at": iter_started_at,
             "last_updated_at": iter_started_at,
-            "elapsed_seconds": 0.0,
-            "estimated_remaining_seconds": None,
-            "completed_experiments": 0,
+            "elapsed_seconds": initial_elapsed_seconds,
+            "estimated_remaining_seconds": initial_estimated_remaining,
+            "completed_experiments": initial_completed_experiments,
             "expected_experiments": expected_experiments,
             "baseline_config_before": deepcopy(baseline_cfg),
             "baseline_config_after": deepcopy(baseline_cfg),
@@ -533,6 +552,32 @@ def main():
             if completed >= expected_experiments and expected_experiments > 0:
                 iter_block["estimated_remaining_seconds"] = 0.0
 
+        def _find_candidate(label_for_log: str, value_for_log: Any) -> Dict[str, Any] | None:
+            for candidate in candidates:
+                if (
+                    candidate.get("param") == label_for_log
+                    and candidate.get("value") == value_for_log
+                ):
+                    return candidate
+            return None
+
+        def _consider_best_choice(cand: Dict[str, Any]) -> None:
+            nonlocal best_choice
+            eff = cand.get("efficiency")
+            if not isinstance(eff, (int, float)) or eff <= 0:
+                return
+            if best_choice is None:
+                best_choice = (eff, cand)
+                return
+            old_eff, old_cand = best_choice
+            if (eff > old_eff) or (
+                math.isinf(eff)
+                and eff == old_eff
+                and cand.get("target_improvement", float("-inf"))
+                > old_cand.get("target_improvement", float("-inf"))
+            ):
+                best_choice = (eff, cand)
+
         for pname in args.param_names:
             if pname not in baseline_cfg:
                 print(f"[WARN] parameter '{pname}' not in baseline config – skipping")
@@ -549,15 +594,50 @@ def main():
             ) -> None:
                 nonlocal best_choice, candidates, iter_block
 
-                seed0 = int(cfg_template.get("seed", 1337))
-                if args.randomize_seed:
-                    seed0 = random.randint(0, 2**31 - 1)
-                seed_runs: List[Dict[str, Any]] = []
-                scores: List[float] = []
-                candidate_started_at = utc_now_iso()
-                candidate_start_time = time.monotonic()
+                existing_candidate = _find_candidate(label_for_log, value_for_log)
+                if existing_candidate and existing_candidate.get("status") == "complete":
+                    _consider_best_choice(existing_candidate)
+                    return
 
-                for r in range(args.random_iterations):
+                seed_runs: List[Dict[str, Any]] = deepcopy(
+                    (existing_candidate or {}).get("seeds", [])
+                )
+                scores: List[float] = [
+                    float(seed_run["score"])
+                    for seed_run in seed_runs
+                    if isinstance(seed_run.get("score"), (int, float))
+                ]
+                seed0 = int(cfg_template.get("seed", 1337))
+                if seed_runs:
+                    seed0 = int(seed_runs[0]["seed"])
+                elif existing_candidate and existing_candidate.get("current_seed") is not None:
+                    seed0 = int(existing_candidate["current_seed"])
+                elif args.randomize_seed:
+                    seed0 = random.randint(0, 2**31 - 1)
+                candidate_started_at = (
+                    existing_candidate.get("started_at")
+                    if existing_candidate and existing_candidate.get("started_at")
+                    else utc_now_iso()
+                )
+                prior_elapsed = (existing_candidate or {}).get("elapsed_seconds", 0.0)
+                if not isinstance(prior_elapsed, (int, float)):
+                    prior_elapsed = 0.0
+                candidate_start_time = time.monotonic() - prior_elapsed
+                nparam = None
+                for seed_run in reversed(seed_runs):
+                    if isinstance(seed_run.get("num_params"), (int, float)):
+                        nparam = seed_run["num_params"]
+                        break
+
+                if len(seed_runs) >= args.random_iterations and nparam is None:
+                    seed_runs = seed_runs[:-1]
+                    scores = [
+                        float(seed_run["score"])
+                        for seed_run in seed_runs
+                        if isinstance(seed_run.get("score"), (int, float))
+                    ]
+
+                for r in range(len(seed_runs), args.random_iterations):
                     cfg_run = deepcopy(cfg_template)
                     cfg_run["seed"] = seed0 + r
 
@@ -606,6 +686,7 @@ def main():
                             "loss": loss,
                             "score": score,
                             "best_iter": best_it,
+                            "num_params": nparam,
                             "peak_torch_allocated_mb": torch_alloc_mb,
                             "peak_torch_reserved_mb": torch_resv_mb,
                             "peak_process_gpu_mb": process_gpu_mb,
@@ -669,6 +750,9 @@ def main():
                     if not math.isnan(avg_areq) and not math.isnan(base_areq)
                     else float("nan")
                 )
+                if nparam is None:
+                    raise RuntimeError("Unable to determine num_params for candidate")
+
                 d_param = nparam - base_params
                 d_torch_alloc = avg_torch_alloc - base_torch_alloc
                 d_torch_reserved = avg_torch_reserved - base_torch_reserved
@@ -756,17 +840,7 @@ def main():
                 upsert_iteration(log, cur_iter, iter_block)
                 save_log(log_path, log)
 
-                if eff > 0:
-                    if best_choice is None:
-                        best_choice = (eff, cand)
-                    else:
-                        old_eff, old_cand = best_choice
-                        if (eff > old_eff) or (
-                            math.isinf(eff)
-                            and eff == old_eff
-                            and cand["target_improvement"] > old_cand["target_improvement"]
-                        ):
-                            best_choice = (eff, cand)
+                _consider_best_choice(cand)
 
             if pname == "n_layer":
                 old_nlayer = int(baseline_cfg["n_layer"])

--- a/view_hp_log.py
+++ b/view_hp_log.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import re
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -64,6 +64,15 @@ def human_duration(seconds: Any) -> str:
     return f"{secs}s"
 
 
+def hms_duration(seconds: Any) -> str:
+    if not isinstance(seconds, (int, float)) or seconds < 0:
+        return "-"
+    seconds = int(round(seconds))
+    hours, rem = divmod(seconds, 3600)
+    minutes, secs = divmod(rem, 60)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+
+
 def parse_iso_time(value: Any) -> datetime | None:
     if not isinstance(value, str) or not value:
         return None
@@ -100,6 +109,72 @@ def progress_text(candidate: Dict[str, Any] | None) -> str:
     done = candidate.get("completed_random_iterations", len(candidate.get("seeds", [])))
     expected = candidate.get("expected_random_iterations", "?")
     return f"{done}/{expected} seeds"
+
+
+def iteration_progress(blk: Dict[str, Any]) -> str:
+    completed = blk.get("completed_experiments")
+    expected = blk.get("expected_experiments")
+    if not isinstance(completed, int):
+        completed = sum(
+            int(
+                candidate.get(
+                    "completed_random_iterations", len(candidate.get("seeds", []))
+                )
+            )
+            for candidate in blk.get("candidates", [])
+        )
+    if not isinstance(expected, int):
+        candidate_expectations = [
+            candidate.get("expected_random_iterations")
+            for candidate in blk.get("candidates", [])
+        ]
+        expected = sum(v for v in candidate_expectations if isinstance(v, int))
+    return f"{completed}/{expected}" if expected else f"{completed}/?"
+
+
+def iteration_elapsed_seconds(blk: Dict[str, Any]) -> Any:
+    if blk.get("status") == "running" and blk.get("started_at"):
+        return elapsed_since(blk.get("started_at"))
+    elapsed = blk.get("elapsed_seconds")
+    if isinstance(elapsed, (int, float)):
+        return elapsed
+    started = parse_iso_time(blk.get("started_at"))
+    updated = parse_iso_time(blk.get("last_updated_at"))
+    if started and updated:
+        if started.tzinfo is None:
+            started = started.replace(tzinfo=timezone.utc)
+        if updated.tzinfo is None:
+            updated = updated.replace(tzinfo=timezone.utc)
+        return (
+            updated.astimezone(timezone.utc) - started.astimezone(timezone.utc)
+        ).total_seconds()
+    return "-"
+
+
+def iteration_remaining_seconds(blk: Dict[str, Any]) -> Any:
+    remaining = blk.get("estimated_remaining_seconds")
+    if isinstance(remaining, (int, float)):
+        return remaining
+    completed = blk.get("completed_experiments")
+    expected = blk.get("expected_experiments")
+    elapsed = iteration_elapsed_seconds(blk)
+    if (
+        isinstance(completed, int)
+        and isinstance(expected, int)
+        and completed > 0
+        and expected >= completed
+        and isinstance(elapsed, (int, float))
+    ):
+        return (elapsed / completed) * (expected - completed)
+    return "-"
+
+
+def eta_completion_time(seconds: Any) -> str:
+    if not isinstance(seconds, (int, float)) or seconds < 0:
+        return "-"
+    return (datetime.now().astimezone() + timedelta(seconds=seconds)).strftime(
+        "%Y-%m-%d %H:%M:%S %Z"
+    )
 
 
 def metrics_panel(
@@ -326,6 +401,10 @@ class SweepViewer(App):
         changed = sorted({it["chosen"]["param"] for it in self.iters if it.get("chosen")})
         hdrs = [
             "iter",
+            "elapsed",
+            "progress",
+            "ETA",
+            "ETA done",
             *changed,
             "best_loss",
             "best_iter",
@@ -363,6 +442,10 @@ class SweepViewer(App):
         rows.append(
             [
                 "-1",
+                "-",
+                "-",
+                "-",
+                "-",
                 *base_vals,
                 fnum(self.base_metrics.get("loss", "-"), "{:.4f}"),
                 str(self.base_metrics.get("best_iter", "-")),
@@ -446,7 +529,17 @@ class SweepViewer(App):
                     "-",
                     "-",
                 ]
-            rows.append([str(it.get("iter", i)), *vals])
+            remaining = iteration_remaining_seconds(it)
+            rows.append(
+                [
+                    str(it.get("iter", i)),
+                    hms_duration(iteration_elapsed_seconds(it)),
+                    iteration_progress(it),
+                    hms_duration(remaining),
+                    eta_completion_time(remaining),
+                    *vals,
+                ]
+            )
         return hdrs, rows
 
     def _refresh_view(self):

--- a/view_hp_log.py
+++ b/view_hp_log.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import re
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -50,8 +51,60 @@ def fnum(val: Any, spec: str) -> str:
     return spec.format(val) if isinstance(val, (int, float)) else str(val)
 
 
+def human_duration(seconds: Any) -> str:
+    if not isinstance(seconds, (int, float)) or seconds < 0:
+        return "-"
+    seconds = int(round(seconds))
+    hours, rem = divmod(seconds, 3600)
+    minutes, secs = divmod(rem, 60)
+    if hours:
+        return f"{hours}h {minutes:02d}m"
+    if minutes:
+        return f"{minutes}m {secs:02d}s"
+    return f"{secs}s"
+
+
+def parse_iso_time(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def short_time(value: Any) -> str:
+    dt = parse_iso_time(value)
+    return dt.astimezone().strftime("%Y-%m-%d %H:%M:%S %Z") if dt else "-"
+
+
+def elapsed_since(value: Any) -> float | None:
+    dt = parse_iso_time(value)
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - dt.astimezone(timezone.utc)).total_seconds()
+
+
+def current_task(blk: Dict[str, Any]) -> Dict[str, Any] | None:
+    for candidate in blk.get("candidates", []):
+        if candidate.get("status") == "running":
+            return candidate
+    return None
+
+
+def progress_text(candidate: Dict[str, Any] | None) -> str:
+    if not candidate:
+        return "-"
+    done = candidate.get("completed_random_iterations", len(candidate.get("seeds", [])))
+    expected = candidate.get("expected_random_iterations", "?")
+    return f"{done}/{expected} seeds"
+
+
 def metrics_panel(
     current_iter_baseline_metrics: Dict[str, Any],
+    iteration_block: Dict[str, Any] | None = None,
     prev_iter_baseline_loss: Any = "-",
     prev_iter_baseline_rankme: Any = "-",
     prev_iter_baseline_areq: Any = "-",
@@ -62,6 +115,22 @@ def metrics_panel(
     g = Table.grid(padding=1)
     g.add_column(justify="right")
     g.add_column()
+    if iteration_block is not None:
+        task = current_task(iteration_block)
+        g.add_row("Status", str(iteration_block.get("status", "-")))
+        g.add_row("Started", short_time(iteration_block.get("started_at")))
+        if task:
+            g.add_row("Running task", f"{task.get('param', '-')}={task.get('value', '-')}")
+            g.add_row("Task progress", progress_text(task))
+            if task.get("current_seed") is not None:
+                g.add_row("Current seed", str(task.get("current_seed")))
+            g.add_row("Task started", short_time(task.get("started_at")))
+            elapsed = task.get("elapsed_seconds")
+            if not isinstance(elapsed, (int, float)) and task.get("started_at"):
+                elapsed = elapsed_since(task.get("started_at"))
+            g.add_row("Task elapsed", human_duration(elapsed))
+            g.add_row("Task ETA", human_duration(task.get("estimated_remaining_seconds")))
+
     g.add_row("Prior Loss", fnum(prev_iter_baseline_loss, "{:.4f}"))
     g.add_row(
         "After Iteration Loss",
@@ -445,6 +514,7 @@ class SweepViewer(App):
         panel.update(
             metrics_panel(
                 current_iter_baseline_metrics=current_baseline_metrics,
+                iteration_block=blk,
                 prev_iter_baseline_loss=prior_loss_val,
                 current_avg_candidate_loss=current_avg_loss_display,
                 prior_avg_candidate_loss=prior_avg_loss_display,
@@ -456,6 +526,12 @@ class SweepViewer(App):
         self.sub_title = f"Iteration {blk['iter']}  (↑/↓ nav, q quit)"
         table.clear(columns=True)
         table.add_columns(
+            "status",
+            "progress",
+            "seed",
+            "started",
+            "elapsed",
+            "ETA",
             "param",
             "value",
             "best_loss",
@@ -484,25 +560,34 @@ class SweepViewer(App):
                 and c["value"] == chosen.get("value")
             )
             st = "bold yellow" if hl else ""
+            elapsed = c.get("elapsed_seconds")
+            if not isinstance(elapsed, (int, float)) and c.get("started_at"):
+                elapsed = elapsed_since(c.get("started_at"))
             table.add_row(
-                Text(str(c["param"]), style=st),
-                Text(str(c["value"]), style=st),
-                f"{c['best_val_loss']:.4f}",
+                Text(str(c.get("status", "complete")), style=st),
+                Text(progress_text(c), style=st),
+                Text(str(c.get("current_seed", "-")), style=st),
+                Text(short_time(c.get("started_at")), style=st),
+                Text(human_duration(elapsed), style=st),
+                Text(human_duration(c.get("estimated_remaining_seconds")), style=st),
+                Text(str(c.get("param", "-")), style=st),
+                Text(str(c.get("value", "-")), style=st),
+                fnum(c.get("best_val_loss", c.get("avg_loss", "-")), "{:.4f}"),
                 str(c.get("best_iter", "-")),
                 fnum(c.get("avg_rankme", "-"), "{:.4f}"),
                 fnum(c.get("delta_rankme", "-"), "{:+.4f}"),
                 fnum(c.get("avg_areq", "-"), "{:.4f}"),
                 fnum(c.get("delta_areq", "-"), "{:+.4f}"),
-                f"{c.get('peak_torch_allocated_mb', c.get('peak_gpu_mb', float('nan'))):.1f}",
-                f"{c.get('peak_torch_reserved_mb', float('nan')):.1f}",
-                f"{c.get('peak_process_gpu_mb', float('nan')):.1f}",
-                f"{c['delta_score']:.2e}",
-                f"{c['delta_params']:.2e}",
-                f"{c.get('delta_torch_allocated_mb', float('nan')):.1f}",
-                f"{c.get('delta_torch_reserved_mb', float('nan')):.1f}",
-                f"{c.get('delta_process_gpu_mb', float('nan')):.1f}",
-                f"{c.get('delta_iter_latency', float('nan')):.2f}",
-                f"{c['efficiency']:.2e}",
+                fnum(c.get('peak_torch_allocated_mb', c.get('peak_gpu_mb', "-")), "{:.1f}"),
+                fnum(c.get('peak_torch_reserved_mb', "-"), "{:.1f}"),
+                fnum(c.get('peak_process_gpu_mb', "-"), "{:.1f}"),
+                fnum(c.get('delta_score', "-"), "{:.2e}"),
+                fnum(c.get('delta_params', "-"), "{:.2e}"),
+                fnum(c.get('delta_torch_allocated_mb', "-"), "{:.1f}"),
+                fnum(c.get('delta_torch_reserved_mb', "-"), "{:.1f}"),
+                fnum(c.get('delta_process_gpu_mb', "-"), "{:.1f}"),
+                fnum(c.get('delta_iter_latency', "-"), "{:.2f}"),
+                fnum(c.get('efficiency', "-"), "{:.2e}"),
             )
 
 


### PR DESCRIPTION
### Motivation
- Improve observability of the greedy hyper-parameter search by recording iteration-level metadata, candidate progress, and timestamps so long-running searches can be monitored and resumed.
- Surface running candidate status, per-seed progress and ETA in the TUI viewer to make live monitoring of multi-seed evaluations usable.

### Description
- Update `hyperparam_search.py` to record ISO timestamps and richer iteration blocks in `sweep_log.yaml`, adding `utc_now_iso()` and `upsert_iteration()` helpers and switching to upsert semantics for iterations instead of naive appends.
- Track per-candidate fields while evaluating multi-seed runs including `status`, `started_at`, `last_updated_at`, `elapsed_seconds`, `estimated_remaining_seconds`, `current_seed`, `completed_random_iterations`, and `expected_random_iterations`, and persist these updates incrementally to the log.
- Ensure candidate blocks are updated in-place (via `_upsert_candidate`) and mark iterations as `running`/`complete` with `baseline_config_before`/`baseline_config_after` snapshots.
- Update `view_hp_log.py` to parse ISO timestamps, display human-friendly durations/ETAs, and show candidate progress in the TUI by adding `human_duration()`, `parse_iso_time()`, `short_time()`, `elapsed_since()`, `current_task()`, and `progress_text()` helpers; add new columns and status/progress fields to the candidate table and the metrics panel.

### Testing
- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e5def68c48326b8ff90b795437d99)