### PR TITLE
Export per-eval LM-head minimum-angle graphs + Plotly viewer, demo, and training integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,52 @@ python3 view_model_stats.py run1_stats.csv run2_stats.csv
 See [documentation/Model_Stats_Table.md](documentation/Model_Stats_Table.md)
 for more details.
 
+## LM-head minimum-angle graph exports
+
+`train.py` can optionally export the same closest-neighbor graph used by the
+LM-head angle explorer's minimum-angular-distance view after each validation
+loss. The export treats each LM-head row as a token vector, streams
+row/column blocks through the selected compute device, excludes each token's
+self-distance, and records the closest non-self token by signed `0°–180°`
+angular distance. The full `vocab_size × vocab_size` angle matrix is never
+materialized.
+
+Enable the export by choosing a labelled output directory and turning on the
+per-eval flag:
+
+```bash
+python3 train.py \
+  --export_min_angle_graph_dir out/min_angle_graphs \
+  --export_min_angle_graph_each_eval \
+  --export_min_angle_graph_label shakespeare_char_baseline
+```
+
+Each validation step writes a labelled CSV and JSON sidecar whose filename
+includes the label, iteration, and validation loss:
+
+```text
+out/min_angle_graphs/shakespeare_char_baseline_iter_00000250_val_1.234567.csv
+out/min_angle_graphs/shakespeare_char_baseline_iter_00000250_val_1.234567.json
+```
+
+The CSV is an edge list with one directed nearest-neighbor edge per token:
+
+```text
+token_id,nearest_token_id,min_angle_deg,cosine,token_vector_length,nearest_token_vector_length,min_angle_rank
+```
+
+Use `--export_min_angle_graph_block_size` to tune temporary matrix multiply
+size, and `--export_min_angle_graph_device` to choose `auto`, `cpu`, or a CUDA
+device such as `cuda:0`. In `auto` mode, the export uses the LM-head tensor's
+current CUDA device when possible, otherwise streams blocks to `cuda:0` if CUDA
+is available, and falls back to CPU.
+
+To review a sequence of exports visually, open
+`analysis/min_angle_graph_plotly_viewer.html` in a browser and select the CSV
+files from one export directory. The page sorts snapshots by the iteration in
+their filenames and provides previous/next/play controls plus a slider to step
+from the first validation export to the last.
+
 ## TODO Section:
 
 TODO: Add links and descriptions to other Readme's and Demos.

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ out/min_angle_graphs/shakespeare_char_baseline_iter_00000250_val_1.234567.json
 The CSV is an edge list with one directed nearest-neighbor edge per token:
 
 ```text
-token_id,nearest_token_id,min_angle_deg,cosine,token_vector_length,nearest_token_vector_length,min_angle_rank
+token_id,token_text_escaped,nearest_token_id,nearest_token_text_escaped,min_angle_deg,cosine,token_vector_length,nearest_token_vector_length,min_angle_rank
 ```
 
 Use `--export_min_angle_graph_block_size` to tune temporary matrix multiply

--- a/analysis/min_angle_graph_plotly_viewer.html
+++ b/analysis/min_angle_graph_plotly_viewer.html
@@ -180,6 +180,7 @@
     <section class="plots">
       <div class="panel plot" id="angleScatter"></div>
       <div class="panel plot" id="angleHistogram"></div>
+      <div class="panel plot" id="magnitudeByRank"></div>
       <div class="panel plot wide" id="edgeMap"></div>
     </section>
 
@@ -396,6 +397,24 @@
         title: "Minimum-angle distribution",
         xaxis: {title: "minimum angle (degrees)"},
         yaxis: {title: "token count", type: "log", autorange: true},
+      }, {responsive: true});
+
+      Plotly.react("magnitudeByRank", [{
+        type: "bar",
+        x: rows.map((row) => row.min_angle_rank),
+        y: rows.map((row) => row.token_vector_length),
+        marker: {
+          color: rows.map((row) => row.min_angle_deg),
+          colorscale: "Viridis",
+          colorbar: {title: "angle°"},
+        },
+        text: rows.map((row) => formatRowHover(row, "rank")),
+        hovertemplate: "%{text}<extra></extra>",
+      }], {
+        ...commonLayout,
+        title: "Token magnitude by minimum-angle rank",
+        xaxis: {title: "minimum-angle rank"},
+        yaxis: {title: "token vector magnitude"},
       }, {responsive: true});
 
       Plotly.react("edgeMap", [{

--- a/analysis/min_angle_graph_plotly_viewer.html
+++ b/analysis/min_angle_graph_plotly_viewer.html
@@ -284,6 +284,14 @@
         .replaceAll("'", "&#39;");
     }
 
+    function tokenTextOrMissing(row, textKey) {
+      const value = row[textKey];
+      if (value === undefined || value === null || value === "") {
+        return "[token text missing: regenerate CSV exports]";
+      }
+      return value;
+    }
+
     function readFile(file) {
       return new Promise((resolve, reject) => {
         const reader = new FileReader();
@@ -309,7 +317,11 @@
     function snapshotLabel(snapshot, index) {
       const iter = Number.isFinite(snapshot.iter) ? snapshot.iter : "unknown";
       const valLoss = Number.isFinite(snapshot.valLoss) ? snapshot.valLoss.toFixed(6) : "unknown";
-      return `Snapshot ${index + 1}/${state.snapshots.length}: ${snapshot.name}\niteration=${iter}, val_loss=${valLoss}, rows=${snapshot.rows.length}`;
+      const hasTokenText = snapshot.rows.some((row) => row.token_text_escaped || row.nearest_token_text_escaped);
+      const tokenTextNote = hasTokenText
+        ? ""
+        : "\nToken text columns are empty/missing; regenerate CSV exports with the latest exporter to show actual token strings.";
+      return `Snapshot ${index + 1}/${state.snapshots.length}: ${snapshot.name}\niteration=${iter}, val_loss=${valLoss}, rows=${snapshot.rows.length}${tokenTextNote}`;
     }
 
     function currentRowsForTable(snapshot) {
@@ -331,8 +343,8 @@
     }
 
     function formatRowHover(row, rankLabel) {
-      const tokenText = escapedCell(row.token_text_escaped || "");
-      const nearestText = escapedCell(row.nearest_token_text_escaped || "");
+      const tokenText = escapedCell(tokenTextOrMissing(row, "token_text_escaped"));
+      const nearestText = escapedCell(tokenTextOrMissing(row, "nearest_token_text_escaped"));
       return [
         `${rankLabel}=${escapedCell(row.min_angle_rank)}`,
         `angle=${formatNumber(row.min_angle_deg)}°`,
@@ -411,9 +423,9 @@
         <tr>
           <td>${row.min_angle_rank}</td>
           <td>${row.token_id}</td>
-          <td>${escapedCell(row.token_text_escaped)}</td>
+          <td>${escapedCell(tokenTextOrMissing(row, "token_text_escaped"))}</td>
           <td>${row.nearest_token_id}</td>
-          <td>${escapedCell(row.nearest_token_text_escaped)}</td>
+          <td>${escapedCell(tokenTextOrMissing(row, "nearest_token_text_escaped"))}</td>
           <td>${Number(row.min_angle_deg).toFixed(6)}° / ${Number(row.token_vector_length).toFixed(6)} → ${Number(row.nearest_token_vector_length).toFixed(6)}</td>
           <td>${Number(row.cosine).toFixed(6)}</td>
           <td>${Number(row.token_vector_length).toFixed(6)}</td>

--- a/analysis/min_angle_graph_plotly_viewer.html
+++ b/analysis/min_angle_graph_plotly_viewer.html
@@ -68,6 +68,16 @@
       padding: 0;
       accent-color: var(--accent);
     }
+    input[type="checkbox"] {
+      width: auto;
+      accent-color: var(--accent);
+    }
+    .checkbox-row {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      min-height: 2.4rem;
+    }
     button {
       cursor: pointer;
       background: #2563eb;
@@ -160,6 +170,13 @@
           <input id="maxPlotPoints" type="number" min="500" max="100000" step="500" value="5000">
         </div>
         <div>
+          <label for="showMagnitudePlot">Optional plots</label>
+          <div class="checkbox-row">
+            <input id="showMagnitudePlot" type="checkbox">
+            <span>Show magnitude-by-rank plot</span>
+          </div>
+        </div>
+        <div>
           <label for="angleCap">Highlight angle cap (degrees)</label>
           <input id="angleCap" type="number" min="0" max="180" step="0.1" value="10">
         </div>
@@ -184,7 +201,7 @@
     <section class="plots">
       <div class="panel plot" id="angleScatter"></div>
       <div class="panel plot" id="angleHistogram"></div>
-      <div class="panel plot" id="magnitudeByRank"></div>
+      <div class="panel plot" id="magnitudeByRank" style="display: none;"></div>
       <div class="panel plot wide" id="edgeMap"></div>
     </section>
 
@@ -221,6 +238,7 @@
     const csvInput = document.getElementById("csvFiles");
     const maxRowsInput = document.getElementById("maxRows");
     const maxPlotPointsInput = document.getElementById("maxPlotPoints");
+    const showMagnitudePlotInput = document.getElementById("showMagnitudePlot");
     const angleCapInput = document.getElementById("angleCap");
     const sortModeInput = document.getElementById("sortMode");
     const slider = document.getElementById("snapshotSlider");
@@ -436,23 +454,30 @@
         yaxis: {title: "token count", type: "log", autorange: true},
       }, {responsive: true});
 
-      Plotly.react("magnitudeByRank", [{
-        type: "bar",
-        x: plotRows.map((row) => row.min_angle_rank),
-        y: plotRows.map((row) => row.token_vector_length),
-        marker: {
-          color: plotRows.map((row) => row.min_angle_deg),
-          colorscale: "Viridis",
-          colorbar: {title: "angle°"},
-        },
-        text: plotRows.map((row) => formatRowHover(row, "rank")),
-        hovertemplate: "%{text}<extra></extra>",
-      }], {
-        ...commonLayout,
-        title: "Token magnitude by minimum-angle rank",
-        xaxis: {title: "minimum-angle rank"},
-        yaxis: {title: "token vector magnitude"},
-      }, {responsive: true});
+      const magnitudePlot = document.getElementById("magnitudeByRank");
+      if (showMagnitudePlotInput.checked) {
+        magnitudePlot.style.display = "";
+        Plotly.react("magnitudeByRank", [{
+          type: "bar",
+          x: plotRows.map((row) => row.min_angle_rank),
+          y: plotRows.map((row) => row.token_vector_length),
+          marker: {
+            color: plotRows.map((row) => row.min_angle_deg),
+            colorscale: "Viridis",
+            colorbar: {title: "angle°"},
+          },
+          text: plotRows.map((row) => formatRowHover(row, "rank")),
+          hovertemplate: "%{text}<extra></extra>",
+        }], {
+          ...commonLayout,
+          title: "Token magnitude by minimum-angle rank",
+          xaxis: {title: "minimum-angle rank"},
+          yaxis: {title: "token vector magnitude"},
+        }, {responsive: true});
+      } else {
+        magnitudePlot.style.display = "none";
+        Plotly.purge("magnitudeByRank");
+      }
 
       Plotly.react("edgeMap", [{
         type: "scattergl",
@@ -570,6 +595,7 @@
     });
     maxRowsInput.addEventListener("input", plotSnapshot);
     maxPlotPointsInput.addEventListener("input", plotSnapshot);
+    showMagnitudePlotInput.addEventListener("change", plotSnapshot);
     angleCapInput.addEventListener("input", plotSnapshot);
     sortModeInput.addEventListener("change", plotSnapshot);
   </script>

--- a/analysis/min_angle_graph_plotly_viewer.html
+++ b/analysis/min_angle_graph_plotly_viewer.html
@@ -191,8 +191,10 @@
             <tr>
               <th>rank</th>
               <th>token_id</th>
+              <th>token_text_escaped</th>
               <th>nearest_token_id</th>
-              <th>min_angle_deg</th>
+              <th>nearest_token_text_escaped</th>
+              <th>min_angle_deg / magnitudes</th>
               <th>cosine</th>
               <th>token_vector_length</th>
               <th>nearest_token_vector_length</th>
@@ -232,14 +234,37 @@
       };
     }
 
+    function parseCsvLine(line) {
+      const values = [];
+      let value = "";
+      let inQuotes = false;
+      for (let index = 0; index < line.length; index += 1) {
+        const char = line[index];
+        const nextChar = line[index + 1];
+        if (char === '"' && inQuotes && nextChar === '"') {
+          value += '"';
+          index += 1;
+        } else if (char === '"') {
+          inQuotes = !inQuotes;
+        } else if (char === "," && !inQuotes) {
+          values.push(value);
+          value = "";
+        } else {
+          value += char;
+        }
+      }
+      values.push(value);
+      return values;
+    }
+
     function parseCsv(text) {
       const lines = text.trim().split(/\r?\n/).filter(Boolean);
       if (lines.length < 2) {
         return [];
       }
-      const headers = lines[0].split(",").map((h) => h.trim());
+      const headers = parseCsvLine(lines[0]).map((h) => h.trim());
       return lines.slice(1).map((line) => {
-        const values = line.split(",");
+        const values = parseCsvLine(line);
         const row = {};
         headers.forEach((header, index) => {
           const raw = values[index] ?? "";
@@ -248,6 +273,15 @@
         });
         return row;
       });
+    }
+
+    function escapedCell(value) {
+      return String(value ?? "")
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#39;");
     }
 
     function readFile(file) {
@@ -312,8 +346,16 @@
         x: rows.map((row) => row.min_angle_rank),
         y: rows.map((row) => row.min_angle_deg),
         marker: {size: 5, color: colors, opacity: 0.75},
-        customdata: rows.map((row) => [row.token_id, row.nearest_token_id, row.cosine]),
-        hovertemplate: "rank=%{x}<br>angle=%{y:.6f}°<br>token=%{customdata[0]}<br>nearest=%{customdata[1]}<br>cosine=%{customdata[2]:.6f}<extra></extra>",
+        customdata: rows.map((row) => [
+          row.token_id,
+          row.token_text_escaped,
+          row.nearest_token_id,
+          row.nearest_token_text_escaped,
+          row.cosine,
+          row.token_vector_length,
+          row.nearest_token_vector_length,
+        ]),
+        hovertemplate: "rank=%{x}<br>angle=%{y:.6f}°<br>token=%{customdata[0]} (%{customdata[1]})<br>nearest=%{customdata[2]} (%{customdata[3]})<br>magnitudes=%{customdata[5]:.6f} → %{customdata[6]:.6f}<br>cosine=%{customdata[4]:.6f}<extra></extra>",
       }], {
         ...commonLayout,
         title: "Minimum angle by sorted rank",
@@ -346,8 +388,16 @@
           colorbar: {title: "angle°"},
           opacity: 0.75,
         },
-        customdata: rows.map((row) => [row.min_angle_rank, row.cosine]),
-        hovertemplate: "token=%{x}<br>nearest=%{y}<br>rank=%{customdata[0]}<br>cosine=%{customdata[1]:.6f}<extra></extra>",
+        customdata: rows.map((row) => [
+          row.min_angle_rank,
+          row.cosine,
+          row.token_text_escaped,
+          row.nearest_token_text_escaped,
+          row.min_angle_deg,
+          row.token_vector_length,
+          row.nearest_token_vector_length,
+        ]),
+        hovertemplate: "token=%{x} (%{customdata[2]})<br>nearest=%{y} (%{customdata[3]})<br>rank=%{customdata[0]}<br>angle=%{customdata[4]:.6f}°<br>magnitudes=%{customdata[5]:.6f} → %{customdata[6]:.6f}<br>cosine=%{customdata[1]:.6f}<extra></extra>",
       }], {
         ...commonLayout,
         title: "Nearest-neighbor edge map",
@@ -359,8 +409,10 @@
         <tr>
           <td>${row.min_angle_rank}</td>
           <td>${row.token_id}</td>
+          <td>${escapedCell(row.token_text_escaped)}</td>
           <td>${row.nearest_token_id}</td>
-          <td>${Number(row.min_angle_deg).toFixed(6)}</td>
+          <td>${escapedCell(row.nearest_token_text_escaped)}</td>
+          <td>${Number(row.min_angle_deg).toFixed(6)}° / ${Number(row.token_vector_length).toFixed(6)} → ${Number(row.nearest_token_vector_length).toFixed(6)}</td>
           <td>${Number(row.cosine).toFixed(6)}</td>
           <td>${Number(row.token_vector_length).toFixed(6)}</td>
           <td>${Number(row.nearest_token_vector_length).toFixed(6)}</td>

--- a/analysis/min_angle_graph_plotly_viewer.html
+++ b/analysis/min_angle_graph_plotly_viewer.html
@@ -103,7 +103,10 @@
       color: var(--muted);
       font-size: 0.9rem;
       margin-top: 0.75rem;
-      white-space: pre-wrap;
+      height: 1.25rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
     .plots {
       display: grid;
@@ -164,10 +167,6 @@
         <div>
           <label for="maxRows">Table rows</label>
           <input id="maxRows" type="number" min="10" max="10000" step="10" value="250">
-        </div>
-        <div>
-          <label for="maxPlotPoints">Max plotted points</label>
-          <input id="maxPlotPoints" type="number" min="500" max="100000" step="500" value="5000">
         </div>
         <div>
           <label for="showMagnitudePlot">Optional plots</label>
@@ -237,7 +236,6 @@
 
     const csvInput = document.getElementById("csvFiles");
     const maxRowsInput = document.getElementById("maxRows");
-    const maxPlotPointsInput = document.getElementById("maxPlotPoints");
     const showMagnitudePlotInput = document.getElementById("showMagnitudePlot");
     const angleCapInput = document.getElementById("angleCap");
     const sortModeInput = document.getElementById("sortMode");
@@ -358,8 +356,8 @@
       const hasTokenText = rows.some((row) => row.token_text_escaped || row.nearest_token_text_escaped);
       const tokenTextNote = hasTokenText
         ? ""
-        : "\nToken text columns are empty/missing; regenerate CSV exports with the latest exporter to show actual token strings.";
-      return `Snapshot ${index + 1}/${state.snapshots.length}: ${snapshot.name}\niteration=${iter}, val_loss=${valLoss}, rows=${rows.length}${tokenTextNote}`;
+        : " | Token text columns are empty/missing; regenerate CSV exports with the latest exporter to show actual token strings.";
+      return `Snapshot ${index + 1}/${state.snapshots.length}: ${snapshot.name} | iteration=${iter}, val_loss=${valLoss}, rows=${rows.length}${tokenTextNote}`;
     }
 
     function currentRowsForTable(snapshot) {
@@ -373,23 +371,6 @@
         rows.sort((a, b) => a.min_angle_rank - b.min_angle_rank);
       }
       return rows.slice(0, Number(maxRowsInput.value || 250));
-    }
-
-    function downsampleRowsByRank(rows, maxPoints) {
-      const limit = Math.max(1, Number(maxPoints || 5000));
-      if (rows.length <= limit) {
-        return rows;
-      }
-      const sortedRows = [...rows].sort((a, b) => a.min_angle_rank - b.min_angle_rank);
-      if (limit === 1) {
-        return [sortedRows[0]];
-      }
-      const step = (sortedRows.length - 1) / (limit - 1);
-      const sampled = [];
-      for (let index = 0; index < limit; index += 1) {
-        sampled.push(sortedRows[Math.round(index * step)]);
-      }
-      return sampled;
     }
 
     function formatNumber(value, digits = 6) {
@@ -416,9 +397,8 @@
       }
       const snapshot = state.snapshots[state.currentIndex];
       const rows = await ensureSnapshotRows(snapshot);
-      const plotRows = downsampleRowsByRank(rows, maxPlotPointsInput.value);
       const cap = Number(angleCapInput.value || 10);
-      const colors = plotRows.map((row) => row.min_angle_deg <= cap ? "#f97316" : "#60a5fa");
+      const colors = rows.map((row) => row.min_angle_deg <= cap ? "#f97316" : "#60a5fa");
       const commonLayout = {
         paper_bgcolor: "#1f2937",
         plot_bgcolor: "#111827",
@@ -429,10 +409,10 @@
       Plotly.react("angleScatter", [{
         type: "scattergl",
         mode: "markers",
-        x: plotRows.map((row) => row.min_angle_rank),
-        y: plotRows.map((row) => row.min_angle_deg),
+        x: rows.map((row) => row.min_angle_rank),
+        y: rows.map((row) => row.min_angle_deg),
         marker: {size: 5, color: colors, opacity: 0.75},
-        text: plotRows.map((row) => formatRowHover(row, "rank")),
+        text: rows.map((row) => formatRowHover(row, "rank")),
         hovertemplate: "%{text}<extra></extra>",
       }], {
         ...commonLayout,
@@ -459,14 +439,14 @@
         magnitudePlot.style.display = "";
         Plotly.react("magnitudeByRank", [{
           type: "bar",
-          x: plotRows.map((row) => row.min_angle_rank),
-          y: plotRows.map((row) => row.token_vector_length),
+          x: rows.map((row) => row.min_angle_rank),
+          y: rows.map((row) => row.token_vector_length),
           marker: {
-            color: plotRows.map((row) => row.min_angle_deg),
+            color: rows.map((row) => row.min_angle_deg),
             colorscale: "Viridis",
             colorbar: {title: "angle°"},
           },
-          text: plotRows.map((row) => formatRowHover(row, "rank")),
+          text: rows.map((row) => formatRowHover(row, "rank")),
           hovertemplate: "%{text}<extra></extra>",
         }], {
           ...commonLayout,
@@ -482,16 +462,16 @@
       Plotly.react("edgeMap", [{
         type: "scattergl",
         mode: "markers",
-        x: plotRows.map((row) => row.token_id),
-        y: plotRows.map((row) => row.nearest_token_id),
+        x: rows.map((row) => row.token_id),
+        y: rows.map((row) => row.nearest_token_id),
         marker: {
           size: 5,
-          color: plotRows.map((row) => row.min_angle_deg),
+          color: rows.map((row) => row.min_angle_deg),
           colorscale: "Viridis",
           colorbar: {title: "angle°"},
           opacity: 0.75,
         },
-        text: plotRows.map((row) => formatRowHover(row, "rank")),
+        text: rows.map((row) => formatRowHover(row, "rank")),
         hovertemplate: "%{text}<extra></extra>",
       }], {
         ...commonLayout,
@@ -515,10 +495,7 @@
       `).join("");
 
       slider.value = state.currentIndex;
-      const plotPointNote = plotRows.length < rows.length
-        ? `\nPlots are downsampled to ${plotRows.length} of ${rows.length} rows for responsiveness; table and histogram still use the active CSV rows.`
-        : "";
-      statusBox.textContent = `${snapshotLabel(snapshot, state.currentIndex)}${plotPointNote}`;
+      statusBox.textContent = snapshotLabel(snapshot, state.currentIndex);
     }
 
     async function loadSnapshots(files) {
@@ -594,7 +571,6 @@
       plotSnapshot();
     });
     maxRowsInput.addEventListener("input", plotSnapshot);
-    maxPlotPointsInput.addEventListener("input", plotSnapshot);
     showMagnitudePlotInput.addEventListener("change", plotSnapshot);
     angleCapInput.addEventListener("input", plotSnapshot);
     sortModeInput.addEventListener("change", plotSnapshot);

--- a/analysis/min_angle_graph_plotly_viewer.html
+++ b/analysis/min_angle_graph_plotly_viewer.html
@@ -1,0 +1,451 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LM-head Minimum-Angle Graph Viewer</title>
+  <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #111827;
+      --panel: #1f2937;
+      --text: #e5e7eb;
+      --muted: #9ca3af;
+      --accent: #60a5fa;
+      --border: #374151;
+    }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    header, main {
+      max-width: 1400px;
+      margin: 0 auto;
+      padding: 1rem;
+    }
+    header h1 {
+      margin: 0 0 0.35rem;
+      font-size: 1.6rem;
+    }
+    header p {
+      margin: 0;
+      color: var(--muted);
+      line-height: 1.45;
+    }
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 0.75rem;
+      padding: 1rem;
+      margin-bottom: 1rem;
+      box-shadow: 0 12px 28px rgba(0, 0, 0, 0.2);
+    }
+    .controls {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 0.75rem;
+      align-items: end;
+    }
+    label {
+      display: block;
+      font-size: 0.85rem;
+      color: var(--muted);
+      margin-bottom: 0.25rem;
+    }
+    input, button, select {
+      width: 100%;
+      box-sizing: border-box;
+      border-radius: 0.45rem;
+      border: 1px solid var(--border);
+      padding: 0.55rem 0.65rem;
+      background: #0f172a;
+      color: var(--text);
+    }
+    input[type="range"] {
+      padding: 0;
+      accent-color: var(--accent);
+    }
+    button {
+      cursor: pointer;
+      background: #2563eb;
+      border-color: #2563eb;
+      font-weight: 650;
+    }
+    button.secondary {
+      background: #374151;
+      border-color: #4b5563;
+    }
+    button:disabled {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+    .step-row {
+      display: grid;
+      grid-template-columns: auto auto 1fr auto;
+      gap: 0.5rem;
+      align-items: center;
+      margin-top: 0.85rem;
+    }
+    .status {
+      color: var(--muted);
+      font-size: 0.9rem;
+      margin-top: 0.75rem;
+      white-space: pre-wrap;
+    }
+    .plots {
+      display: grid;
+      grid-template-columns: 1.25fr 0.75fr;
+      gap: 1rem;
+    }
+    .plot {
+      min-height: 420px;
+    }
+    .wide {
+      grid-column: 1 / -1;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.85rem;
+    }
+    th, td {
+      border-bottom: 1px solid var(--border);
+      padding: 0.45rem;
+      text-align: right;
+      font-variant-numeric: tabular-nums;
+    }
+    th {
+      color: var(--muted);
+      position: sticky;
+      top: 0;
+      background: var(--panel);
+    }
+    .table-wrap {
+      max-height: 360px;
+      overflow: auto;
+    }
+    @media (max-width: 900px) {
+      .plots, .step-row {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>LM-head Minimum-Angle Graph Viewer</h1>
+    <p>
+      Load one or more CSV exports from <code>--export_min_angle_graph_dir</code>.
+      The viewer sorts snapshots by iteration and lets you step from the first
+      validation export to the last without uploading data anywhere.
+    </p>
+  </header>
+
+  <main>
+    <section class="panel">
+      <div class="controls">
+        <div>
+          <label for="csvFiles">Minimum-angle graph CSV files</label>
+          <input id="csvFiles" type="file" multiple accept=".csv,text/csv">
+        </div>
+        <div>
+          <label for="maxRows">Table rows</label>
+          <input id="maxRows" type="number" min="10" max="10000" step="10" value="250">
+        </div>
+        <div>
+          <label for="angleCap">Highlight angle cap (degrees)</label>
+          <input id="angleCap" type="number" min="0" max="180" step="0.1" value="10">
+        </div>
+        <div>
+          <label for="sortMode">Table sort</label>
+          <select id="sortMode">
+            <option value="rank">Minimum-angle rank</option>
+            <option value="token">Token ID</option>
+            <option value="angle_desc">Largest angle</option>
+          </select>
+        </div>
+      </div>
+      <div class="step-row">
+        <button id="prevBtn" class="secondary" disabled>Previous</button>
+        <button id="playBtn" disabled>Play</button>
+        <input id="snapshotSlider" type="range" min="0" max="0" value="0" disabled>
+        <button id="nextBtn" class="secondary" disabled>Next</button>
+      </div>
+      <div id="status" class="status">Choose CSV files to begin.</div>
+    </section>
+
+    <section class="plots">
+      <div class="panel plot" id="angleScatter"></div>
+      <div class="panel plot" id="angleHistogram"></div>
+      <div class="panel plot wide" id="edgeMap"></div>
+    </section>
+
+    <section class="panel">
+      <h2>Snapshot rows</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>rank</th>
+              <th>token_id</th>
+              <th>nearest_token_id</th>
+              <th>min_angle_deg</th>
+              <th>cosine</th>
+              <th>token_vector_length</th>
+              <th>nearest_token_vector_length</th>
+            </tr>
+          </thead>
+          <tbody id="rowsBody"></tbody>
+        </table>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    const state = {
+      snapshots: [],
+      currentIndex: 0,
+      playTimer: null,
+    };
+
+    const csvInput = document.getElementById("csvFiles");
+    const maxRowsInput = document.getElementById("maxRows");
+    const angleCapInput = document.getElementById("angleCap");
+    const sortModeInput = document.getElementById("sortMode");
+    const slider = document.getElementById("snapshotSlider");
+    const prevBtn = document.getElementById("prevBtn");
+    const nextBtn = document.getElementById("nextBtn");
+    const playBtn = document.getElementById("playBtn");
+    const statusBox = document.getElementById("status");
+    const rowsBody = document.getElementById("rowsBody");
+
+    function parseSnapshotName(name) {
+      const iterMatch = name.match(/(?:^|_)iter_(\d+)/);
+      const valMatch = name.match(/(?:^|_)val_([0-9.]+)/);
+      return {
+        name,
+        iter: iterMatch ? Number(iterMatch[1]) : Number.NaN,
+        valLoss: valMatch ? Number.parseFloat(valMatch[1]) : Number.NaN,
+      };
+    }
+
+    function parseCsv(text) {
+      const lines = text.trim().split(/\r?\n/).filter(Boolean);
+      if (lines.length < 2) {
+        return [];
+      }
+      const headers = lines[0].split(",").map((h) => h.trim());
+      return lines.slice(1).map((line) => {
+        const values = line.split(",");
+        const row = {};
+        headers.forEach((header, index) => {
+          const raw = values[index] ?? "";
+          const numberValue = Number(raw);
+          row[header] = raw === "" || Number.isNaN(numberValue) ? raw : numberValue;
+        });
+        return row;
+      });
+    }
+
+    function readFile(file) {
+      return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+          const parsedName = parseSnapshotName(file.name);
+          resolve({
+            ...parsedName,
+            rows: parseCsv(String(reader.result)),
+          });
+        };
+        reader.onerror = () => reject(reader.error);
+        reader.readAsText(file);
+      });
+    }
+
+    function enableControls(enabled) {
+      slider.disabled = !enabled;
+      prevBtn.disabled = !enabled;
+      nextBtn.disabled = !enabled;
+      playBtn.disabled = !enabled;
+    }
+
+    function snapshotLabel(snapshot, index) {
+      const iter = Number.isFinite(snapshot.iter) ? snapshot.iter : "unknown";
+      const valLoss = Number.isFinite(snapshot.valLoss) ? snapshot.valLoss.toFixed(6) : "unknown";
+      return `Snapshot ${index + 1}/${state.snapshots.length}: ${snapshot.name}\niteration=${iter}, val_loss=${valLoss}, rows=${snapshot.rows.length}`;
+    }
+
+    function currentRowsForTable(snapshot) {
+      const rows = [...snapshot.rows];
+      const sortMode = sortModeInput.value;
+      if (sortMode === "token") {
+        rows.sort((a, b) => a.token_id - b.token_id);
+      } else if (sortMode === "angle_desc") {
+        rows.sort((a, b) => b.min_angle_deg - a.min_angle_deg);
+      } else {
+        rows.sort((a, b) => a.min_angle_rank - b.min_angle_rank);
+      }
+      return rows.slice(0, Number(maxRowsInput.value || 250));
+    }
+
+    function plotSnapshot() {
+      if (!state.snapshots.length) {
+        return;
+      }
+      const snapshot = state.snapshots[state.currentIndex];
+      const rows = snapshot.rows;
+      const cap = Number(angleCapInput.value || 10);
+      const colors = rows.map((row) => row.min_angle_deg <= cap ? "#f97316" : "#60a5fa");
+      const commonLayout = {
+        paper_bgcolor: "#1f2937",
+        plot_bgcolor: "#111827",
+        font: {color: "#e5e7eb"},
+        margin: {l: 60, r: 20, t: 45, b: 55},
+      };
+
+      Plotly.react("angleScatter", [{
+        type: "scattergl",
+        mode: "markers",
+        x: rows.map((row) => row.min_angle_rank),
+        y: rows.map((row) => row.min_angle_deg),
+        marker: {size: 5, color: colors, opacity: 0.75},
+        customdata: rows.map((row) => [row.token_id, row.nearest_token_id, row.cosine]),
+        hovertemplate: "rank=%{x}<br>angle=%{y:.6f}°<br>token=%{customdata[0]}<br>nearest=%{customdata[1]}<br>cosine=%{customdata[2]:.6f}<extra></extra>",
+      }], {
+        ...commonLayout,
+        title: "Minimum angle by sorted rank",
+        xaxis: {title: "minimum-angle rank"},
+        yaxis: {title: "minimum angle (degrees)"},
+      }, {responsive: true});
+
+      Plotly.react("angleHistogram", [{
+        type: "histogram",
+        x: rows.map((row) => row.min_angle_deg),
+        nbinsx: 60,
+        marker: {color: "#34d399"},
+        hovertemplate: "angle bin=%{x}<br>count=%{y}<extra></extra>",
+      }], {
+        ...commonLayout,
+        title: "Minimum-angle distribution",
+        xaxis: {title: "minimum angle (degrees)"},
+        yaxis: {title: "token count", type: "log", autorange: true},
+      }, {responsive: true});
+
+      Plotly.react("edgeMap", [{
+        type: "scattergl",
+        mode: "markers",
+        x: rows.map((row) => row.token_id),
+        y: rows.map((row) => row.nearest_token_id),
+        marker: {
+          size: 5,
+          color: rows.map((row) => row.min_angle_deg),
+          colorscale: "Viridis",
+          colorbar: {title: "angle°"},
+          opacity: 0.75,
+        },
+        customdata: rows.map((row) => [row.min_angle_rank, row.cosine]),
+        hovertemplate: "token=%{x}<br>nearest=%{y}<br>rank=%{customdata[0]}<br>cosine=%{customdata[1]:.6f}<extra></extra>",
+      }], {
+        ...commonLayout,
+        title: "Nearest-neighbor edge map",
+        xaxis: {title: "token_id"},
+        yaxis: {title: "nearest_token_id"},
+      }, {responsive: true});
+
+      rowsBody.innerHTML = currentRowsForTable(snapshot).map((row) => `
+        <tr>
+          <td>${row.min_angle_rank}</td>
+          <td>${row.token_id}</td>
+          <td>${row.nearest_token_id}</td>
+          <td>${Number(row.min_angle_deg).toFixed(6)}</td>
+          <td>${Number(row.cosine).toFixed(6)}</td>
+          <td>${Number(row.token_vector_length).toFixed(6)}</td>
+          <td>${Number(row.nearest_token_vector_length).toFixed(6)}</td>
+        </tr>
+      `).join("");
+
+      slider.value = state.currentIndex;
+      statusBox.textContent = snapshotLabel(snapshot, state.currentIndex);
+    }
+
+    async function loadSnapshots(files) {
+      if (!files.length) {
+        return;
+      }
+      stopPlayback();
+      statusBox.textContent = "Loading CSV snapshots...";
+      const snapshots = await Promise.all([...files].map(readFile));
+      snapshots.sort((a, b) => {
+        const iterA = Number.isFinite(a.iter) ? a.iter : Number.MAX_SAFE_INTEGER;
+        const iterB = Number.isFinite(b.iter) ? b.iter : Number.MAX_SAFE_INTEGER;
+        return iterA - iterB || a.name.localeCompare(b.name);
+      });
+      state.snapshots = snapshots;
+      state.currentIndex = 0;
+      slider.max = Math.max(0, snapshots.length - 1);
+      enableControls(snapshots.length > 0);
+      plotSnapshot();
+    }
+
+    function step(delta) {
+      if (!state.snapshots.length) {
+        return;
+      }
+      state.currentIndex = Math.max(0, Math.min(state.snapshots.length - 1, state.currentIndex + delta));
+      plotSnapshot();
+    }
+
+    function stopPlayback() {
+      if (state.playTimer) {
+        clearInterval(state.playTimer);
+        state.playTimer = null;
+      }
+      playBtn.textContent = "Play";
+    }
+
+    function togglePlayback() {
+      if (state.playTimer) {
+        stopPlayback();
+        return;
+      }
+      if (!state.snapshots.length) {
+        return;
+      }
+      if (state.currentIndex >= state.snapshots.length - 1) {
+        state.currentIndex = 0;
+        plotSnapshot();
+      }
+      if (state.snapshots.length === 1) {
+        return;
+      }
+      playBtn.textContent = "Pause";
+      state.playTimer = setInterval(() => {
+        if (state.currentIndex >= state.snapshots.length - 1) {
+          stopPlayback();
+          return;
+        }
+        step(1);
+      }, 900);
+    }
+
+    csvInput.addEventListener("change", (event) => loadSnapshots(event.target.files).catch((error) => {
+      console.error(error);
+      statusBox.textContent = `Failed to load snapshots: ${error}`;
+      enableControls(false);
+    }));
+    prevBtn.addEventListener("click", () => step(-1));
+    nextBtn.addEventListener("click", () => step(1));
+    playBtn.addEventListener("click", togglePlayback);
+    slider.addEventListener("input", () => {
+      state.currentIndex = Number(slider.value);
+      plotSnapshot();
+    });
+    maxRowsInput.addEventListener("input", plotSnapshot);
+    angleCapInput.addEventListener("input", plotSnapshot);
+    sortModeInput.addEventListener("change", plotSnapshot);
+  </script>
+</body>
+</html>

--- a/analysis/min_angle_graph_plotly_viewer.html
+++ b/analysis/min_angle_graph_plotly_viewer.html
@@ -325,6 +325,24 @@
       return rows.slice(0, Number(maxRowsInput.value || 250));
     }
 
+    function formatNumber(value, digits = 6) {
+      const numberValue = Number(value);
+      return Number.isFinite(numberValue) ? numberValue.toFixed(digits) : "";
+    }
+
+    function formatRowHover(row, rankLabel) {
+      const tokenText = escapedCell(row.token_text_escaped || "");
+      const nearestText = escapedCell(row.nearest_token_text_escaped || "");
+      return [
+        `${rankLabel}=${escapedCell(row.min_angle_rank)}`,
+        `angle=${formatNumber(row.min_angle_deg)}°`,
+        `token=${escapedCell(row.token_id)} (${tokenText})`,
+        `nearest=${escapedCell(row.nearest_token_id)} (${nearestText})`,
+        `magnitudes=${formatNumber(row.token_vector_length)} → ${formatNumber(row.nearest_token_vector_length)}`,
+        `cosine=${formatNumber(row.cosine)}`,
+      ].join("<br>");
+    }
+
     function plotSnapshot() {
       if (!state.snapshots.length) {
         return;
@@ -346,16 +364,8 @@
         x: rows.map((row) => row.min_angle_rank),
         y: rows.map((row) => row.min_angle_deg),
         marker: {size: 5, color: colors, opacity: 0.75},
-        customdata: rows.map((row) => [
-          row.token_id,
-          row.token_text_escaped,
-          row.nearest_token_id,
-          row.nearest_token_text_escaped,
-          row.cosine,
-          row.token_vector_length,
-          row.nearest_token_vector_length,
-        ]),
-        hovertemplate: "rank=%{x}<br>angle=%{y:.6f}°<br>token=%{customdata[0]} (%{customdata[1]})<br>nearest=%{customdata[2]} (%{customdata[3]})<br>magnitudes=%{customdata[5]:.6f} → %{customdata[6]:.6f}<br>cosine=%{customdata[4]:.6f}<extra></extra>",
+        text: rows.map((row) => formatRowHover(row, "rank")),
+        hovertemplate: "%{text}<extra></extra>",
       }], {
         ...commonLayout,
         title: "Minimum angle by sorted rank",
@@ -388,16 +398,8 @@
           colorbar: {title: "angle°"},
           opacity: 0.75,
         },
-        customdata: rows.map((row) => [
-          row.min_angle_rank,
-          row.cosine,
-          row.token_text_escaped,
-          row.nearest_token_text_escaped,
-          row.min_angle_deg,
-          row.token_vector_length,
-          row.nearest_token_vector_length,
-        ]),
-        hovertemplate: "token=%{x} (%{customdata[2]})<br>nearest=%{y} (%{customdata[3]})<br>rank=%{customdata[0]}<br>angle=%{customdata[4]:.6f}°<br>magnitudes=%{customdata[5]:.6f} → %{customdata[6]:.6f}<br>cosine=%{customdata[1]:.6f}<extra></extra>",
+        text: rows.map((row) => formatRowHover(row, "rank")),
+        hovertemplate: "%{text}<extra></extra>",
       }], {
         ...commonLayout,
         title: "Nearest-neighbor edge map",

--- a/analysis/min_angle_graph_plotly_viewer.html
+++ b/analysis/min_angle_graph_plotly_viewer.html
@@ -156,6 +156,10 @@
           <input id="maxRows" type="number" min="10" max="10000" step="10" value="250">
         </div>
         <div>
+          <label for="maxPlotPoints">Max plotted points</label>
+          <input id="maxPlotPoints" type="number" min="500" max="100000" step="500" value="5000">
+        </div>
+        <div>
           <label for="angleCap">Highlight angle cap (degrees)</label>
           <input id="angleCap" type="number" min="0" max="180" step="0.1" value="10">
         </div>
@@ -216,6 +220,7 @@
 
     const csvInput = document.getElementById("csvFiles");
     const maxRowsInput = document.getElementById("maxRows");
+    const maxPlotPointsInput = document.getElementById("maxPlotPoints");
     const angleCapInput = document.getElementById("angleCap");
     const sortModeInput = document.getElementById("sortMode");
     const slider = document.getElementById("snapshotSlider");
@@ -293,19 +298,32 @@
       return value;
     }
 
-    function readFile(file) {
+    function snapshotFromFile(file) {
+      return {
+        ...parseSnapshotName(file.name),
+        file,
+        rows: null,
+      };
+    }
+
+    function readSnapshotRows(snapshot) {
       return new Promise((resolve, reject) => {
         const reader = new FileReader();
         reader.onload = () => {
-          const parsedName = parseSnapshotName(file.name);
-          resolve({
-            ...parsedName,
-            rows: parseCsv(String(reader.result)),
-          });
+          snapshot.rows = parseCsv(String(reader.result));
+          resolve(snapshot.rows);
         };
         reader.onerror = () => reject(reader.error);
-        reader.readAsText(file);
+        reader.readAsText(snapshot.file);
       });
+    }
+
+    async function ensureSnapshotRows(snapshot) {
+      if (snapshot.rows !== null) {
+        return snapshot.rows;
+      }
+      statusBox.textContent = `Parsing ${snapshot.name}...`;
+      return readSnapshotRows(snapshot);
     }
 
     function enableControls(enabled) {
@@ -318,11 +336,12 @@
     function snapshotLabel(snapshot, index) {
       const iter = Number.isFinite(snapshot.iter) ? snapshot.iter : "unknown";
       const valLoss = Number.isFinite(snapshot.valLoss) ? snapshot.valLoss.toFixed(6) : "unknown";
-      const hasTokenText = snapshot.rows.some((row) => row.token_text_escaped || row.nearest_token_text_escaped);
+      const rows = snapshot.rows || [];
+      const hasTokenText = rows.some((row) => row.token_text_escaped || row.nearest_token_text_escaped);
       const tokenTextNote = hasTokenText
         ? ""
         : "\nToken text columns are empty/missing; regenerate CSV exports with the latest exporter to show actual token strings.";
-      return `Snapshot ${index + 1}/${state.snapshots.length}: ${snapshot.name}\niteration=${iter}, val_loss=${valLoss}, rows=${snapshot.rows.length}${tokenTextNote}`;
+      return `Snapshot ${index + 1}/${state.snapshots.length}: ${snapshot.name}\niteration=${iter}, val_loss=${valLoss}, rows=${rows.length}${tokenTextNote}`;
     }
 
     function currentRowsForTable(snapshot) {
@@ -336,6 +355,23 @@
         rows.sort((a, b) => a.min_angle_rank - b.min_angle_rank);
       }
       return rows.slice(0, Number(maxRowsInput.value || 250));
+    }
+
+    function downsampleRowsByRank(rows, maxPoints) {
+      const limit = Math.max(1, Number(maxPoints || 5000));
+      if (rows.length <= limit) {
+        return rows;
+      }
+      const sortedRows = [...rows].sort((a, b) => a.min_angle_rank - b.min_angle_rank);
+      if (limit === 1) {
+        return [sortedRows[0]];
+      }
+      const step = (sortedRows.length - 1) / (limit - 1);
+      const sampled = [];
+      for (let index = 0; index < limit; index += 1) {
+        sampled.push(sortedRows[Math.round(index * step)]);
+      }
+      return sampled;
     }
 
     function formatNumber(value, digits = 6) {
@@ -356,14 +392,15 @@
       ].join("<br>");
     }
 
-    function plotSnapshot() {
+    async function plotSnapshot() {
       if (!state.snapshots.length) {
         return;
       }
       const snapshot = state.snapshots[state.currentIndex];
-      const rows = snapshot.rows;
+      const rows = await ensureSnapshotRows(snapshot);
+      const plotRows = downsampleRowsByRank(rows, maxPlotPointsInput.value);
       const cap = Number(angleCapInput.value || 10);
-      const colors = rows.map((row) => row.min_angle_deg <= cap ? "#f97316" : "#60a5fa");
+      const colors = plotRows.map((row) => row.min_angle_deg <= cap ? "#f97316" : "#60a5fa");
       const commonLayout = {
         paper_bgcolor: "#1f2937",
         plot_bgcolor: "#111827",
@@ -374,10 +411,10 @@
       Plotly.react("angleScatter", [{
         type: "scattergl",
         mode: "markers",
-        x: rows.map((row) => row.min_angle_rank),
-        y: rows.map((row) => row.min_angle_deg),
+        x: plotRows.map((row) => row.min_angle_rank),
+        y: plotRows.map((row) => row.min_angle_deg),
         marker: {size: 5, color: colors, opacity: 0.75},
-        text: rows.map((row) => formatRowHover(row, "rank")),
+        text: plotRows.map((row) => formatRowHover(row, "rank")),
         hovertemplate: "%{text}<extra></extra>",
       }], {
         ...commonLayout,
@@ -401,14 +438,14 @@
 
       Plotly.react("magnitudeByRank", [{
         type: "bar",
-        x: rows.map((row) => row.min_angle_rank),
-        y: rows.map((row) => row.token_vector_length),
+        x: plotRows.map((row) => row.min_angle_rank),
+        y: plotRows.map((row) => row.token_vector_length),
         marker: {
-          color: rows.map((row) => row.min_angle_deg),
+          color: plotRows.map((row) => row.min_angle_deg),
           colorscale: "Viridis",
           colorbar: {title: "angle°"},
         },
-        text: rows.map((row) => formatRowHover(row, "rank")),
+        text: plotRows.map((row) => formatRowHover(row, "rank")),
         hovertemplate: "%{text}<extra></extra>",
       }], {
         ...commonLayout,
@@ -420,16 +457,16 @@
       Plotly.react("edgeMap", [{
         type: "scattergl",
         mode: "markers",
-        x: rows.map((row) => row.token_id),
-        y: rows.map((row) => row.nearest_token_id),
+        x: plotRows.map((row) => row.token_id),
+        y: plotRows.map((row) => row.nearest_token_id),
         marker: {
           size: 5,
-          color: rows.map((row) => row.min_angle_deg),
+          color: plotRows.map((row) => row.min_angle_deg),
           colorscale: "Viridis",
           colorbar: {title: "angle°"},
           opacity: 0.75,
         },
-        text: rows.map((row) => formatRowHover(row, "rank")),
+        text: plotRows.map((row) => formatRowHover(row, "rank")),
         hovertemplate: "%{text}<extra></extra>",
       }], {
         ...commonLayout,
@@ -453,7 +490,10 @@
       `).join("");
 
       slider.value = state.currentIndex;
-      statusBox.textContent = snapshotLabel(snapshot, state.currentIndex);
+      const plotPointNote = plotRows.length < rows.length
+        ? `\nPlots are downsampled to ${plotRows.length} of ${rows.length} rows for responsiveness; table and histogram still use the active CSV rows.`
+        : "";
+      statusBox.textContent = `${snapshotLabel(snapshot, state.currentIndex)}${plotPointNote}`;
     }
 
     async function loadSnapshots(files) {
@@ -461,8 +501,8 @@
         return;
       }
       stopPlayback();
-      statusBox.textContent = "Loading CSV snapshots...";
-      const snapshots = await Promise.all([...files].map(readFile));
+      statusBox.textContent = "Registering CSV snapshots...";
+      const snapshots = [...files].map(snapshotFromFile);
       snapshots.sort((a, b) => {
         const iterA = Number.isFinite(a.iter) ? a.iter : Number.MAX_SAFE_INTEGER;
         const iterB = Number.isFinite(b.iter) ? b.iter : Number.MAX_SAFE_INTEGER;
@@ -472,15 +512,15 @@
       state.currentIndex = 0;
       slider.max = Math.max(0, snapshots.length - 1);
       enableControls(snapshots.length > 0);
-      plotSnapshot();
+      await plotSnapshot();
     }
 
-    function step(delta) {
+    async function step(delta) {
       if (!state.snapshots.length) {
         return;
       }
       state.currentIndex = Math.max(0, Math.min(state.snapshots.length - 1, state.currentIndex + delta));
-      plotSnapshot();
+      await plotSnapshot();
     }
 
     function stopPlayback() {
@@ -491,7 +531,7 @@
       playBtn.textContent = "Play";
     }
 
-    function togglePlayback() {
+    async function togglePlayback() {
       if (state.playTimer) {
         stopPlayback();
         return;
@@ -501,7 +541,7 @@
       }
       if (state.currentIndex >= state.snapshots.length - 1) {
         state.currentIndex = 0;
-        plotSnapshot();
+        await plotSnapshot();
       }
       if (state.snapshots.length === 1) {
         return;
@@ -529,6 +569,7 @@
       plotSnapshot();
     });
     maxRowsInput.addEventListener("input", plotSnapshot);
+    maxPlotPointsInput.addEventListener("input", plotSnapshot);
     angleCapInput.addEventListener("input", plotSnapshot);
     sortModeInput.addEventListener("change", plotSnapshot);
   </script>

--- a/demos/min_angle_graph_export_demo.sh
+++ b/demos/min_angle_graph_export_demo.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Demo the per-validation LM-head minimum-angle graph export on the small
+# exploration config, then point the user at the local Plotly viewer.
+#
+# Optional environment variables:
+#   OUTPUT_DIR  Base output directory for train.py runs. Default: out
+#   PREFIX      Prefix for exploration run names. Default: timestamped demo prefix
+#   EXPORT_ROOT Directory where the exploration config writes CSV/JSON exports.
+#               Default: out/min_angle_graph_exports
+
+OUTPUT_DIR="${OUTPUT_DIR:-out}"
+PREFIX="${PREFIX:-min_angle_graph_demo_$(date +%Y%m%d_%H%M%S)_}"
+EXPORT_ROOT="${EXPORT_ROOT:-out/min_angle_graph_exports}"
+CONFIG="explorations/min_angle_graph_export.yaml"
+VIEWER="analysis/min_angle_graph_plotly_viewer.html"
+
+before_csv_count="$(find "${EXPORT_ROOT}" -type f -name "${PREFIX}*.csv" 2>/dev/null | wc -l | tr -d ' ')"
+
+cat <<EOF
+Starting LM-head minimum-angle graph export demo.
+
+Config:      ${CONFIG}
+Output dir:  ${OUTPUT_DIR}
+Export root: ${EXPORT_ROOT}
+Run prefix:  ${PREFIX}
+
+This runs the shakespeare_char and minipile smoke-test configurations. The
+minipile export scans a much larger vocabulary, so it can take noticeably
+longer than the shakespeare_char run even though the training run is tiny.
+EOF
+
+python3 optimization_and_search/run_experiments.py \
+  --config "${CONFIG}" \
+  --config_format yaml \
+  --output_dir "${OUTPUT_DIR}" \
+  --prefix "${PREFIX}"
+
+after_csv_count="$(find "${EXPORT_ROOT}" -type f -name "${PREFIX}*.csv" 2>/dev/null | wc -l | tr -d ' ')"
+if [[ "${after_csv_count}" -le "${before_csv_count}" ]]; then
+  cat >&2 <<EOF
+
+Minimum-angle graph export demo did not produce new CSV exports.
+
+The experiment runner may have reported a failed train.py run without exiting
+non-zero. Review the run output above and fix the training error, then rerun
+this demo. Expected new CSV files matching:
+  ${EXPORT_ROOT}/${PREFIX}*.csv
+EOF
+  exit 1
+fi
+
+cat <<EOF
+
+Minimum-angle graph export demo completed.
+
+CSV/JSON exports are written under:
+  ${EXPORT_ROOT}/<run-name>/
+
+New CSV exports detected:
+$(find "${EXPORT_ROOT}" -type f -name "${PREFIX}*.csv" 2>/dev/null | sort)
+
+Open the Plotly viewer in your browser:
+  ${VIEWER}
+
+Then select one or more exported CSV files from an export directory to step
+through validation snapshots from first iteration to last.
+EOF

--- a/explorations/min_angle_graph_export.yaml
+++ b/explorations/min_angle_graph_export.yaml
@@ -1,0 +1,39 @@
+# Smoke-test the optional LM-head minimum-angle graph export on a tiny
+# validation cadence for both a character-tokenized and GPT-style dataset.
+#
+# Run with:
+#   python3 optimization_and_search/run_experiments.py \
+#     --config explorations/min_angle_graph_export.yaml \
+#     --config_format yaml \
+#     --prefix min_angle_export_
+#
+# The minipile run has a much larger vocabulary than shakespeare_char, so the
+# default smoke settings use CUDA/float16 and a GPU-friendly export block size.
+---
+
+common_group:
+  n_layer: [3]
+  n_head: [3]
+  n_embd: [150]
+  block_size: [64]
+  batch_size: [4]
+  max_iters: [2000]
+  eval_interval: [20]
+  eval_iters: [20]
+  device: ["cuda:0"]
+  dtype: ["float16"]
+  compile: [true]
+  never_save_checkpoint: [true]
+  export_min_angle_graph_each_eval: [true]
+  export_min_angle_graph_device: ["cuda:0"]
+
+parameter_groups:
+  - dataset: ["shakespeare_char"]
+    export_min_angle_graph_block_size: [512]
+    export_min_angle_graph_label: ["${RUN_NAME}"]
+    export_min_angle_graph_dir: ["out/min_angle_graph_exports/${RUN_NAME}"]
+
+  - dataset: ["minipile"]
+    export_min_angle_graph_block_size: [2048]
+    export_min_angle_graph_label: ["${RUN_NAME}"]
+    export_min_angle_graph_dir: ["out/min_angle_graph_exports/${RUN_NAME}"]

--- a/train.py
+++ b/train.py
@@ -1821,6 +1821,10 @@ class Trainer:
             return
 
         weight = self.raw_model.apply_lm_head_norm(self.raw_model.lm_head.weight).detach()
+        if not hasattr(self, "_min_angle_graph_token_texts"):
+            self._min_angle_graph_token_texts = [
+                self.decode([token_id]) for token_id in range(weight.shape[0])
+            ]
         label = getattr(self.args, "export_min_angle_graph_label", None) or "min_angle_graph"
         val_loss = losses["val"].item() if hasattr(losses["val"], "item") else float(losses["val"])
         csv_path, _ = write_min_angle_graph_export(
@@ -1831,6 +1835,7 @@ class Trainer:
             val_loss=val_loss,
             block_size=getattr(self.args, "export_min_angle_graph_block_size", 2048),
             compute_device=getattr(self.args, "export_min_angle_graph_device", "auto"),
+            token_texts=self._min_angle_graph_token_texts,
         )
         print(f"Minimum-angle graph exported to {csv_path}")
 

--- a/train.py
+++ b/train.py
@@ -12,6 +12,22 @@ import time
 from collections import deque
 from datetime import datetime, timedelta
 
+# Some user worktrees may contain helper files named like Python stdlib modules
+# (for example copy.py). Preload stdlib modules that Rich/dataclasses need
+# before third-party imports so local helper files cannot shadow them during
+# interpreter startup.
+_repo_dir = os.path.dirname(os.path.abspath(__file__))
+_removed_sys_path_entries = []
+for _entry in ("", _repo_dir):
+    while _entry in sys.path:
+        sys.path.remove(_entry)
+        _removed_sys_path_entries.append(_entry)
+import copy as _stdlib_copy
+import dataclasses as _stdlib_dataclasses
+for _entry in reversed(_removed_sys_path_entries):
+    sys.path.insert(0, _entry)
+del _entry, _removed_sys_path_entries, _repo_dir, _stdlib_copy, _stdlib_dataclasses
+
 from rich.console import Group
 from rich.console import Console
 from rich.text import Text
@@ -27,6 +43,7 @@ from train_variations.loss_variants import build_loss_function
 from train_variations.distillation_loss_variants import build_distillation_loss
 
 from utils.gpu_monitoring import get_gpu_memory_info, get_process_gpu_memory_bytes
+from utils.min_angle_graph_export import export_min_angle_graph as write_min_angle_graph_export
 from torch.cuda import reset_peak_memory_stats, max_memory_allocated, max_memory_reserved
 
 try:
@@ -1797,6 +1814,26 @@ class Trainer:
                 }
         torch.save(checkpoint, os.path.join(self.args.out_dir, filename))
 
+    def export_min_angle_graph(self, losses):
+        """Export the current LM-head minimum-angle graph using the configured writer."""
+        export_dir = getattr(self.args, "export_min_angle_graph_dir", None)
+        if not export_dir:
+            return
+
+        weight = self.raw_model.apply_lm_head_norm(self.raw_model.lm_head.weight).detach()
+        label = getattr(self.args, "export_min_angle_graph_label", None) or "min_angle_graph"
+        val_loss = losses["val"].item() if hasattr(losses["val"], "item") else float(losses["val"])
+        csv_path, _ = write_min_angle_graph_export(
+            weight=weight,
+            export_dir=export_dir,
+            label=label,
+            iter_num=self.iter_num,
+            val_loss=val_loss,
+            block_size=getattr(self.args, "export_min_angle_graph_block_size", 2048),
+            compute_device=getattr(self.args, "export_min_angle_graph_device", "auto"),
+        )
+        print(f"Minimum-angle graph exported to {csv_path}")
+
     def run_validation_step(self, running_mfu, current_epoch, current_dataset, num_steps_with_worse_loss, live=None):
         losses = self.estimate_loss()
 
@@ -1887,6 +1924,13 @@ class Trainer:
             with open(self.args.out_dir + "/nan_iter_num.txt", 'w') as file:
                 print("Exiting with nan")
                 file.write(str(self.iter_num))
+
+        if self.args.export_min_angle_graph_each_eval:
+            if live:
+                live.stop()
+            self.export_min_angle_graph(losses)
+            if live:
+                live.start()
 
         if (not self.args.never_save_checkpoint and
             self.args.save_major_ckpt_interval is not None):

--- a/train_args.py
+++ b/train_args.py
@@ -80,6 +80,20 @@ def parse_args():
     training_group.add_argument('--log_interval', default=10, type=int)
     training_group.add_argument('--eval_iters', default=200, type=int)
     training_group.add_argument('--eval_only', default=False, action=argparse.BooleanOptionalAction)
+
+    # Validation-time LM-head minimum-angle graph export args
+    training_group.add_argument('--export_min_angle_graph_dir', default=None, type=str,
+                                help='Optional directory for per-validation LM-head minimum-angle graph exports.')
+    training_group.add_argument('--export_min_angle_graph_each_eval', default=False,
+                                action=argparse.BooleanOptionalAction,
+                                help='Export the LM-head minimum-angle graph after every validation loss.')
+    training_group.add_argument('--export_min_angle_graph_block_size', default=2048, type=int,
+                                help='Row/column block size used when exporting the minimum-angle graph.')
+    training_group.add_argument('--export_min_angle_graph_device', default='auto', type=str,
+                                help="Compute device for minimum-angle graph export: 'auto', 'cpu', or a CUDA device such as 'cuda:0'.")
+    training_group.add_argument('--export_min_angle_graph_label', default=None, type=str,
+                                help='Optional label inserted into minimum-angle graph export filenames.')
+
     training_group.add_argument(
         '--mezo_epsilon',
         type=float,

--- a/utils/min_angle_graph_export.py
+++ b/utils/min_angle_graph_export.py
@@ -1,0 +1,152 @@
+# utils/min_angle_graph_export.py
+import csv
+import json
+import os
+
+import torch
+import torch.nn.functional as F
+
+
+def resolve_min_angle_graph_device(weight, requested_device="auto"):
+    """Choose the compute device for blockwise minimum-angle graph export."""
+    if requested_device == "auto":
+        if weight.is_cuda:
+            return weight.device
+        if torch.cuda.is_available():
+            return torch.device("cuda:0")
+        return torch.device("cpu")
+    if requested_device.startswith("cuda") and not torch.cuda.is_available():
+        print("CUDA requested for minimum-angle graph export but is unavailable; using CPU.")
+        return torch.device("cpu")
+    return torch.device(requested_device)
+
+
+def compute_min_angle_graph(weight, block_size=2048, compute_device="auto"):
+    """Compute each row vector's closest non-self row by signed angular distance."""
+    compute_device = resolve_min_angle_graph_device(weight, compute_device)
+    block_size = max(1, int(block_size))
+    vocab_size = weight.shape[0]
+
+    with torch.no_grad():
+        weight = weight.detach()
+        norms = torch.linalg.vector_norm(weight, ord=2, dim=1).detach().cpu()
+        best_cosine = torch.full((vocab_size,), -float("inf"), device=compute_device)
+        best_other_token_id = torch.full((vocab_size,), -1, dtype=torch.long, device=compute_device)
+
+        for row_start in range(0, vocab_size, block_size):
+            row_end = min(row_start + block_size, vocab_size)
+            row_block = weight[row_start:row_end].to(compute_device, non_blocking=True)
+            row_block = F.normalize(row_block, p=2, dim=1)
+
+            for col_start in range(0, vocab_size, block_size):
+                col_end = min(col_start + block_size, vocab_size)
+                col_block = weight[col_start:col_end].to(compute_device, non_blocking=True)
+                col_block = F.normalize(col_block, p=2, dim=1)
+                cosine_block = row_block @ col_block.T
+
+                if row_start < col_end and col_start < row_end:
+                    diag_start = max(row_start, col_start)
+                    diag_end = min(row_end, col_end)
+                    diag_rows = torch.arange(
+                        diag_start - row_start,
+                        diag_end - row_start,
+                        device=compute_device,
+                    )
+                    diag_cols = torch.arange(
+                        diag_start - col_start,
+                        diag_end - col_start,
+                        device=compute_device,
+                    )
+                    cosine_block[diag_rows, diag_cols] = -float("inf")
+
+                block_best_cosine, block_best_col = cosine_block.max(dim=1)
+                current_best = best_cosine[row_start:row_end]
+                current_other = best_other_token_id[row_start:row_end]
+                update_mask = block_best_cosine > current_best
+                current_best[update_mask] = block_best_cosine[update_mask]
+                current_other[update_mask] = block_best_col[update_mask] + col_start
+
+        best_cosine = best_cosine.clamp(-1.0, 1.0).cpu()
+        best_other_token_id = best_other_token_id.cpu()
+        min_angles = torch.rad2deg(torch.acos(best_cosine))
+        sorted_rank = torch.argsort(min_angles)
+        rank_by_token = torch.empty_like(sorted_rank)
+        rank_by_token[sorted_rank] = torch.arange(vocab_size, dtype=torch.long)
+
+    return {
+        "vocab_size": vocab_size,
+        "block_size": block_size,
+        "compute_device": str(compute_device),
+        "norms": norms,
+        "best_cosine": best_cosine,
+        "best_other_token_id": best_other_token_id,
+        "min_angles": min_angles,
+        "rank_by_token": rank_by_token,
+    }
+
+
+def safe_filename_label(label):
+    """Return a filesystem-friendly label while preserving readable separators."""
+    return "".join(ch if ch.isalnum() or ch in ("-", "_") else "_" for ch in label)
+
+
+def write_min_angle_graph_export(graph, export_dir, label, iter_num, val_loss):
+    """Write a minimum-angle graph CSV plus JSON sidecar and return both paths."""
+    export_dir = os.path.expanduser(export_dir)
+    os.makedirs(export_dir, exist_ok=True)
+
+    safe_label = safe_filename_label(label)
+    file_stem = f"{safe_label}_iter_{iter_num:08d}_val_{val_loss:.6f}"
+    csv_path = os.path.join(export_dir, f"{file_stem}.csv")
+    json_path = os.path.join(export_dir, f"{file_stem}.json")
+
+    norms = graph["norms"]
+    best_cosine = graph["best_cosine"]
+    best_other_token_id = graph["best_other_token_id"]
+    min_angles = graph["min_angles"]
+    rank_by_token = graph["rank_by_token"]
+    vocab_size = graph["vocab_size"]
+
+    with open(csv_path, "w", newline="") as csv_file:
+        writer = csv.writer(csv_file)
+        writer.writerow([
+            "token_id",
+            "nearest_token_id",
+            "min_angle_deg",
+            "cosine",
+            "token_vector_length",
+            "nearest_token_vector_length",
+            "min_angle_rank",
+        ])
+        for token_id in range(vocab_size):
+            other_id = int(best_other_token_id[token_id])
+            writer.writerow([
+                token_id,
+                other_id,
+                f"{float(min_angles[token_id]):.9f}",
+                f"{float(best_cosine[token_id]):.9f}",
+                f"{float(norms[token_id]):.9f}",
+                f"{float(norms[other_id]):.9f}" if other_id >= 0 else "",
+                int(rank_by_token[token_id]),
+            ])
+
+    metadata = {
+        "iter_num": iter_num,
+        "val_loss": val_loss,
+        "label": label,
+        "csv_path": csv_path,
+        "vocab_size": vocab_size,
+        "block_size": graph["block_size"],
+        "compute_device": graph["compute_device"],
+        "angle_definition": "signed 0-180 degrees, closest non-self token by maximum cosine",
+    }
+    with open(json_path, "w") as json_file:
+        json.dump(metadata, json_file, indent=2)
+
+    return csv_path, json_path
+
+
+def export_min_angle_graph(weight, export_dir, label, iter_num, val_loss, block_size=2048, compute_device="auto"):
+    """Compute and write the LM-head minimum-angle graph export."""
+    graph = compute_min_angle_graph(weight, block_size=block_size, compute_device=compute_device)
+    return write_min_angle_graph_export(graph, export_dir, label, iter_num, val_loss)

--- a/utils/min_angle_graph_export.py
+++ b/utils/min_angle_graph_export.py
@@ -90,7 +90,12 @@ def safe_filename_label(label):
     return "".join(ch if ch.isalnum() or ch in ("-", "_") else "_" for ch in label)
 
 
-def write_min_angle_graph_export(graph, export_dir, label, iter_num, val_loss):
+def escape_token_text(text):
+    """Escape token text for CSV/HTML display while preserving visible escapes."""
+    return str(text).encode("unicode_escape").decode("ascii")
+
+
+def write_min_angle_graph_export(graph, export_dir, label, iter_num, val_loss, token_texts=None):
     """Write a minimum-angle graph CSV plus JSON sidecar and return both paths."""
     export_dir = os.path.expanduser(export_dir)
     os.makedirs(export_dir, exist_ok=True)
@@ -106,12 +111,21 @@ def write_min_angle_graph_export(graph, export_dir, label, iter_num, val_loss):
     min_angles = graph["min_angles"]
     rank_by_token = graph["rank_by_token"]
     vocab_size = graph["vocab_size"]
+    escaped_token_texts = None
+    if token_texts is not None:
+        if len(token_texts) != vocab_size:
+            raise ValueError(
+                f"Expected {vocab_size} token strings, got {len(token_texts)}."
+            )
+        escaped_token_texts = [escape_token_text(text) for text in token_texts]
 
     with open(csv_path, "w", newline="") as csv_file:
         writer = csv.writer(csv_file)
         writer.writerow([
             "token_id",
+            "token_text_escaped",
             "nearest_token_id",
+            "nearest_token_text_escaped",
             "min_angle_deg",
             "cosine",
             "token_vector_length",
@@ -122,7 +136,9 @@ def write_min_angle_graph_export(graph, export_dir, label, iter_num, val_loss):
             other_id = int(best_other_token_id[token_id])
             writer.writerow([
                 token_id,
+                escaped_token_texts[token_id] if escaped_token_texts is not None else "",
                 other_id,
+                escaped_token_texts[other_id] if escaped_token_texts is not None and other_id >= 0 else "",
                 f"{float(min_angles[token_id]):.9f}",
                 f"{float(best_cosine[token_id]):.9f}",
                 f"{float(norms[token_id]):.9f}",
@@ -138,6 +154,7 @@ def write_min_angle_graph_export(graph, export_dir, label, iter_num, val_loss):
         "vocab_size": vocab_size,
         "block_size": graph["block_size"],
         "compute_device": graph["compute_device"],
+        "has_token_text_escaped": escaped_token_texts is not None,
         "angle_definition": "signed 0-180 degrees, closest non-self token by maximum cosine",
     }
     with open(json_path, "w") as json_file:
@@ -146,7 +163,23 @@ def write_min_angle_graph_export(graph, export_dir, label, iter_num, val_loss):
     return csv_path, json_path
 
 
-def export_min_angle_graph(weight, export_dir, label, iter_num, val_loss, block_size=2048, compute_device="auto"):
+def export_min_angle_graph(
+    weight,
+    export_dir,
+    label,
+    iter_num,
+    val_loss,
+    block_size=2048,
+    compute_device="auto",
+    token_texts=None,
+):
     """Compute and write the LM-head minimum-angle graph export."""
     graph = compute_min_angle_graph(weight, block_size=block_size, compute_device=compute_device)
-    return write_min_angle_graph_export(graph, export_dir, label, iter_num, val_loss)
+    return write_min_angle_graph_export(
+        graph,
+        export_dir,
+        label,
+        iter_num,
+        val_loss,
+        token_texts=token_texts,
+    )


### PR DESCRIPTION
### Motivation

- Provide an efficient, per-validation export of the LM-head closest-neighbor graph (closest non-self token by signed 0°–180° angular distance) to aid analysis of token-vector geometry during training.
- Offer an offline, browser-based viewer and a small demo/config so researchers can quickly generate and inspect snapshots without materializing the full vocab×vocab matrix.

### Description

- Add `utils/min_angle_graph_export.py` which computes the per-row nearest neighbor via blockwise, device-aware cosine computations and writes a CSV edge list plus JSON sidecar; it never materializes the full similarity matrix and supports `auto`/`cpu`/`cuda` devices and adjustable block sizes.
- Integrate the feature into training by adding CLI args in `train_args.py` and calling `export_min_angle_graph` from `train.py` after validation when `--export_min_angle_graph_each_eval` is enabled, including a small preload of stdlib modules to avoid local name shadowing at import time.
- Add an interactive viewer `analysis/min_angle_graph_plotly_viewer.html` that loads exported CSV snapshots in-browser (no upload) and provides timeline playback, plots, and a sortable table.
- Add a demo script `demos/min_angle_graph_export_demo.sh` and a smoke-test experiment config `explorations/min_angle_graph_export.yaml`, and document the feature in `README.md` with usage and filename conventions.

### Testing

- Ran the demo script `demos/min_angle_graph_export_demo.sh` which invoked the exploration config via `optimization_and_search/run_experiments.py` and produced CSV/JSON exports under `out/min_angle_graph_exports/`; the export files were created as expected (smoke test succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2edcf1dfb483268b8eecbe02013c80)