### PR TITLE
Separate Wo from output sphere visualization

### DIFF
--- a/report/threejs/attention-read-activate-write-quant-compare-v3-hotkeys.html
+++ b/report/threejs/attention-read-activate-write-quant-compare-v3-hotkeys.html
@@ -1896,27 +1896,65 @@ function renderChain(pass, glyphs, color, opacity, progress) {
     glyphs[i].set(start, end, color, opacity * (localT > 0.01 ? 1 : 0), 0.75);
   }
 }
+function basisVector(index) {
+  if (index === 0) return new THREE.Vector3(1, 0, 0);
+  if (index === 1) return new THREE.Vector3(0, 1, 0);
+  return new THREE.Vector3(0, 0, 1);
+}
+function componentLabel(index) { return index === 0 ? 'x' : index === 1 ? 'y' : 'z'; }
+function renderMatrixDotComposition({ inputTip, matrixKey, matrixCenter, outputCenter, rows, components, outputGlyph, outputColor, lineColor, labelBase, lineBase, progress, componentScale, finalEnd, outputLabel }) {
+  const t = smoothstep01(progress);
+  let cumulative = new THREE.Vector3();
+  for (let i = 0; i < 3; i++) {
+    const local = smoothstep01(t * 3 - i + 0.15);
+    const rowTip = endpoint(matrixCenter, rows[i]);
+    setLine(dyn.transferLines[lineBase + i], inputTip, rowTip, 0.22 * local, lineColor);
+
+    const component = basisVector(i).multiplyScalar(components[i] * componentScale);
+    const segStart = outputCenter.clone().add(cumulative);
+    cumulative.add(component);
+    const segEnd = lerpVec(segStart, outputCenter.clone().add(cumulative), local);
+    setLine(dyn.transferLines[lineBase + 3 + i], segStart, segEnd, 0.62 * local, outputColor);
+
+    labelAt(dyn.labels[labelBase + i], rowTip.clone().add(new THREE.Vector3(0.14, 0.10 - 0.09 * i, 0.12)), `${matrixKey}${componentLabel(i)}=${components[i].toFixed(2)}`, lineColor, local);
+  }
+  outputGlyph.set(outputCenter, lerpVec(outputCenter, finalEnd, t), outputColor, 0.22 + 0.78 * t);
+  labelAt(dyn.labels[labelBase + 3], finalEnd.clone().add(new THREE.Vector3(0.22, 0.12, 0.12)), outputLabel, outputColor, t);
+}
 function renderContextAndOutput(pass, contextGlyph, outputGlyph, colorContext, colorOutput, opacity, progress, quant = false) {
   const t = smoothstep01(progress);
-  const local = smoothstep01(t);
   const contextEnd = rawEndpoint(CENTERS.v, pass.context, derived.chainScale);
   contextGlyph.set(CENTERS.v, contextEnd, colorContext, opacity);
 
-  // Mirror the Wq stage: vector enters the Wo matrix, exits as Wo·context,
-  // and the transformed vector is then shown on the separate Output sphere.
+  // Mirror the Wq stage: draw the final v/context tip to the Wo rows, then show
+  // the x/y/z dot-product components adding up to the vector on Output.
   const midIn = CENTERS.Wo.clone().add(new THREE.Vector3(-SPHERE_RADIUS, 0, 0));
   const midOut = CENTERS.Wo.clone().add(new THREE.Vector3(SPHERE_RADIUS, 0, 0));
   const finalEnd = endpoint(CENTERS.Output, pass.output);
-  const carryEnd = lerpVec(CENTERS.Wo, endpoint(CENTERS.Wo, pass.context), local);
+  const rows = matRows(pass.Wo);
+  const outputLen = Math.max(pass.output.length(), 1e-9);
+  const components = [pass.output.x, pass.output.y, pass.output.z];
 
-  dyn.woContextGhost.set(CENTERS.Wo, carryEnd, quant ? QUANT : VALUE, opacity * (0.18 + 0.44 * local));
-  setLine(dyn.transferLines[10], contextEnd, midIn, opacity * 0.34 * local, colorContext);
-  setLine(dyn.transferLines[11], midOut, finalEnd, opacity * 0.34 * local, quant ? QUANT_FINAL : colorOutput);
-  outputGlyph.set(CENTERS.Output, lerpVec(CENTERS.Output, finalEnd, local), colorOutput, opacity * (0.20 + 0.80 * local));
-
-  labelAt(dyn.labels[74], contextEnd.clone().add(new THREE.Vector3(0.18, -0.12, 0.12)), quant ? 'final ṽ/context' : 'final v/context', colorContext, opacity * local);
-  labelAt(dyn.labels[75], CENTERS.Wo.clone().add(new THREE.Vector3(0, -SPHERE_RADIUS - 0.40, 0)), quant ? 'W̃o · context' : 'Wo · context', quant ? QUANT : TENSOR, opacity * local);
-  labelAt(dyn.labels[76], finalEnd.clone().add(new THREE.Vector3(0.24, 0.10, 0.12)), quant ? 'quant output' : 'final output', colorOutput, opacity * local);
+  setLine(dyn.transferLines[10], contextEnd, midIn, opacity * 0.28 * t, colorContext);
+  setLine(dyn.transferLines[11], midOut, CENTERS.Output.clone().add(new THREE.Vector3(-SPHERE_RADIUS, 0, 0)), opacity * 0.20 * t, quant ? QUANT_FINAL : colorOutput);
+  renderMatrixDotComposition({
+    inputTip: contextEnd,
+    matrixKey: quant ? 'õ' : 'o',
+    matrixCenter: CENTERS.Wo,
+    outputCenter: CENTERS.Output,
+    rows,
+    components,
+    outputGlyph,
+    outputColor: colorOutput,
+    lineColor: quant ? QUANT : TENSOR,
+    labelBase: 74,
+    lineBase: 12,
+    progress: t,
+    componentScale: SPHERE_RADIUS / outputLen,
+    finalEnd,
+    outputLabel: quant ? 'quant output' : 'final output',
+  });
+  labelAt(dyn.labels[78], CENTERS.Wo.clone().add(new THREE.Vector3(0, -SPHERE_RADIUS - 0.40, 0)), quant ? 'dot ṽ with W̃o rows' : 'dot v/context with Wo rows', quant ? QUANT : TENSOR, opacity * t);
 }
 function renderCompare() {
   const fade = 0.035;
@@ -1997,8 +2035,23 @@ function renderStage() {
     const end = rawProjEndpoint(CENTERS.q, derived.continuous.qRaw);
     setLine(dyn.transferLines[0], start, midIn, 0.38 * local, CURRENT);
     setLine(dyn.transferLines[1], midOut, end, 0.38 * local, QUERY);
-    dyn.qArrow.set(CENTERS.q, lerpVec(CENTERS.q, end, local), QUERY, local);
-    labelAt(dyn.labels[0], end.clone().add(new THREE.Vector3(0.16, 0.12, 0.10)), 'raw q = Wq x₀', QUERY, local);
+    renderMatrixDotComposition({
+      inputTip: start,
+      matrixKey: 'q',
+      matrixCenter: CENTERS.Wq,
+      outputCenter: CENTERS.q,
+      rows: derived.tensorContinuous.Wq,
+      components: [derived.continuous.qRaw.x, derived.continuous.qRaw.y, derived.continuous.qRaw.z],
+      outputGlyph: dyn.qArrow,
+      outputColor: QUERY,
+      lineColor: TENSOR,
+      labelBase: 90,
+      lineBase: 20,
+      progress: local,
+      componentScale: derived.projectionScale,
+      finalEnd: end,
+      outputLabel: 'raw q = Wq x₀',
+    });
   }
 
   if (s === 2) {

--- a/report/threejs/attention-read-activate-write-quant-compare-v3-hotkeys.html
+++ b/report/threejs/attention-read-activate-write-quant-compare-v3-hotkeys.html
@@ -1907,16 +1907,15 @@ function renderMatrixDotComposition({ inputTip, matrixKey, matrixCenter, outputC
   let cumulative = new THREE.Vector3();
   for (let i = 0; i < 3; i++) {
     const local = smoothstep01(t * 3 - i + 0.15);
-    const rowTip = endpoint(matrixCenter, rows[i]);
-    setLine(dyn.transferLines[lineBase + i], inputTip, rowTip, 0.22 * local, lineColor);
-
     const component = basisVector(i).multiplyScalar(components[i] * componentScale);
     const segStart = outputCenter.clone().add(cumulative);
     cumulative.add(component);
-    const segEnd = lerpVec(segStart, outputCenter.clone().add(cumulative), local);
+    const componentTip = outputCenter.clone().add(cumulative);
+    const segEnd = lerpVec(segStart, componentTip, local);
+    setLine(dyn.transferLines[lineBase + i], inputTip, componentTip, 0.18 * local, lineColor);
     setLine(dyn.transferLines[lineBase + 3 + i], segStart, segEnd, 0.62 * local, outputColor);
 
-    labelAt(dyn.labels[labelBase + i], rowTip.clone().add(new THREE.Vector3(0.14, 0.10 - 0.09 * i, 0.12)), `${matrixKey}${componentLabel(i)}=${components[i].toFixed(2)}`, lineColor, local);
+    labelAt(dyn.labels[labelBase + i], componentTip.clone().add(new THREE.Vector3(0.14, 0.10 - 0.09 * i, 0.12)), `${matrixKey}${componentLabel(i)}=${components[i].toFixed(2)}`, lineColor, local);
   }
   outputGlyph.set(outputCenter, lerpVec(outputCenter, finalEnd, t), outputColor, 0.22 + 0.78 * t);
   labelAt(dyn.labels[labelBase + 3], finalEnd.clone().add(new THREE.Vector3(0.22, 0.12, 0.12)), outputLabel, outputColor, t);
@@ -1935,7 +1934,6 @@ function renderContextAndOutput(pass, contextGlyph, outputGlyph, colorContext, c
   const outputLen = Math.max(pass.output.length(), 1e-9);
   const components = [pass.output.x, pass.output.y, pass.output.z];
 
-  setLine(dyn.transferLines[10], contextEnd, midIn, opacity * 0.28 * t, colorContext);
   setLine(dyn.transferLines[11], midOut, CENTERS.Output.clone().add(new THREE.Vector3(-SPHERE_RADIUS, 0, 0)), opacity * 0.20 * t, quant ? QUANT_FINAL : colorOutput);
   renderMatrixDotComposition({
     inputTip: contextEnd,
@@ -2033,7 +2031,6 @@ function renderStage() {
     const midIn = CENTERS.Wq.clone().add(new THREE.Vector3(-SPHERE_RADIUS, 0, 0));
     const midOut = CENTERS.Wq.clone().add(new THREE.Vector3(SPHERE_RADIUS, 0, 0));
     const end = rawProjEndpoint(CENTERS.q, derived.continuous.qRaw);
-    setLine(dyn.transferLines[0], start, midIn, 0.38 * local, CURRENT);
     setLine(dyn.transferLines[1], midOut, end, 0.38 * local, QUERY);
     renderMatrixDotComposition({
       inputTip: start,

--- a/report/threejs/attention-read-activate-write-quant-compare-v3-hotkeys.html
+++ b/report/threejs/attention-read-activate-write-quant-compare-v3-hotkeys.html
@@ -357,7 +357,7 @@
         <div class="title-card">
           <h1>One-Head Attention: Read → Project Q/K/V → Norm → Activate → Write Values → Wo Output</h1>
           <div class="subtitle">
-            The tokens physically reside on the leftmost input (x) sphere. The current token (red) reads through the Wq matrix weights into q. All tokens (current + prior) read through the Wk and Wv matrix weights into k and v. After projection, q/k/v are normalized back to the hypersphere surface, q interacts with every k vector, activation produces coefficients, coefficients scale the value vectors, and Wo acts as a separate output-projection matrix: the final context/v vector dots with the Wo rows, those row outputs are scaled and added, and the output sphere displays the resulting final vector.
+            The tokens physically reside on the leftmost input (x) sphere. The current token (red) reads through the Wq matrix weights into q. All tokens (current + prior) read through the Wk and Wv matrix weights into k and v. After projection, q/k/v are normalized back to the hypersphere surface, q interacts with every k vector, activation produces coefficients, coefficients scale the value vectors, and Wo acts as a separate output-projection matrix: the final context/v vector passes through Wo just like x₀ passes through Wq, and the transformed final output is displayed on the separate output sphere.
           </div>
         </div>
       </div>
@@ -615,7 +615,7 @@ const stageLabels = {
   6: 'Activation produces attention coefficients aᵢ',
   7: 'Attention coefficients scale each value vector aᵢ vᵢ',
   8: 'Write and sum scaled values into one context vector',
-  9: 'Final v/context dots with Wo rows; scaled row outputs add on the output sphere',
+  9: 'Project final v/context through Wo into the separate output sphere',
   10: 'Quantize selected Wq / Wk / Wv / Wo tensors onto the blue grid',
   11: 'Q Wq → q: project with the selected quantized Wq path',
   12: 'Q Wk → k: project all tokens with the selected quantized Wk path',
@@ -1896,50 +1896,27 @@ function renderChain(pass, glyphs, color, opacity, progress) {
     glyphs[i].set(start, end, color, opacity * (localT > 0.01 ? 1 : 0), 0.75);
   }
 }
-function outputBasisVector(index) {
-  if (index === 0) return new THREE.Vector3(1, 0, 0);
-  if (index === 1) return new THREE.Vector3(0, 1, 0);
-  return new THREE.Vector3(0, 0, 1);
-}
 function renderContextAndOutput(pass, contextGlyph, outputGlyph, colorContext, colorOutput, opacity, progress, quant = false) {
   const t = smoothstep01(progress);
-  const carryT = smoothstep01(t / 0.34);
-  const dotT = smoothstep01((t - 0.18) / 0.42);
-  const sumT = smoothstep01((t - 0.48) / 0.52);
+  const local = smoothstep01(t);
   const contextEnd = rawEndpoint(CENTERS.v, pass.context, derived.chainScale);
   contextGlyph.set(CENTERS.v, contextEnd, colorContext, opacity);
 
-  // Wo is a matrix, not the output sphere. The final v/context vector is carried to Wo,
-  // dotted with each Wo row, and the resulting output-axis components are added on Output.
-  const contextAtWoEnd = endpoint(CENTERS.Wo, pass.context);
-  const outputLen = Math.max(pass.output.length(), 1e-9);
+  // Mirror the Wq stage: vector enters the Wo matrix, exits as Wo·context,
+  // and the transformed vector is then shown on the separate Output sphere.
+  const midIn = CENTERS.Wo.clone().add(new THREE.Vector3(-SPHERE_RADIUS, 0, 0));
+  const midOut = CENTERS.Wo.clone().add(new THREE.Vector3(SPHERE_RADIUS, 0, 0));
   const finalEnd = endpoint(CENTERS.Output, pass.output);
-  const rowVectors = matRows(pass.Wo || (quant ? derived.quantized.Wo : derived.continuous.Wo));
-  const components = [pass.output.x, pass.output.y, pass.output.z];
-  const componentGlyphs = quant ? dyn.scaledVQ : dyn.scaledV;
+  const carryEnd = lerpVec(CENTERS.Wo, endpoint(CENTERS.Wo, pass.context), local);
 
-  dyn.woContextGhost.set(CENTERS.Wo, lerpVec(CENTERS.Wo, contextAtWoEnd, carryT), quant ? QUANT : VALUE, opacity * (0.20 + 0.42 * carryT));
-  setLine(dyn.transferLines[10], contextEnd, contextAtWoEnd, opacity * 0.26 * carryT, colorContext);
-  labelAt(dyn.labels[74], contextAtWoEnd.clone().add(new THREE.Vector3(0.20, -0.12, 0.10)), quant ? 'ṽ/context dots W̃o rows' : 'v/context dots Wo rows', quant ? QUANT : VALUE, opacity * dotT);
+  dyn.woContextGhost.set(CENTERS.Wo, carryEnd, quant ? QUANT : VALUE, opacity * (0.18 + 0.44 * local));
+  setLine(dyn.transferLines[10], contextEnd, midIn, opacity * 0.34 * local, colorContext);
+  setLine(dyn.transferLines[11], midOut, finalEnd, opacity * 0.34 * local, quant ? QUANT_FINAL : colorOutput);
+  outputGlyph.set(CENTERS.Output, lerpVec(CENTERS.Output, finalEnd, local), colorOutput, opacity * (0.20 + 0.80 * local));
 
-  let cumulative = new THREE.Vector3();
-  for (let i = 0; i < 3; i++) {
-    const rowTip = endpoint(CENTERS.Wo, rowVectors[i]);
-    const localDotT = smoothstep01(dotT * 3 - i + 0.15);
-    setLine(dyn.transferLines[11 + i], contextAtWoEnd, rowTip, opacity * 0.18 * localDotT, quant ? QUANT : TENSOR);
-
-    const component = outputBasisVector(i).multiplyScalar(components[i] / outputLen * SPHERE_RADIUS);
-    const segStart = CENTERS.Output.clone().add(cumulative);
-    cumulative.add(component);
-    const localSumT = smoothstep01(sumT * 3 - i);
-    const segEnd = lerpVec(segStart, CENTERS.Output.clone().add(cumulative), localSumT);
-    componentGlyphs[i].set(segStart, segEnd, quant ? QUANT_FINAL : colorOutput, opacity * localSumT, 0.72);
-    labelAt(dyn.labels[76 + i], rowTip.clone().add(new THREE.Vector3(0.16, 0.08 - 0.08 * i, 0.12)), `dot${i}=${components[i].toFixed(2)}`, quant ? QUANT : TENSOR, opacity * localDotT);
-  }
-
-  outputGlyph.set(CENTERS.Output, lerpVec(CENTERS.Output, finalEnd, sumT), colorOutput, opacity * (0.25 + 0.75 * sumT));
-  setLine(dyn.transferLines[14], CENTERS.Wo.clone().add(new THREE.Vector3(SPHERE_RADIUS, 0, 0)), CENTERS.Output.clone().add(new THREE.Vector3(-SPHERE_RADIUS, 0, 0)), opacity * 0.18 * sumT, quant ? QUANT_FINAL : FINAL);
-  labelAt(dyn.labels[75], finalEnd.clone().add(new THREE.Vector3(0.24, 0.10, 0.12)), quant ? 'Σ dotᵢ(W̃o, ṽ)' : 'Σ dotᵢ(Wo, v)', colorOutput, opacity * sumT);
+  labelAt(dyn.labels[74], contextEnd.clone().add(new THREE.Vector3(0.18, -0.12, 0.12)), quant ? 'final ṽ/context' : 'final v/context', colorContext, opacity * local);
+  labelAt(dyn.labels[75], CENTERS.Wo.clone().add(new THREE.Vector3(0, -SPHERE_RADIUS - 0.40, 0)), quant ? 'W̃o · context' : 'Wo · context', quant ? QUANT : TENSOR, opacity * local);
+  labelAt(dyn.labels[76], finalEnd.clone().add(new THREE.Vector3(0.24, 0.10, 0.12)), quant ? 'quant output' : 'final output', colorOutput, opacity * local);
 }
 function renderCompare() {
   const fade = 0.035;

--- a/report/threejs/attention-read-activate-write-quant-compare-v3-hotkeys.html
+++ b/report/threejs/attention-read-activate-write-quant-compare-v3-hotkeys.html
@@ -357,7 +357,7 @@
         <div class="title-card">
           <h1>One-Head Attention: Read → Project Q/K/V → Norm → Activate → Write Values → Wo Output</h1>
           <div class="subtitle">
-            The tokens physically reside on the leftmost input (x) sphere. The current token (red) reads through the Wq matrix weights into q. All tokens (current + prior) read through the Wk and Wv matrix weights into k and v. After projection, q/k/v are normalized back to the hypersphere surface, q interacts with every k vector, activation produces coefficients, coefficients scale the value vectors, and Wo acts as a separate output-projection matrix: the final context/v vector interacts with Wo, then the output sphere displays the result as a rotation from the initial context direction to the final output direction.
+            The tokens physically reside on the leftmost input (x) sphere. The current token (red) reads through the Wq matrix weights into q. All tokens (current + prior) read through the Wk and Wv matrix weights into k and v. After projection, q/k/v are normalized back to the hypersphere surface, q interacts with every k vector, activation produces coefficients, coefficients scale the value vectors, and Wo acts as a separate output-projection matrix: the final context/v vector dots with the Wo rows, those row outputs are scaled and added, and the output sphere displays the resulting final vector.
           </div>
         </div>
       </div>
@@ -615,7 +615,7 @@ const stageLabels = {
   6: 'Activation produces attention coefficients aᵢ',
   7: 'Attention coefficients scale each value vector aᵢ vᵢ',
   8: 'Write and sum scaled values into one context vector',
-  9: 'Final v/context interacts with Wo, then rotates onto the output sphere',
+  9: 'Final v/context dots with Wo rows; scaled row outputs add on the output sphere',
   10: 'Quantize selected Wq / Wk / Wv / Wo tensors onto the blue grid',
   11: 'Q Wq → q: project with the selected quantized Wq path',
   12: 'Q Wk → k: project all tokens with the selected quantized Wk path',
@@ -1896,28 +1896,50 @@ function renderChain(pass, glyphs, color, opacity, progress) {
     glyphs[i].set(start, end, color, opacity * (localT > 0.01 ? 1 : 0), 0.75);
   }
 }
+function outputBasisVector(index) {
+  if (index === 0) return new THREE.Vector3(1, 0, 0);
+  if (index === 1) return new THREE.Vector3(0, 1, 0);
+  return new THREE.Vector3(0, 0, 1);
+}
 function renderContextAndOutput(pass, contextGlyph, outputGlyph, colorContext, colorOutput, opacity, progress, quant = false) {
   const t = smoothstep01(progress);
+  const carryT = smoothstep01(t / 0.34);
+  const dotT = smoothstep01((t - 0.18) / 0.42);
+  const sumT = smoothstep01((t - 0.48) / 0.52);
   const contextEnd = rawEndpoint(CENTERS.v, pass.context, derived.chainScale);
   contextGlyph.set(CENTERS.v, contextEnd, colorContext, opacity);
 
-  // Keep Wo visually distinct from the output sphere: first carry the final v/context
-  // direction into the Wo matrix, then display Wo's result as a rotation on Output.
+  // Wo is a matrix, not the output sphere. The final v/context vector is carried to Wo,
+  // dotted with each Wo row, and the resulting output-axis components are added on Output.
   const contextAtWoEnd = endpoint(CENTERS.Wo, pass.context);
-  const startDir = pass.context.length() > 1e-9 ? pass.context : new THREE.Vector3(0, 1, 0);
-  const finalDir = pass.output.length() > 1e-9 ? pass.output : new THREE.Vector3(0, 1, 0);
-  const interp = slerpUnit(startDir, finalDir, t);
-  const outputStart = endpoint(CENTERS.Output, startDir);
-  const outEnd = CENTERS.Output.clone().add(interp.multiplyScalar(SPHERE_RADIUS));
+  const outputLen = Math.max(pass.output.length(), 1e-9);
+  const finalEnd = endpoint(CENTERS.Output, pass.output);
+  const rowVectors = matRows(pass.Wo || (quant ? derived.quantized.Wo : derived.continuous.Wo));
+  const components = [pass.output.x, pass.output.y, pass.output.z];
+  const componentGlyphs = quant ? dyn.scaledVQ : dyn.scaledV;
 
-  dyn.woContextGhost.set(CENTERS.Wo, contextAtWoEnd, quant ? QUANT : VALUE, opacity * 0.52);
-  outputGlyph.set(CENTERS.Output, outEnd, colorLerp(colorContext, colorOutput, t), opacity);
-  setLine(dyn.transferLines[10], contextEnd, contextAtWoEnd, opacity * 0.26, colorContext);
-  setLine(dyn.transferLines[11], contextAtWoEnd, outputStart, opacity * 0.18, quant ? QUANT : FINAL);
-  setLine(dyn.transferLines[12], outputStart, outEnd, opacity * 0.34, quant ? QUANT_FINAL : FINAL);
-  labelAt(dyn.labels[74], contextAtWoEnd.clone().add(new THREE.Vector3(0.20, -0.12, 0.10)), quant ? 'ṽ/context meets W̃o' : 'v/context meets Wo', quant ? QUANT : VALUE, opacity * 0.75);
-  labelAt(dyn.labels[75], outEnd.clone().add(new THREE.Vector3(0.24, 0.10, 0.12)), quant ? 'rotated q-output' : 'rotated output', colorOutput, opacity);
-  labelAt(dyn.labels[76], outputStart.clone().add(new THREE.Vector3(0.20, -0.14, 0.12)), quant ? 'initial ṽ dir' : 'initial v dir', colorContext, opacity * (1 - 0.35 * t));
+  dyn.woContextGhost.set(CENTERS.Wo, lerpVec(CENTERS.Wo, contextAtWoEnd, carryT), quant ? QUANT : VALUE, opacity * (0.20 + 0.42 * carryT));
+  setLine(dyn.transferLines[10], contextEnd, contextAtWoEnd, opacity * 0.26 * carryT, colorContext);
+  labelAt(dyn.labels[74], contextAtWoEnd.clone().add(new THREE.Vector3(0.20, -0.12, 0.10)), quant ? 'ṽ/context dots W̃o rows' : 'v/context dots Wo rows', quant ? QUANT : VALUE, opacity * dotT);
+
+  let cumulative = new THREE.Vector3();
+  for (let i = 0; i < 3; i++) {
+    const rowTip = endpoint(CENTERS.Wo, rowVectors[i]);
+    const localDotT = smoothstep01(dotT * 3 - i + 0.15);
+    setLine(dyn.transferLines[11 + i], contextAtWoEnd, rowTip, opacity * 0.18 * localDotT, quant ? QUANT : TENSOR);
+
+    const component = outputBasisVector(i).multiplyScalar(components[i] / outputLen * SPHERE_RADIUS);
+    const segStart = CENTERS.Output.clone().add(cumulative);
+    cumulative.add(component);
+    const localSumT = smoothstep01(sumT * 3 - i);
+    const segEnd = lerpVec(segStart, CENTERS.Output.clone().add(cumulative), localSumT);
+    componentGlyphs[i].set(segStart, segEnd, quant ? QUANT_FINAL : colorOutput, opacity * localSumT, 0.72);
+    labelAt(dyn.labels[76 + i], rowTip.clone().add(new THREE.Vector3(0.16, 0.08 - 0.08 * i, 0.12)), `dot${i}=${components[i].toFixed(2)}`, quant ? QUANT : TENSOR, opacity * localDotT);
+  }
+
+  outputGlyph.set(CENTERS.Output, lerpVec(CENTERS.Output, finalEnd, sumT), colorOutput, opacity * (0.25 + 0.75 * sumT));
+  setLine(dyn.transferLines[14], CENTERS.Wo.clone().add(new THREE.Vector3(SPHERE_RADIUS, 0, 0)), CENTERS.Output.clone().add(new THREE.Vector3(-SPHERE_RADIUS, 0, 0)), opacity * 0.18 * sumT, quant ? QUANT_FINAL : FINAL);
+  labelAt(dyn.labels[75], finalEnd.clone().add(new THREE.Vector3(0.24, 0.10, 0.12)), quant ? 'Σ dotᵢ(W̃o, ṽ)' : 'Σ dotᵢ(Wo, v)', colorOutput, opacity * sumT);
 }
 function renderCompare() {
   const fade = 0.035;
@@ -2173,9 +2195,9 @@ function desiredCameraDistance(stage) {
   if (state.forceOverview || stage === 0 || stage === 10) return 17.5;
   if (stage === 20) return 4.6;
   if (stage === 1 || stage === 2 || stage === 3 || stage === 11 || stage === 12 || stage === 13) return 11.5;
-  if (stage === 5 || stage === 6 || stage === 16 || stage === 17) return 9.8;
-  if (stage === 9 || stage === 19) return 11.0;
-  if (stage === 4 || stage === 14 || stage === 15) return 9.8;
+  if (stage === 5 || stage === 6 || stage === 16 || stage === 17) return 11.0;
+  if (stage === 9 || stage === 19) return 12.0;
+  if (stage === 4 || stage === 14 || stage === 15) return 11.0;
   return 6.8;
 }
 

--- a/report/threejs/attention-read-activate-write-quant-compare-v3-hotkeys.html
+++ b/report/threejs/attention-read-activate-write-quant-compare-v3-hotkeys.html
@@ -1917,7 +1917,7 @@ function renderMatrixDotComposition({ inputTip, matrixKey, matrixCenter, outputC
     setLine(dyn.transferLines[lineBase + 3 + i], rowTip, componentTip, 0.20 * local, lineColor);
     setLine(dyn.transferLines[lineBase + 6 + i], segStart, segEnd, 0.62 * local, outputColor);
 
-    labelAt(dyn.labels[labelBase + i], componentTip.clone().add(new THREE.Vector3(0.14, 0.10 - 0.09 * i, 0.12)), `${matrixKey}${componentLabel(i)}=${components[i].toFixed(2)}`, lineColor, local);
+    labelAt(dyn.labels[labelBase + i], rowTip.clone().add(new THREE.Vector3(0.14, 0.10 - 0.09 * i, 0.12)), `${matrixKey}${componentLabel(i)}=${components[i].toFixed(2)}`, lineColor, local);
   }
   outputGlyph.set(outputCenter, lerpVec(outputCenter, finalEnd, t), outputColor, 0.22 + 0.78 * t);
   labelAt(dyn.labels[labelBase + 3], finalEnd.clone().add(new THREE.Vector3(0.22, 0.12, 0.12)), outputLabel, outputColor, t);

--- a/report/threejs/attention-read-activate-write-quant-compare-v3-hotkeys.html
+++ b/report/threejs/attention-read-activate-write-quant-compare-v3-hotkeys.html
@@ -357,12 +357,12 @@
         <div class="title-card">
           <h1>One-Head Attention: Read → Project Q/K/V → Norm → Activate → Write Values → Wo Output</h1>
           <div class="subtitle">
-            The tokens physically reside on the leftmost input (x) sphere. The current token (red) reads through the Wq matrix weights into q. All tokens (current + prior) read through the Wk and Wv matrix weights into k and v. After projection, q/k/v are normalized back to the hypersphere surface, q interacts with every k vector, activation produces coefficients, coefficients scale the value vectors, and Wo rotates the context into the final output.
+            The tokens physically reside on the leftmost input (x) sphere. The current token (red) reads through the Wq matrix weights into q. All tokens (current + prior) read through the Wk and Wv matrix weights into k and v. After projection, q/k/v are normalized back to the hypersphere surface, q interacts with every k vector, activation produces coefficients, coefficients scale the value vectors, and Wo acts as a separate output-projection matrix: the final context/v vector interacts with Wo, then the output sphere displays the result as a rotation from the initial context direction to the final output direction.
           </div>
         </div>
       </div>
       <div class="overlay-bottom">
-        Drag to rotate • Scroll to zoom • Right-drag to pan • Hotkeys: <span class="mono">j/→</span> next, <span class="mono">k/←</span> previous, <span class="mono">;/Space</span> play, <span class="mono">m</span> hotkey card. Red is the current token, slate arrows are prior tokens, cyan is the quantized comparison path. Compare zooms to the output sphere.
+        Drag to rotate • Scroll to zoom • Right-drag to pan • Hotkeys: <span class="mono">j/→</span> next, <span class="mono">k/←</span> previous, <span class="mono">;/Space</span> play, <span class="mono">m</span> hotkey card. Red is the current token, slate arrows are prior tokens, cyan is the quantized comparison path. Compare zooms to the separated output sphere.
       </div>
       <div id="hotkeyToast" aria-live="polite"></div>
     </div>
@@ -601,7 +601,8 @@ const CENTERS = {
   q: new THREE.Vector3(-1.2, 3.15, 0),
   k: new THREE.Vector3(-1.2, 0.0, 0),
   v: new THREE.Vector3(-1.2, -3.15, 0),
-  Wo: new THREE.Vector3(4.35, -0.25, 0),
+  Wo: new THREE.Vector3(4.05, -0.25, 0),
+  Output: new THREE.Vector3(8.2, -0.25, 0),
 };
 
 const stageLabels = {
@@ -614,7 +615,7 @@ const stageLabels = {
   6: 'Activation produces attention coefficients aᵢ',
   7: 'Attention coefficients scale each value vector aᵢ vᵢ',
   8: 'Write and sum scaled values into one context vector',
-  9: 'Wo rotates / projects the value context into final output',
+  9: 'Final v/context interacts with Wo, then rotates onto the output sphere',
   10: 'Quantize selected Wq / Wk / Wv / Wo tensors onto the blue grid',
   11: 'Q Wq → q: project with the selected quantized Wq path',
   12: 'Q Wk → k: project all tokens with the selected quantized Wk path',
@@ -1195,7 +1196,8 @@ addSphere('Wv', 'Wv weight rows', TENSOR);
 addSphere('q', 'q sphere', QUERY);
 addSphere('k', 'k sphere', KEY);
 addSphere('v', 'v / context sphere', VALUE);
-addSphere('Wo', 'Wo output sphere', FINAL);
+addSphere('Wo', 'Wo output matrix', TENSOR);
+addSphere('Output', 'output sphere', FINAL);
 
 const QUANT_DOT_KEYS = ['Wq', 'Wk', 'Wv', 'Wo', 'q', 'k', 'v'];
 const quantDotGroups = {};
@@ -1895,15 +1897,27 @@ function renderChain(pass, glyphs, color, opacity, progress) {
   }
 }
 function renderContextAndOutput(pass, contextGlyph, outputGlyph, colorContext, colorOutput, opacity, progress, quant = false) {
+  const t = smoothstep01(progress);
   const contextEnd = rawEndpoint(CENTERS.v, pass.context, derived.chainScale);
   contextGlyph.set(CENTERS.v, contextEnd, colorContext, opacity);
+
+  // Keep Wo visually distinct from the output sphere: first carry the final v/context
+  // direction into the Wo matrix, then display Wo's result as a rotation on Output.
+  const contextAtWoEnd = endpoint(CENTERS.Wo, pass.context);
   const startDir = pass.context.length() > 1e-9 ? pass.context : new THREE.Vector3(0, 1, 0);
   const finalDir = pass.output.length() > 1e-9 ? pass.output : new THREE.Vector3(0, 1, 0);
-  const interp = slerpUnit(startDir, finalDir, smoothstep01(progress));
-  const outEnd = CENTERS.Wo.clone().add(interp.multiplyScalar(SPHERE_RADIUS));
-  outputGlyph.set(CENTERS.Wo, outEnd, colorLerp(colorContext, colorOutput, progress), opacity);
-  setLine(dyn.transferLines[10], contextEnd, outEnd, opacity * 0.32, quant ? QUANT : FINAL);
-  labelAt(dyn.labels[75], outEnd.clone().add(new THREE.Vector3(0.24, 0.10, 0.12)), quant ? 'quant output' : 'output', colorOutput, opacity);
+  const interp = slerpUnit(startDir, finalDir, t);
+  const outputStart = endpoint(CENTERS.Output, startDir);
+  const outEnd = CENTERS.Output.clone().add(interp.multiplyScalar(SPHERE_RADIUS));
+
+  dyn.woContextGhost.set(CENTERS.Wo, contextAtWoEnd, quant ? QUANT : VALUE, opacity * 0.52);
+  outputGlyph.set(CENTERS.Output, outEnd, colorLerp(colorContext, colorOutput, t), opacity);
+  setLine(dyn.transferLines[10], contextEnd, contextAtWoEnd, opacity * 0.26, colorContext);
+  setLine(dyn.transferLines[11], contextAtWoEnd, outputStart, opacity * 0.18, quant ? QUANT : FINAL);
+  setLine(dyn.transferLines[12], outputStart, outEnd, opacity * 0.34, quant ? QUANT_FINAL : FINAL);
+  labelAt(dyn.labels[74], contextAtWoEnd.clone().add(new THREE.Vector3(0.20, -0.12, 0.10)), quant ? 'ṽ/context meets W̃o' : 'v/context meets Wo', quant ? QUANT : VALUE, opacity * 0.75);
+  labelAt(dyn.labels[75], outEnd.clone().add(new THREE.Vector3(0.24, 0.10, 0.12)), quant ? 'rotated q-output' : 'rotated output', colorOutput, opacity);
+  labelAt(dyn.labels[76], outputStart.clone().add(new THREE.Vector3(0.20, -0.14, 0.12)), quant ? 'initial ṽ dir' : 'initial v dir', colorContext, opacity * (1 - 0.35 * t));
 }
 function renderCompare() {
   const fade = 0.035;
@@ -1913,14 +1927,14 @@ function renderCompare() {
   renderChain(derived.quantized, dyn.chainVQ, QUANT_FINAL, fade, 1.0);
   dyn.contextArrow.set(CENTERS.v, rawEndpoint(CENTERS.v, derived.continuous.context, derived.chainScale), SUM, 0.22);
   dyn.contextArrowQ.set(CENTERS.v, rawEndpoint(CENTERS.v, derived.quantized.context, derived.chainScale), QUANT, 0.28);
-  const contTip = endpoint(CENTERS.Wo, derived.continuous.output);
-  const qTip = endpoint(CENTERS.Wo, derived.quantized.output);
-  dyn.outputArrow.set(CENTERS.Wo, contTip, FINAL, 1.0);
-  dyn.outputArrowQ.set(CENTERS.Wo, qTip, QUANT_FINAL, 1.0);
+  const contTip = endpoint(CENTERS.Output, derived.continuous.output);
+  const qTip = endpoint(CENTERS.Output, derived.quantized.output);
+  dyn.outputArrow.set(CENTERS.Output, contTip, FINAL, 1.0);
+  dyn.outputArrowQ.set(CENTERS.Output, qTip, QUANT_FINAL, 1.0);
   setLine(dyn.transferLines[10], contTip, qTip, 0.48, QUANT_FINAL);
   labelAt(dyn.labels[75], contTip.clone().add(new THREE.Vector3(0.25, 0.14, 0.12)), 'continuous output', FINAL, 1.0);
   labelAt(dyn.labels[76], qTip.clone().add(new THREE.Vector3(0.25, -0.14, 0.12)), 'quantized output', QUANT_FINAL, 1.0);
-  labelAt(dyn.labels[77], CENTERS.Wo.clone().add(new THREE.Vector3(0, -SPHERE_RADIUS - 0.50, 0)), `cos=${derived.cos.toFixed(4)}, angle=${derived.angleDeg.toFixed(2)}°`, WHITE, 1.0);
+  labelAt(dyn.labels[77], CENTERS.Output.clone().add(new THREE.Vector3(0, -SPHERE_RADIUS - 0.50, 0)), `cos=${derived.cos.toFixed(4)}, angle=${derived.angleDeg.toFixed(2)}°`, WHITE, 1.0);
 }
 
 function renderStage() {
@@ -1928,16 +1942,16 @@ function renderStage() {
   const t = state.progress;
   hideDynamics();
 
-  if (state.forceOverview || s === 0) setSphereEmphasis(['Input', 'Wq', 'Wk', 'Wv', 'q', 'k', 'v', 'Wo']);
+  if (state.forceOverview || s === 0) setSphereEmphasis(['Input', 'Wq', 'Wk', 'Wv', 'q', 'k', 'v', 'Wo', 'Output']);
   else if (s === 1 || s === 11) setSphereEmphasis(['Input', 'Wq', 'q']);
   else if (s === 2 || s === 12) setSphereEmphasis(['Input', 'Wk', 'k']);
   else if (s === 3 || s === 13) setSphereEmphasis(['Input', 'Wv', 'v']);
   else if (s === 4 || s === 14 || s === 15) setSphereEmphasis(['q', 'k', 'v']);
   else if (s === 5 || s === 6 || s === 16 || s === 17) setSphereEmphasis(['q', 'k']);
   else if (s === 7 || s === 8 || s === 18) setSphereEmphasis(['v']);
-  else if (s === 9 || s === 19) setSphereEmphasis(['v', 'Wo']);
+  else if (s === 9 || s === 19) setSphereEmphasis(['v', 'Wo', 'Output']);
   else if (s === 10) setSphereEmphasis(['Input', 'Wq', 'Wk', 'Wv', 'Wo']);
-  else if (s === 20) setSphereEmphasis(['Wo']);
+  else if (s === 20) setSphereEmphasis(['Output']);
 
   if (s <= 3 || s === 0) renderInputTokens(s === 0 ? 0.95 : 0.42);
   else if (s >= 10 && s <= 13) renderInputTokens(s === 10 ? 0.95 : 0.30);
@@ -2051,9 +2065,6 @@ function renderStage() {
     renderFinalProjections(derived.continuous, 0.04, 0.04, 0.08, false);
     renderChain(derived.continuous, dyn.chainV, SUM, 0.25, 1.0);
     renderContextAndOutput(derived.continuous, dyn.contextArrow, dyn.outputArrow, SUM, FINAL, 1.0, t, false);
-    const ghostEnd = CENTERS.Wo.clone().add(displayDir(derived.continuous.context));
-    dyn.woContextGhost.set(CENTERS.Wo, ghostEnd, VALUE, 0.42);
-    labelAt(dyn.labels[1], ghostEnd.clone().add(new THREE.Vector3(0.20, -0.10, 0.10)), 'context before Wo', VALUE, 0.55);
   }
 
   if (s === 10) renderTensorSnap(t, 1.0);
@@ -2146,8 +2157,8 @@ function focusCenter(stage) {
   if (stage === 4 || stage === 14 || stage === 15) return new THREE.Vector3(-1.2, 0, 0);
   if (stage === 5 || stage === 6 || stage === 16 || stage === 17) return new THREE.Vector3(-1.2, 1.45, 0);
   if (stage === 7 || stage === 8 || stage === 18) return CENTERS.v.clone();
-  if (stage === 9 || stage === 19) return new THREE.Vector3(1.6, -1.7, 0);
-  if (stage === 20) return CENTERS.Wo.clone();
+  if (stage === 9 || stage === 19) return new THREE.Vector3(4.9, -1.1, 0);
+  if (stage === 20) return CENTERS.Output.clone();
   return new THREE.Vector3(-3.25, 0, 0);
 }
 function desiredCameraDistance(stage) {

--- a/report/threejs/attention-read-activate-write-quant-compare-v3-hotkeys.html
+++ b/report/threejs/attention-read-activate-write-quant-compare-v3-hotkeys.html
@@ -1556,7 +1556,7 @@ function replayStageHotkey() {
   state.progress = 0;
   state.playing = true;
   state.stageStartedAt = performance.now();
-  state.cameraGuideUntil = performance.now() + 1400;
+  state.cameraGuideUntil = 0;
   refreshUi();
   showHotkeyToast(`Replay: ${stageLabels[state.stage]}`);
 }
@@ -2157,17 +2157,25 @@ function focusCenter(stage) {
   if (stage === 4 || stage === 14 || stage === 15) return new THREE.Vector3(-1.2, 0, 0);
   if (stage === 5 || stage === 6 || stage === 16 || stage === 17) return new THREE.Vector3(-1.2, 1.45, 0);
   if (stage === 7 || stage === 8 || stage === 18) return CENTERS.v.clone();
-  if (stage === 9 || stage === 19) return new THREE.Vector3(4.9, -1.1, 0);
+  if (stage === 9 || stage === 19) return new THREE.Vector3(3.5, -1.0, 0);
   if (stage === 20) return CENTERS.Output.clone();
   return new THREE.Vector3(-3.25, 0, 0);
+}
+
+function desiredCameraPosition(stage, target) {
+  if (stage === 9 || stage === 19) {
+    // Front-on composition: Wv/context on the left, Wo centered, output sphere on the right.
+    return target.clone().add(new THREE.Vector3(0, 0.45, desiredCameraDistance(stage)));
+  }
+  return null;
 }
 function desiredCameraDistance(stage) {
   if (state.forceOverview || stage === 0 || stage === 10) return 17.5;
   if (stage === 20) return 4.6;
   if (stage === 1 || stage === 2 || stage === 3 || stage === 11 || stage === 12 || stage === 13) return 11.5;
-  if (stage === 6 || stage === 17) return 8.2;
-  if (stage === 9 || stage === 19) return 7.1;
-  if (stage === 4 || stage === 14 || stage === 15) return 8.4;
+  if (stage === 5 || stage === 6 || stage === 16 || stage === 17) return 9.8;
+  if (stage === 9 || stage === 19) return 11.0;
+  if (stage === 4 || stage === 14 || stage === 15) return 9.8;
   return 6.8;
 }
 
@@ -2184,10 +2192,15 @@ function animate(ts) {
   const target = focusCenter(state.stage);
   controls.target.lerp(target, 0.08);
   if (ts < state.cameraGuideUntil && !state.autoRotate) {
-    const offset = camera.position.clone().sub(controls.target);
-    if (offset.length() > 0.001) {
-      const desired = controls.target.clone().add(offset.normalize().multiplyScalar(desiredCameraDistance(state.stage)));
-      camera.position.lerp(desired, 0.055);
+    const guidedPosition = desiredCameraPosition(state.stage, target);
+    if (guidedPosition) {
+      camera.position.lerp(guidedPosition, 0.055);
+    } else {
+      const offset = camera.position.clone().sub(controls.target);
+      if (offset.length() > 0.001) {
+        const desired = controls.target.clone().add(offset.normalize().multiplyScalar(desiredCameraDistance(state.stage)));
+        camera.position.lerp(desired, 0.055);
+      }
     }
   }
   if (state.autoRotate) {

--- a/report/threejs/attention-read-activate-write-quant-compare-v3-hotkeys.html
+++ b/report/threejs/attention-read-activate-write-quant-compare-v3-hotkeys.html
@@ -1907,13 +1907,15 @@ function renderMatrixDotComposition({ inputTip, matrixKey, matrixCenter, outputC
   let cumulative = new THREE.Vector3();
   for (let i = 0; i < 3; i++) {
     const local = smoothstep01(t * 3 - i + 0.15);
+    const rowTip = endpoint(matrixCenter, rows[i]);
     const component = basisVector(i).multiplyScalar(components[i] * componentScale);
     const segStart = outputCenter.clone().add(cumulative);
     cumulative.add(component);
     const componentTip = outputCenter.clone().add(cumulative);
     const segEnd = lerpVec(segStart, componentTip, local);
-    setLine(dyn.transferLines[lineBase + i], inputTip, componentTip, 0.18 * local, lineColor);
-    setLine(dyn.transferLines[lineBase + 3 + i], segStart, segEnd, 0.62 * local, outputColor);
+    setLine(dyn.transferLines[lineBase + i], inputTip, rowTip, 0.20 * local, lineColor);
+    setLine(dyn.transferLines[lineBase + 3 + i], rowTip, componentTip, 0.20 * local, lineColor);
+    setLine(dyn.transferLines[lineBase + 6 + i], segStart, segEnd, 0.62 * local, outputColor);
 
     labelAt(dyn.labels[labelBase + i], componentTip.clone().add(new THREE.Vector3(0.14, 0.10 - 0.09 * i, 0.12)), `${matrixKey}${componentLabel(i)}=${components[i].toFixed(2)}`, lineColor, local);
   }

--- a/report/threejs/attention-read-activate-write-quant-compare-v3-hotkeys.html
+++ b/report/threejs/attention-read-activate-write-quant-compare-v3-hotkeys.html
@@ -2124,13 +2124,26 @@ function renderStage() {
     renderRawProjections(derived.continuous, 0.08, 0.08, 0.08, false);
     const local = smoothstep01(t);
     const start = endpoint(CENTERS.Input, data.tokens[0]);
-    const midIn = CENTERS.Wq.clone().add(new THREE.Vector3(-SPHERE_RADIUS, 0, 0));
     const midOut = CENTERS.Wq.clone().add(new THREE.Vector3(SPHERE_RADIUS, 0, 0));
     const end = rawProjEndpoint(CENTERS.q, derived.quantized.qRaw);
-    setLine(dyn.transferLines[0], start, midIn, 0.42 * local, CURRENT);
     setLine(dyn.transferLines[1], midOut, end, 0.42 * local, QUANT);
-    dyn.qArrowQ.set(CENTERS.q, lerpVec(CENTERS.q, end, local), QUANT, local);
-    labelAt(dyn.labels[0], end.clone().add(new THREE.Vector3(0.16, 0.10, 0.10)), state.quantWq ? 'raw q̃ = W̃q x₀' : 'raw q̃ = Wq x₀', QUANT, local);
+    renderMatrixDotComposition({
+      inputTip: start,
+      matrixKey: 'q̃',
+      matrixCenter: CENTERS.Wq,
+      outputCenter: CENTERS.q,
+      rows: derived.tensorQuantized.Wq,
+      components: [derived.quantized.qRaw.x, derived.quantized.qRaw.y, derived.quantized.qRaw.z],
+      outputGlyph: dyn.qArrowQ,
+      outputColor: QUANT,
+      lineColor: QUANT,
+      labelBase: 90,
+      lineBase: 20,
+      progress: local,
+      componentScale: derived.projectionScale,
+      finalEnd: end,
+      outputLabel: state.quantWq ? 'raw q̃ = W̃q x₀' : 'raw q̃ = Wq x₀',
+    });
   }
 
   if (s === 12) {

--- a/report/threejs/end-to-end-transformer-hotkeys.html
+++ b/report/threejs/end-to-end-transformer-hotkeys.html
@@ -1,0 +1,202 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>End-to-End Transformer Path: Attention + MLP</title>
+  <style>
+    :root { --bg:#151829; --panel:rgba(255,255,255,.07); --border:rgba(255,255,255,.14); --text:#fff; --muted:rgba(255,255,255,.68); --token:#ff7b72; --res:#94a3b8; --norm:#7dd3fc; --attn:#52b788; --mlp:#ffd166; --plus:#f4a261; --out:#c77dff; }
+    * { box-sizing:border-box; }
+    html, body { margin:0; width:100%; height:100%; overflow:hidden; background:var(--bg); color:var(--text); font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+    #app { display:grid; grid-template-columns:1fr 420px; width:100vw; height:100vh; }
+    #scene-wrap { position:relative; min-width:0; }
+    #scene { width:100%; height:100%; display:block; }
+    .title { position:absolute; left:20px; top:18px; max-width:920px; padding:15px 17px; border:1px solid var(--border); border-radius:20px; background:rgba(0,0,0,.28); backdrop-filter:blur(8px); pointer-events:none; }
+    h1 { margin:0; font-size:28px; line-height:1.08; letter-spacing:-.035em; }
+    .subtitle { margin-top:8px; color:var(--muted); font-size:14px; line-height:1.48; }
+    .hint { position:absolute; left:18px; bottom:18px; padding:10px 12px; border:1px solid var(--border); border-radius:16px; background:rgba(0,0,0,.30); color:rgba(255,255,255,.84); font-size:13px; pointer-events:none; }
+    aside { border-left:1px solid var(--border); background:rgba(255,255,255,.035); overflow:auto; padding:18px; }
+    .panel { background:var(--panel); border:1px solid var(--border); border-radius:18px; padding:15px; margin-bottom:14px; }
+    .panel h2 { margin:0 0 10px; font-size:12px; text-transform:uppercase; letter-spacing:.16em; color:rgba(255,255,255,.58); }
+    .stage { font-size:18px; font-weight:650; line-height:1.32; margin-bottom:10px; }
+    button, select { width:100%; appearance:none; border:1px solid var(--border); background:rgba(255,255,255,.09); color:var(--text); border-radius:14px; padding:10px 12px; font-size:13px; cursor:pointer; }
+    button:hover, select:hover { background:rgba(255,255,255,.14); }
+    .grid { display:grid; grid-template-columns:1fr 1fr; gap:9px; }
+    .row { display:flex; justify-content:space-between; gap:12px; color:rgba(255,255,255,.88); font-size:14px; padding:5px 0; }
+    .small { color:var(--muted); font-size:13px; line-height:1.45; }
+    .kbd { font-family:ui-monospace,SFMono-Regular,Menlo,monospace; padding:2px 6px; border:1px solid var(--border); border-radius:7px; background:rgba(255,255,255,.09); }
+    input[type=range] { width:100%; accent-color:#7dd3fc; }
+  </style>
+</head>
+<body>
+<div id="app">
+  <div id="scene-wrap">
+    <canvas id="scene"></canvas>
+    <div class="title">
+      <h1>End-to-End Transformer: x → Attention → MLP → y</h1>
+      <div class="subtitle">Pick a word to create an input vector. The vector shuttles down the residual stream, clones into norm spheres, projects onto each sphere surface, enters attention/MLP stations, and is added back at residual “+” stations.</div>
+    </div>
+    <div class="hint">Drag to rotate • Scroll to zoom • <span class="kbd">j/→</span> next • <span class="kbd">k/←</span> previous • <span class="kbd">Space</span> play/pause • <span class="kbd">r</span> replay</div>
+  </div>
+  <aside>
+    <div class="panel">
+      <h2>Token</h2>
+      <select id="wordSelect"></select>
+      <div class="small" style="margin-top:10px;">Each word deterministically seeds a 3D representation so the same word always follows the same end-to-end path.</div>
+    </div>
+    <div class="panel">
+      <h2>Current stage</h2>
+      <div class="stage" id="stageName"></div>
+      <div class="grid"><button id="prevBtn">Previous</button><button id="nextBtn">Next</button><button id="playBtn">Play</button><button id="replayBtn">Replay</button></div>
+      <div style="margin-top:12px;"><input id="progress" type="range" min="0" max="100" value="0" /></div>
+    </div>
+    <div class="panel">
+      <h2>Path</h2>
+      <div id="pathRows"></div>
+    </div>
+    <div class="panel">
+      <h2>Legend</h2>
+      <div class="row"><span>Residual stream</span><span style="color:var(--res)">x,r,+,h,y</span></div>
+      <div class="row"><span>Norm clone</span><span style="color:var(--norm)">n1…n5</span></div>
+      <div class="row"><span>Attention</span><span style="color:var(--attn)">a1,a2</span></div>
+      <div class="row"><span>MLP</span><span style="color:var(--mlp)">m1,m2</span></div>
+    </div>
+  </aside>
+</div>
+<script type="module">
+import * as THREE from 'https://esm.sh/three@0.160.0';
+import { OrbitControls } from 'https://esm.sh/three@0.160.0/examples/jsm/controls/OrbitControls.js';
+
+const COLORS = { bg:'#151829', token:'#ff7b72', res:'#94a3b8', norm:'#7dd3fc', attn:'#52b788', mlp:'#ffd166', plus:'#f4a261', out:'#c77dff', white:'#ffffff' };
+const R = 0.58;
+const STAGE_SECONDS = 1.35;
+const words = ['transformer', 'attention', 'residual', 'sphere', 'token', 'gradient', 'matrix', 'context', 'logit'];
+const path = [
+  {key:'x', label:'x input', kind:'res', p:[-3.8,4.8,0]},
+  {key:'r0', label:'r0 residual', kind:'res', p:[-3.8,3.6,0]},
+  {key:'n1', label:'n1 norm clone', kind:'norm', p:[-1.55,3.6,0]},
+  {key:'a1', label:'a1 attention', kind:'attn', p:[0.65,3.6,0]},
+  {key:'plus1', label:'+ add attention', kind:'plus', p:[-3.8,2.4,0]},
+  {key:'r1', label:'r1 residual', kind:'res', p:[-3.8,1.2,0]},
+  {key:'n2', label:'n2 norm clone', kind:'norm', p:[-1.55,1.2,0]},
+  {key:'m1', label:'m1 MLP', kind:'mlp', p:[0.65,1.2,0]},
+  {key:'plus2', label:'+ add MLP', kind:'plus', p:[-3.8,0,0]},
+  {key:'r2', label:'r2 residual', kind:'res', p:[-3.8,-1.2,0]},
+  {key:'n3', label:'n3 norm clone', kind:'norm', p:[-1.55,-1.2,0]},
+  {key:'a2', label:'a2 attention', kind:'attn', p:[0.65,-1.2,0]},
+  {key:'plus3', label:'+ add attention', kind:'plus', p:[-3.8,-2.4,0]},
+  {key:'r3', label:'r3 residual', kind:'res', p:[-3.8,-3.6,0]},
+  {key:'n4', label:'n4 norm clone', kind:'norm', p:[-1.55,-3.6,0]},
+  {key:'m2', label:'m2 MLP', kind:'mlp', p:[0.65,-3.6,0]},
+  {key:'plus4', label:'+ add MLP', kind:'plus', p:[-3.8,-4.8,0]},
+  {key:'r4', label:'r4 residual', kind:'res', p:[-3.8,-6.0,0]},
+  {key:'n5', label:'n5 final norm', kind:'norm', p:[-3.8,-7.2,0]},
+  {key:'h', label:'h hidden state', kind:'out', p:[-3.8,-8.4,0]},
+  {key:'y', label:'y logits', kind:'out', p:[-3.8,-9.6,0]},
+];
+const stages = path.map((p, i) => `${i + 1}. ${p.label}`);
+const canvas = document.getElementById('scene');
+const renderer = new THREE.WebGLRenderer({canvas, antialias:true});
+renderer.setPixelRatio(Math.min(2, window.devicePixelRatio));
+renderer.setClearColor(COLORS.bg, 1);
+renderer.outputColorSpace = THREE.SRGBColorSpace;
+const scene = new THREE.Scene();
+const world = new THREE.Group(); scene.add(world);
+const camera = new THREE.PerspectiveCamera(48, 1, 0.1, 100);
+camera.position.set(3.7, -2.3, 13.5);
+const controls = new OrbitControls(camera, canvas); controls.target.set(-2.1, -2.2, 0); controls.update();
+scene.add(new THREE.HemisphereLight(0xffffff, 0x223355, 1.4));
+
+function colorFor(kind) { return COLORS[kind] || COLORS.white; }
+function v3(a) { return new THREE.Vector3(a[0], a[1], a[2]); }
+function clamp01(x) { return Math.max(0, Math.min(1, x)); }
+function smoothstep01(x) { const t = clamp01(x); return t*t*(3-2*t); }
+function unit(v) { const n = v.length(); return n > 1e-9 ? v.clone().multiplyScalar(1/n) : new THREE.Vector3(0,1,0); }
+function lerpVec(a,b,t) { return a.clone().lerp(b, clamp01(t)); }
+function hashWord(w) { let h=2166136261; for (const ch of w) { h^=ch.charCodeAt(0); h=Math.imul(h,16777619); } return h>>>0; }
+function rand(seed) { let s=seed>>>0; return () => { s = Math.imul(1664525, s) + 1013904223 | 0; return ((s>>>0)/4294967296); }; }
+function wordVector(word) { const r=rand(hashWord(word)); return unit(new THREE.Vector3(r()*2-1, r()*2-1, r()*2-1)); }
+function transformVec(v, key) {
+  const angle = key.startsWith('a') ? 0.68 : key.startsWith('m') ? -0.52 : key === 'n5' ? 0.25 : 0.12;
+  const axis = unit(new THREE.Vector3(key.length + 1, key.charCodeAt(0)%7 + 1, 3));
+  return unit(v.clone().applyAxisAngle(axis, angle));
+}
+function stateVectorAt(index, base) {
+  let v = base.clone();
+  for (let i=1; i<=index; i++) {
+    const key = path[i].key;
+    if (key.startsWith('a') || key.startsWith('m') || key === 'n5' || key === 'h' || key === 'y') v = transformVec(v, key);
+  }
+  return v;
+}
+
+function makeText(text, color=COLORS.white, w=220, h=64, font=26) {
+  const c=document.createElement('canvas'); c.width=w; c.height=h; const ctx=c.getContext('2d');
+  ctx.clearRect(0,0,w,h); ctx.font=`700 ${font}px Inter, sans-serif`; ctx.textAlign='center'; ctx.textBaseline='middle';
+  ctx.fillStyle=color; ctx.fillText(text, w/2, h/2);
+  const tex=new THREE.CanvasTexture(c); tex.colorSpace=THREE.SRGBColorSpace;
+  const mat=new THREE.SpriteMaterial({map:tex, transparent:true, depthWrite:false});
+  const sp=new THREE.Sprite(mat); sp.scale.set(w/120, h/120, 1); return sp;
+}
+function makeLine(color, dashed=false) {
+  const g=new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(), new THREE.Vector3()]);
+  const m=dashed ? new THREE.LineDashedMaterial({color, transparent:true, opacity:.45, dashSize:.06, gapSize:.05, depthWrite:false}) : new THREE.LineBasicMaterial({color, transparent:true, opacity:.5, depthWrite:false});
+  const l=new THREE.Line(g,m); l.visible=false; world.add(l); return l;
+}
+function setLine(l,a,b,opacity,color) { l.geometry.setFromPoints([a,b]); l.material.opacity=opacity; if(color) l.material.color.set(color); l.computeLineDistances?.(); l.visible=opacity>.005; }
+
+class Arrow {
+  constructor(color) { this.group=new THREE.Group(); this.line=makeLine(color,false); world.remove(this.line); this.group.add(this.line); const geom=new THREE.ConeGeometry(.07,.18,18); const mat=new THREE.MeshBasicMaterial({color, transparent:true, opacity:1}); this.cone=new THREE.Mesh(geom,mat); this.group.add(this.cone); world.add(this.group); }
+  set(a,b,color,opacity=1) { const dir=b.clone().sub(a); const len=dir.length(); this.group.visible=opacity>.005 && len>.001; setLine(this.line,a,b,opacity,color); this.line.material.opacity=opacity; this.cone.material.opacity=opacity; this.cone.material.color.set(color); this.cone.position.copy(b); this.cone.quaternion.setFromUnitVectors(new THREE.Vector3(0,1,0), unit(dir)); }
+}
+
+const stationMeshes = new Map();
+const stationLabels = new Map();
+for (const node of path) {
+  const pos=v3(node.p);
+  const sphere=new THREE.Mesh(new THREE.SphereGeometry(R,24,14), new THREE.MeshBasicMaterial({color:COLORS.white, wireframe:true, transparent:true, opacity:.12, depthWrite:false}));
+  sphere.position.copy(pos); world.add(sphere); stationMeshes.set(node.key, sphere);
+  const label=makeText(node.key, colorFor(node.kind), 160, 58, node.key.startsWith('plus') ? 32 : 27); label.position.copy(pos.clone().add(new THREE.Vector3(0,R+.28,0))); world.add(label); stationLabels.set(node.key,label);
+}
+const pathLines=[]; for (let i=0;i<path.length-1;i++) pathLines.push(makeLine(COLORS.res,true));
+const branchPairs = [['r0','n1'],['n1','a1'],['a1','plus1'],['r1','n2'],['n2','m1'],['m1','plus2'],['r2','n3'],['n3','a2'],['a2','plus3'],['r3','n4'],['n4','m2'],['m2','plus4']];
+const branchLines = branchPairs.map(() => makeLine(COLORS.white,true));
+const arrows = path.map(() => new Arrow(COLORS.token));
+const shuttle = new THREE.Mesh(new THREE.SphereGeometry(.11,18,12), new THREE.MeshBasicMaterial({color:COLORS.token})); world.add(shuttle);
+
+const state = { stage:0, progress:0, playing:false, word:words[0], started:performance.now() };
+const stageNameEl=document.getElementById('stageName'); const progressEl=document.getElementById('progress'); const playBtn=document.getElementById('playBtn');
+const wordSelect=document.getElementById('wordSelect'); words.forEach(w=>{ const o=document.createElement('option'); o.value=w; o.textContent=w; wordSelect.appendChild(o); });
+const pathRows=document.getElementById('pathRows'); pathRows.innerHTML=path.map((p,i)=>`<div class="row"><span>${i+1}. ${p.key}</span><span style="color:${colorFor(p.kind)}">${p.label}</span></div>`).join('');
+function refreshUi(){ stageNameEl.textContent=stages[state.stage]; progressEl.value=Math.round(state.progress*100); playBtn.textContent=state.playing?'Pause':'Play'; wordSelect.value=state.word; }
+function go(delta){ state.stage=Math.max(0,Math.min(path.length-1,state.stage+delta)); state.progress=0; state.playing=false; state.started=performance.now(); refreshUi(); }
+document.getElementById('prevBtn').onclick=()=>go(-1); document.getElementById('nextBtn').onclick=()=>go(1);
+playBtn.onclick=()=>{ state.playing=!state.playing; state.started=performance.now()-state.progress*STAGE_SECONDS*1000; refreshUi(); };
+document.getElementById('replayBtn').onclick=()=>{ state.progress=0; state.playing=true; state.started=performance.now(); refreshUi(); };
+progressEl.oninput=e=>{ state.progress=Number(e.target.value)/100; state.playing=false; refreshUi(); };
+wordSelect.onchange=e=>{ state.word=e.target.value; state.progress=0; state.stage=0; refreshUi(); };
+window.addEventListener('keydown', e=>{ if(['ArrowRight','j'].includes(e.key)){go(1);e.preventDefault();} else if(['ArrowLeft','k'].includes(e.key)){go(-1);e.preventDefault();} else if(e.key===' '){playBtn.onclick();e.preventDefault();} else if(e.key==='r'){document.getElementById('replayBtn').onclick();e.preventDefault();} });
+
+function render() {
+  const base=wordVector(state.word);
+  for (let i=0;i<path.length-1;i++) {
+    const a=v3(path[i].p), b=v3(path[i+1].p);
+    const active = i === state.stage-1 || i === state.stage;
+    setLine(pathLines[i], a, b, active ? .42 : .16, COLORS.res);
+  }
+  branchPairs.forEach((pair,i)=>{ const a=v3(path.find(p=>p.key===pair[0]).p), b=v3(path.find(p=>p.key===pair[1]).p); setLine(branchLines[i], a,b,.22, COLORS.white); });
+  arrows.forEach(a=>a.group.visible=false);
+  for (let i=0;i<=state.stage;i++) {
+    const node=path[i]; const center=v3(node.p); const vec=stateVectorAt(i, base); const end=center.clone().add(vec.multiplyScalar(R));
+    arrows[i].set(center,end,colorFor(node.kind), i===state.stage ? 1 : .30);
+  }
+  const current=v3(path[state.stage].p); const prev=state.stage>0 ? v3(path[state.stage-1].p) : current;
+  shuttle.position.copy(lerpVec(prev,current,state.progress));
+  stationMeshes.forEach((mesh,key)=>{ const i=path.findIndex(p=>p.key===key); mesh.material.opacity = i===state.stage ? .22 : .08; });
+}
+function resize(){ const w=canvas.clientWidth,h=canvas.clientHeight; renderer.setSize(w,h,false); camera.aspect=w/h; camera.updateProjectionMatrix(); }
+window.addEventListener('resize', resize); resize(); refreshUi();
+let last=performance.now(); function animate(ts){ if(state.playing){ state.progress=clamp01((ts-state.started)/(STAGE_SECONDS*1000)); if(state.progress>=1){ state.playing=false; if(state.stage<path.length-1){ state.stage++; state.progress=0; state.playing=true; state.started=ts; } } refreshUi(); } render(); controls.update(); renderer.render(scene,camera); requestAnimationFrame(animate); last=ts; } requestAnimationFrame(animate);
+</script>
+</body>
+</html>

--- a/report/threejs/end-to-end-transformer-hotkeys.html
+++ b/report/threejs/end-to-end-transformer-hotkeys.html
@@ -34,9 +34,9 @@
     <canvas id="scene"></canvas>
     <div class="title">
       <h1>End-to-End Transformer: x → Attention → MLP → y</h1>
-      <div class="subtitle">Pick a word to create an input vector. The vector shuttles down the residual stream, clones into norm spheres, projects onto each sphere surface, enters attention/MLP stations, and is added back at residual “+” stations.</div>
+      <div class="subtitle">Pick a word to create an input vector. The vector shuttles down the residual stream, clones into norm spheres, enters spinning 3D Attention/MLP blocks, produces an output sphere, and is added back at residual “+” stations.</div>
     </div>
-    <div class="hint">Drag to rotate • Scroll to zoom • <span class="kbd">j/→</span> next • <span class="kbd">k/←</span> previous • <span class="kbd">Space</span> play/pause • <span class="kbd">r</span> replay</div>
+    <div class="hint">Drag to rotate • Scroll to zoom • <span class="kbd">j/→</span> next • <span class="kbd">k/←</span> previous • <span class="kbd">Space</span> play/pause • <span class="kbd">r</span> replay • <span class="kbd">s</span> spin</div>
   </div>
   <aside>
     <div class="panel">
@@ -49,6 +49,7 @@
       <div class="stage" id="stageName"></div>
       <div class="grid"><button id="prevBtn">Previous</button><button id="nextBtn">Next</button><button id="playBtn">Play</button><button id="replayBtn">Replay</button></div>
       <div style="margin-top:12px;"><input id="progress" type="range" min="0" max="100" value="0" /></div>
+      <label class="row" style="margin-top:8px;"><span>Spin modules / camera</span><input id="spinToggle" type="checkbox" checked /></label>
     </div>
     <div class="panel">
       <h2>Path</h2>
@@ -58,8 +59,9 @@
       <h2>Legend</h2>
       <div class="row"><span>Residual stream</span><span style="color:var(--res)">x,r,+,h,y</span></div>
       <div class="row"><span>Norm clone</span><span style="color:var(--norm)">n1…n5</span></div>
-      <div class="row"><span>Attention</span><span style="color:var(--attn)">a1,a2</span></div>
-      <div class="row"><span>MLP</span><span style="color:var(--mlp)">m1,m2</span></div>
+      <div class="row"><span>Attention blocks</span><span style="color:var(--attn)">3D rectangles</span></div>
+      <div class="row"><span>MLP blocks</span><span style="color:var(--mlp)">3D rectangles</span></div>
+      <div class="row"><span>Module outputs</span><span style="color:var(--out)">output spheres</span></div>
     </div>
   </aside>
 </div>
@@ -72,27 +74,31 @@ const R = 0.58;
 const STAGE_SECONDS = 1.35;
 const words = ['transformer', 'attention', 'residual', 'sphere', 'token', 'gradient', 'matrix', 'context', 'logit'];
 const path = [
-  {key:'x', label:'x input', kind:'res', p:[-3.8,4.8,0]},
-  {key:'r0', label:'r0 residual', kind:'res', p:[-3.8,3.6,0]},
-  {key:'n1', label:'n1 norm clone', kind:'norm', p:[-1.55,3.6,0]},
-  {key:'a1', label:'a1 attention', kind:'attn', p:[0.65,3.6,0]},
-  {key:'plus1', label:'+ add attention', kind:'plus', p:[-3.8,2.4,0]},
-  {key:'r1', label:'r1 residual', kind:'res', p:[-3.8,1.2,0]},
-  {key:'n2', label:'n2 norm clone', kind:'norm', p:[-1.55,1.2,0]},
-  {key:'m1', label:'m1 MLP', kind:'mlp', p:[0.65,1.2,0]},
-  {key:'plus2', label:'+ add MLP', kind:'plus', p:[-3.8,0,0]},
-  {key:'r2', label:'r2 residual', kind:'res', p:[-3.8,-1.2,0]},
-  {key:'n3', label:'n3 norm clone', kind:'norm', p:[-1.55,-1.2,0]},
-  {key:'a2', label:'a2 attention', kind:'attn', p:[0.65,-1.2,0]},
-  {key:'plus3', label:'+ add attention', kind:'plus', p:[-3.8,-2.4,0]},
-  {key:'r3', label:'r3 residual', kind:'res', p:[-3.8,-3.6,0]},
-  {key:'n4', label:'n4 norm clone', kind:'norm', p:[-1.55,-3.6,0]},
-  {key:'m2', label:'m2 MLP', kind:'mlp', p:[0.65,-3.6,0]},
-  {key:'plus4', label:'+ add MLP', kind:'plus', p:[-3.8,-4.8,0]},
-  {key:'r4', label:'r4 residual', kind:'res', p:[-3.8,-6.0,0]},
-  {key:'n5', label:'n5 final norm', kind:'norm', p:[-3.8,-7.2,0]},
-  {key:'h', label:'h hidden state', kind:'out', p:[-3.8,-8.4,0]},
-  {key:'y', label:'y logits', kind:'out', p:[-3.8,-9.6,0]},
+  {key:'x', label:'x input', kind:'res', p:[-3.8,5.4,0]},
+  {key:'r0', label:'r0 residual', kind:'res', p:[-3.8,4.2,0]},
+  {key:'n1', label:'n1 norm clone', kind:'norm', p:[-1.75,4.2,0]},
+  {key:'a1', label:'a1 attention block', kind:'attn', p:[0.35,4.2,0]},
+  {key:'a1o', label:'a1 output sphere', kind:'modout', p:[2.2,4.2,0]},
+  {key:'plus1', label:'+ add attention', kind:'plus', p:[-3.8,3.0,0]},
+  {key:'r1', label:'r1 residual', kind:'res', p:[-3.8,1.8,0]},
+  {key:'n2', label:'n2 norm clone', kind:'norm', p:[-1.75,1.8,0]},
+  {key:'m1', label:'m1 MLP block', kind:'mlp', p:[0.35,1.8,0]},
+  {key:'m1o', label:'m1 output sphere', kind:'modout', p:[2.2,1.8,0]},
+  {key:'plus2', label:'+ add MLP', kind:'plus', p:[-3.8,0.6,0]},
+  {key:'r2', label:'r2 residual', kind:'res', p:[-3.8,-0.6,0]},
+  {key:'n3', label:'n3 norm clone', kind:'norm', p:[-1.75,-0.6,0]},
+  {key:'a2', label:'a2 attention block', kind:'attn', p:[0.35,-0.6,0]},
+  {key:'a2o', label:'a2 output sphere', kind:'modout', p:[2.2,-0.6,0]},
+  {key:'plus3', label:'+ add attention', kind:'plus', p:[-3.8,-1.8,0]},
+  {key:'r3', label:'r3 residual', kind:'res', p:[-3.8,-3.0,0]},
+  {key:'n4', label:'n4 norm clone', kind:'norm', p:[-1.75,-3.0,0]},
+  {key:'m2', label:'m2 MLP block', kind:'mlp', p:[0.35,-3.0,0]},
+  {key:'m2o', label:'m2 output sphere', kind:'modout', p:[2.2,-3.0,0]},
+  {key:'plus4', label:'+ add MLP', kind:'plus', p:[-3.8,-4.2,0]},
+  {key:'r4', label:'r4 residual', kind:'res', p:[-3.8,-5.4,0]},
+  {key:'n5', label:'n5 final norm', kind:'norm', p:[-3.8,-6.6,0]},
+  {key:'h', label:'h hidden state', kind:'out', p:[-3.8,-7.8,0]},
+  {key:'y', label:'y logits', kind:'out', p:[-3.8,-9.0,0]},
 ];
 const stages = path.map((p, i) => `${i + 1}. ${p.label}`);
 const canvas = document.getElementById('scene');
@@ -107,7 +113,7 @@ camera.position.set(3.7, -2.3, 13.5);
 const controls = new OrbitControls(camera, canvas); controls.target.set(-2.1, -2.2, 0); controls.update();
 scene.add(new THREE.HemisphereLight(0xffffff, 0x223355, 1.4));
 
-function colorFor(kind) { return COLORS[kind] || COLORS.white; }
+function colorFor(kind) { return kind === 'modout' ? COLORS.out : (COLORS[kind] || COLORS.white); }
 function v3(a) { return new THREE.Vector3(a[0], a[1], a[2]); }
 function clamp01(x) { return Math.max(0, Math.min(1, x)); }
 function smoothstep01(x) { const t = clamp01(x); return t*t*(3-2*t); }
@@ -117,7 +123,7 @@ function hashWord(w) { let h=2166136261; for (const ch of w) { h^=ch.charCodeAt(
 function rand(seed) { let s=seed>>>0; return () => { s = Math.imul(1664525, s) + 1013904223 | 0; return ((s>>>0)/4294967296); }; }
 function wordVector(word) { const r=rand(hashWord(word)); return unit(new THREE.Vector3(r()*2-1, r()*2-1, r()*2-1)); }
 function transformVec(v, key) {
-  const angle = key.startsWith('a') ? 0.68 : key.startsWith('m') ? -0.52 : key === 'n5' ? 0.25 : 0.12;
+  const angle = key.startsWith('a') ? 0.68 : key.startsWith('m') ? -0.52 : key.endsWith('o') ? 0.34 : key === 'n5' ? 0.25 : 0.12;
   const axis = unit(new THREE.Vector3(key.length + 1, key.charCodeAt(0)%7 + 1, 3));
   return unit(v.clone().applyAxisAngle(axis, angle));
 }
@@ -152,30 +158,42 @@ class Arrow {
 
 const stationMeshes = new Map();
 const stationLabels = new Map();
+const moduleMeshes = [];
 for (const node of path) {
   const pos=v3(node.p);
-  const sphere=new THREE.Mesh(new THREE.SphereGeometry(R,24,14), new THREE.MeshBasicMaterial({color:COLORS.white, wireframe:true, transparent:true, opacity:.12, depthWrite:false}));
-  sphere.position.copy(pos); world.add(sphere); stationMeshes.set(node.key, sphere);
-  const label=makeText(node.key, colorFor(node.kind), 160, 58, node.key.startsWith('plus') ? 32 : 27); label.position.copy(pos.clone().add(new THREE.Vector3(0,R+.28,0))); world.add(label); stationLabels.set(node.key,label);
+  let mesh;
+  if (node.kind === 'attn' || node.kind === 'mlp') {
+    const geom = new THREE.BoxGeometry(1.05, 0.78, 0.52);
+    const mat = new THREE.MeshBasicMaterial({color:colorFor(node.kind), transparent:true, opacity:.34, wireframe:false, depthWrite:false});
+    mesh = new THREE.Mesh(geom, mat);
+    const edges = new THREE.LineSegments(new THREE.EdgesGeometry(geom), new THREE.LineBasicMaterial({color:colorFor(node.kind), transparent:true, opacity:.9}));
+    mesh.add(edges);
+    moduleMeshes.push(mesh);
+  } else {
+    mesh=new THREE.Mesh(new THREE.SphereGeometry(R,24,14), new THREE.MeshBasicMaterial({color:COLORS.white, wireframe:true, transparent:true, opacity:.12, depthWrite:false}));
+  }
+  mesh.position.copy(pos); world.add(mesh); stationMeshes.set(node.key, mesh);
+  const label=makeText(node.key, colorFor(node.kind), 170, 58, node.key.startsWith('plus') ? 32 : 27); label.position.copy(pos.clone().add(new THREE.Vector3(0,R+.33,0))); world.add(label); stationLabels.set(node.key,label);
 }
 const pathLines=[]; for (let i=0;i<path.length-1;i++) pathLines.push(makeLine(COLORS.res,true));
-const branchPairs = [['r0','n1'],['n1','a1'],['a1','plus1'],['r1','n2'],['n2','m1'],['m1','plus2'],['r2','n3'],['n3','a2'],['a2','plus3'],['r3','n4'],['n4','m2'],['m2','plus4']];
+const branchPairs = [['r0','n1'],['n1','a1'],['a1','a1o'],['a1o','plus1'],['r1','n2'],['n2','m1'],['m1','m1o'],['m1o','plus2'],['r2','n3'],['n3','a2'],['a2','a2o'],['a2o','plus3'],['r3','n4'],['n4','m2'],['m2','m2o'],['m2o','plus4']];
 const branchLines = branchPairs.map(() => makeLine(COLORS.white,true));
 const arrows = path.map(() => new Arrow(COLORS.token));
 const shuttle = new THREE.Mesh(new THREE.SphereGeometry(.11,18,12), new THREE.MeshBasicMaterial({color:COLORS.token})); world.add(shuttle);
 
-const state = { stage:0, progress:0, playing:false, word:words[0], started:performance.now() };
-const stageNameEl=document.getElementById('stageName'); const progressEl=document.getElementById('progress'); const playBtn=document.getElementById('playBtn');
+const state = { stage:0, progress:0, playing:false, word:words[0], started:performance.now(), spin:true };
+const stageNameEl=document.getElementById('stageName'); const progressEl=document.getElementById('progress'); const playBtn=document.getElementById('playBtn'); const spinToggle=document.getElementById('spinToggle');
 const wordSelect=document.getElementById('wordSelect'); words.forEach(w=>{ const o=document.createElement('option'); o.value=w; o.textContent=w; wordSelect.appendChild(o); });
 const pathRows=document.getElementById('pathRows'); pathRows.innerHTML=path.map((p,i)=>`<div class="row"><span>${i+1}. ${p.key}</span><span style="color:${colorFor(p.kind)}">${p.label}</span></div>`).join('');
-function refreshUi(){ stageNameEl.textContent=stages[state.stage]; progressEl.value=Math.round(state.progress*100); playBtn.textContent=state.playing?'Pause':'Play'; wordSelect.value=state.word; }
+function refreshUi(){ stageNameEl.textContent=stages[state.stage]; progressEl.value=Math.round(state.progress*100); playBtn.textContent=state.playing?'Pause':'Play'; wordSelect.value=state.word; spinToggle.checked=state.spin; }
 function go(delta){ state.stage=Math.max(0,Math.min(path.length-1,state.stage+delta)); state.progress=0; state.playing=false; state.started=performance.now(); refreshUi(); }
 document.getElementById('prevBtn').onclick=()=>go(-1); document.getElementById('nextBtn').onclick=()=>go(1);
 playBtn.onclick=()=>{ state.playing=!state.playing; state.started=performance.now()-state.progress*STAGE_SECONDS*1000; refreshUi(); };
 document.getElementById('replayBtn').onclick=()=>{ state.progress=0; state.playing=true; state.started=performance.now(); refreshUi(); };
 progressEl.oninput=e=>{ state.progress=Number(e.target.value)/100; state.playing=false; refreshUi(); };
 wordSelect.onchange=e=>{ state.word=e.target.value; state.progress=0; state.stage=0; refreshUi(); };
-window.addEventListener('keydown', e=>{ if(['ArrowRight','j'].includes(e.key)){go(1);e.preventDefault();} else if(['ArrowLeft','k'].includes(e.key)){go(-1);e.preventDefault();} else if(e.key===' '){playBtn.onclick();e.preventDefault();} else if(e.key==='r'){document.getElementById('replayBtn').onclick();e.preventDefault();} });
+spinToggle.onchange=e=>{ state.spin=e.target.checked; refreshUi(); };
+window.addEventListener('keydown', e=>{ if(['ArrowRight','j'].includes(e.key)){go(1);e.preventDefault();} else if(['ArrowLeft','k'].includes(e.key)){go(-1);e.preventDefault();} else if(e.key===' '){playBtn.onclick();e.preventDefault();} else if(e.key==='r'){document.getElementById('replayBtn').onclick();e.preventDefault();} else if(e.key==='s'){state.spin=!state.spin; refreshUi(); e.preventDefault();} });
 
 function render() {
   const base=wordVector(state.word);
@@ -192,11 +210,12 @@ function render() {
   }
   const current=v3(path[state.stage].p); const prev=state.stage>0 ? v3(path[state.stage-1].p) : current;
   shuttle.position.copy(lerpVec(prev,current,state.progress));
-  stationMeshes.forEach((mesh,key)=>{ const i=path.findIndex(p=>p.key===key); mesh.material.opacity = i===state.stage ? .22 : .08; });
+  stationMeshes.forEach((mesh,key)=>{ const i=path.findIndex(p=>p.key===key); const node=path[i]; const active=i===state.stage; if (node.kind === 'attn' || node.kind === 'mlp') { mesh.material.opacity = active ? .48 : .28; mesh.scale.setScalar(active ? 1.12 : 1.0); } else { mesh.material.opacity = active ? .22 : .08; } });
+  if (state.spin) moduleMeshes.forEach((m,i)=>{ m.rotation.y += 0.012 + i * 0.001; m.rotation.x = Math.sin(performance.now()*0.001 + i) * 0.10; });
 }
 function resize(){ const w=canvas.clientWidth,h=canvas.clientHeight; renderer.setSize(w,h,false); camera.aspect=w/h; camera.updateProjectionMatrix(); }
 window.addEventListener('resize', resize); resize(); refreshUi();
-let last=performance.now(); function animate(ts){ if(state.playing){ state.progress=clamp01((ts-state.started)/(STAGE_SECONDS*1000)); if(state.progress>=1){ state.playing=false; if(state.stage<path.length-1){ state.stage++; state.progress=0; state.playing=true; state.started=ts; } } refreshUi(); } render(); controls.update(); renderer.render(scene,camera); requestAnimationFrame(animate); last=ts; } requestAnimationFrame(animate);
+let last=performance.now(); function animate(ts){ if(state.playing){ state.progress=clamp01((ts-state.started)/(STAGE_SECONDS*1000)); if(state.progress>=1){ state.playing=false; if(state.stage<path.length-1){ state.stage++; state.progress=0; state.playing=true; state.started=ts; } } refreshUi(); } render(); if(state.spin){ const center=controls.target.clone(); camera.position.sub(center).applyAxisAngle(new THREE.Vector3(0,1,0),0.0018).add(center); } controls.update(); renderer.render(scene,camera); requestAnimationFrame(animate); last=ts; } requestAnimationFrame(animate);
 </script>
 </body>
 </html>

--- a/report/threejs/end-to-end-transformer-hotkeys.html
+++ b/report/threejs/end-to-end-transformer-hotkeys.html
@@ -3,15 +3,15 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>End-to-End Transformer Path: Attention + MLP</title>
+  <title>Transformer Train: One Layer + LM Head</title>
   <style>
-    :root { --bg:#151829; --panel:rgba(255,255,255,.07); --border:rgba(255,255,255,.14); --text:#fff; --muted:rgba(255,255,255,.68); --token:#ff7b72; --res:#94a3b8; --norm:#7dd3fc; --attn:#52b788; --mlp:#ffd166; --plus:#f4a261; --out:#c77dff; }
+    :root { --bg:#151829; --panel:rgba(255,255,255,.07); --border:rgba(255,255,255,.14); --text:#fff; --muted:rgba(255,255,255,.68); --token:#ff7b72; --res:#94a3b8; --norm:#7dd3fc; --attn:#52b788; --mlp:#ffd166; --plus:#f4a261; --out:#c77dff; --soft:#58c4dd; }
     * { box-sizing:border-box; }
     html, body { margin:0; width:100%; height:100%; overflow:hidden; background:var(--bg); color:var(--text); font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
-    #app { display:grid; grid-template-columns:1fr 420px; width:100vw; height:100vh; }
+    #app { display:grid; grid-template-columns:1fr 430px; width:100vw; height:100vh; }
     #scene-wrap { position:relative; min-width:0; }
     #scene { width:100%; height:100%; display:block; }
-    .title { position:absolute; left:20px; top:18px; max-width:920px; padding:15px 17px; border:1px solid var(--border); border-radius:20px; background:rgba(0,0,0,.28); backdrop-filter:blur(8px); pointer-events:none; }
+    .title { position:absolute; left:20px; top:18px; max-width:980px; padding:15px 17px; border:1px solid var(--border); border-radius:20px; background:rgba(0,0,0,.28); backdrop-filter:blur(8px); pointer-events:none; }
     h1 { margin:0; font-size:28px; line-height:1.08; letter-spacing:-.035em; }
     .subtitle { margin-top:8px; color:var(--muted); font-size:14px; line-height:1.48; }
     .hint { position:absolute; left:18px; bottom:18px; padding:10px 12px; border:1px solid var(--border); border-radius:16px; background:rgba(0,0,0,.30); color:rgba(255,255,255,.84); font-size:13px; pointer-events:none; }
@@ -33,35 +33,34 @@
   <div id="scene-wrap">
     <canvas id="scene"></canvas>
     <div class="title">
-      <h1>End-to-End Transformer: x → Attention → MLP → y</h1>
-      <div class="subtitle">Pick a word to create an input vector. The vector shuttles down the residual stream, clones into norm spheres, enters spinning 3D Attention/MLP blocks, produces an output sphere, and is added back at residual “+” stations.</div>
+      <h1>Transformer Train: residual sphere through one layer</h1>
+      <div class="subtitle">Choose a word, then watch the residual vector travel like a train through Attention, MLP, output norm, LM-head read vectors, softmax, top-1 selection, and beam back to the start for the next token.</div>
     </div>
-    <div class="hint">Drag to rotate • Scroll to zoom • <span class="kbd">j/→</span> next • <span class="kbd">k/←</span> previous • <span class="kbd">Space</span> play/pause • <span class="kbd">r</span> replay • <span class="kbd">s</span> spin</div>
+    <div class="hint">Drag to rotate • Scroll to zoom • Right-drag to pan • <span class="kbd">j/→</span> next • <span class="kbd">k/←</span> previous • <span class="kbd">Space</span> play/pause • <span class="kbd">r</span> replay • <span class="kbd">c</span> camera guide</div>
   </div>
   <aside>
     <div class="panel">
-      <h2>Token</h2>
+      <h2>Input word</h2>
       <select id="wordSelect"></select>
-      <div class="small" style="margin-top:10px;">Each word deterministically seeds a 3D representation so the same word always follows the same end-to-end path.</div>
+      <div class="small" style="margin-top:10px;">The start sphere uses the same word directions as the LM-head read sphere: cat, dog, owl, horse, hamster.</div>
     </div>
     <div class="panel">
       <h2>Current stage</h2>
       <div class="stage" id="stageName"></div>
       <div class="grid"><button id="prevBtn">Previous</button><button id="nextBtn">Next</button><button id="playBtn">Play</button><button id="replayBtn">Replay</button></div>
       <div style="margin-top:12px;"><input id="progress" type="range" min="0" max="100" value="0" /></div>
-      <label class="row" style="margin-top:8px;"><span>Spin modules / camera</span><input id="spinToggle" type="checkbox" checked /></label>
+      <label class="row" style="margin-top:8px;"><span>Guided camera</span><input id="cameraToggle" type="checkbox" checked /></label>
     </div>
     <div class="panel">
-      <h2>Path</h2>
-      <div id="pathRows"></div>
+      <h2>Readout</h2>
+      <div id="readout"></div>
     </div>
     <div class="panel">
       <h2>Legend</h2>
-      <div class="row"><span>Residual stream</span><span style="color:var(--res)">x,r,+,h,y</span></div>
-      <div class="row"><span>Norm clone</span><span style="color:var(--norm)">n1…n5</span></div>
-      <div class="row"><span>Attention blocks</span><span style="color:var(--attn)">3D rectangles</span></div>
-      <div class="row"><span>MLP blocks</span><span style="color:var(--mlp)">3D rectangles</span></div>
-      <div class="row"><span>Module outputs</span><span style="color:var(--out)">output spheres</span></div>
+      <div class="row"><span>Residual train</span><span style="color:var(--token)">moving sphere</span></div>
+      <div class="row"><span>Norm copies</span><span style="color:var(--norm)">project to surface</span></div>
+      <div class="row"><span>Blocks</span><span style="color:var(--attn)">3D rectangles</span></div>
+      <div class="row"><span>LM Head</span><span style="color:var(--soft)">read dots + softmax</span></div>
     </div>
   </aside>
 </div>
@@ -69,153 +68,120 @@
 import * as THREE from 'https://esm.sh/three@0.160.0';
 import { OrbitControls } from 'https://esm.sh/three@0.160.0/examples/jsm/controls/OrbitControls.js';
 
-const COLORS = { bg:'#151829', token:'#ff7b72', res:'#94a3b8', norm:'#7dd3fc', attn:'#52b788', mlp:'#ffd166', plus:'#f4a261', out:'#c77dff', white:'#ffffff' };
-const R = 0.58;
-const STAGE_SECONDS = 1.35;
-const words = ['transformer', 'attention', 'residual', 'sphere', 'token', 'gradient', 'matrix', 'context', 'logit'];
-const path = [
-  {key:'x', label:'x input', kind:'res', p:[-3.8,5.4,0]},
-  {key:'r0', label:'r0 residual', kind:'res', p:[-3.8,4.2,0]},
-  {key:'n1', label:'n1 norm clone', kind:'norm', p:[-1.75,4.2,0]},
-  {key:'a1', label:'a1 attention block', kind:'attn', p:[0.35,4.2,0]},
-  {key:'a1o', label:'a1 output sphere', kind:'modout', p:[2.2,4.2,0]},
-  {key:'plus1', label:'+ add attention', kind:'plus', p:[-3.8,3.0,0]},
-  {key:'r1', label:'r1 residual', kind:'res', p:[-3.8,1.8,0]},
-  {key:'n2', label:'n2 norm clone', kind:'norm', p:[-1.75,1.8,0]},
-  {key:'m1', label:'m1 MLP block', kind:'mlp', p:[0.35,1.8,0]},
-  {key:'m1o', label:'m1 output sphere', kind:'modout', p:[2.2,1.8,0]},
-  {key:'plus2', label:'+ add MLP', kind:'plus', p:[-3.8,0.6,0]},
-  {key:'r2', label:'r2 residual', kind:'res', p:[-3.8,-0.6,0]},
-  {key:'n3', label:'n3 norm clone', kind:'norm', p:[-1.75,-0.6,0]},
-  {key:'a2', label:'a2 attention block', kind:'attn', p:[0.35,-0.6,0]},
-  {key:'a2o', label:'a2 output sphere', kind:'modout', p:[2.2,-0.6,0]},
-  {key:'plus3', label:'+ add attention', kind:'plus', p:[-3.8,-1.8,0]},
-  {key:'r3', label:'r3 residual', kind:'res', p:[-3.8,-3.0,0]},
-  {key:'n4', label:'n4 norm clone', kind:'norm', p:[-1.75,-3.0,0]},
-  {key:'m2', label:'m2 MLP block', kind:'mlp', p:[0.35,-3.0,0]},
-  {key:'m2o', label:'m2 output sphere', kind:'modout', p:[2.2,-3.0,0]},
-  {key:'plus4', label:'+ add MLP', kind:'plus', p:[-3.8,-4.2,0]},
-  {key:'r4', label:'r4 residual', kind:'res', p:[-3.8,-5.4,0]},
-  {key:'n5', label:'n5 final norm', kind:'norm', p:[-3.8,-6.6,0]},
-  {key:'h', label:'h hidden state', kind:'out', p:[-3.8,-7.8,0]},
-  {key:'y', label:'y logits', kind:'out', p:[-3.8,-9.0,0]},
+const COLORS = { bg:'#151829', token:'#ff7b72', res:'#94a3b8', norm:'#7dd3fc', attn:'#52b788', mlp:'#ffd166', plus:'#f4a261', out:'#c77dff', soft:'#58c4dd', white:'#ffffff' };
+const R = 0.72;
+const STAGE_SECONDS = 1.55;
+const WORDS = ['cat', 'dog', 'owl', 'horse', 'hamster'];
+const STAGES = [
+  'Start: choose a word vector on the input sphere',
+  'Residual train moves forward to Attention input',
+  'Attention norm: copy residual, then project to sphere surface',
+  'Attention block: norm vector enters rectangle and emits output sphere',
+  'Residual add: attention output vector adds back into residual',
+  'Residual train moves forward to MLP input',
+  'MLP norm: copy residual, then project to sphere surface',
+  'MLP block: norm vector enters rectangle and emits output sphere',
+  'Residual add: MLP output vector adds back into residual',
+  'Residual train moves forward to output norm',
+  'Output norm projects residual to the sphere surface',
+  'LM Head read sphere: dot hidden state with word vectors',
+  'Softmax output sphere: scale word vectors by probabilities',
+  'Top-1 selection beams back and becomes the next input',
 ];
-const stages = path.map((p, i) => `${i + 1}. ${p.label}`);
+const P = {
+  start: new THREE.Vector3(-6.0, 0, 0),
+  attnIn: new THREE.Vector3(-2.8, 0, 0),
+  mlpIn: new THREE.Vector3(0.6, 0, 0),
+  outNorm: new THREE.Vector3(3.8, 0, 0),
+  lmHead: new THREE.Vector3(6.8, 0, 0),
+  softmax: new THREE.Vector3(9.5, 0, 0),
+  attnNorm: new THREE.Vector3(-2.8, 2.15, 0),
+  attnBlock: new THREE.Vector3(-.75, 2.15, 0),
+  attnOut: new THREE.Vector3(1.15, 2.15, 0),
+  mlpNorm: new THREE.Vector3(.6, -2.15, 0),
+  mlpBlock: new THREE.Vector3(2.65, -2.15, 0),
+  mlpOut: new THREE.Vector3(4.55, -2.15, 0),
+};
+
 const canvas = document.getElementById('scene');
 const renderer = new THREE.WebGLRenderer({canvas, antialias:true});
-renderer.setPixelRatio(Math.min(2, window.devicePixelRatio));
+renderer.setPixelRatio(Math.min(2, devicePixelRatio));
 renderer.setClearColor(COLORS.bg, 1);
 renderer.outputColorSpace = THREE.SRGBColorSpace;
 const scene = new THREE.Scene();
 const world = new THREE.Group(); scene.add(world);
 const camera = new THREE.PerspectiveCamera(48, 1, 0.1, 100);
-camera.position.set(3.7, -2.3, 13.5);
-const controls = new OrbitControls(camera, canvas); controls.target.set(-2.1, -2.2, 0); controls.update();
-scene.add(new THREE.HemisphereLight(0xffffff, 0x223355, 1.4));
+camera.position.set(1.2, 1.4, 11.5);
+const controls = new OrbitControls(camera, canvas); controls.target.set(1.0, 0, 0); controls.update();
+scene.add(new THREE.HemisphereLight(0xffffff, 0x223355, 1.5));
 
-function colorFor(kind) { return kind === 'modout' ? COLORS.out : (COLORS[kind] || COLORS.white); }
-function v3(a) { return new THREE.Vector3(a[0], a[1], a[2]); }
-function clamp01(x) { return Math.max(0, Math.min(1, x)); }
-function smoothstep01(x) { const t = clamp01(x); return t*t*(3-2*t); }
-function unit(v) { const n = v.length(); return n > 1e-9 ? v.clone().multiplyScalar(1/n) : new THREE.Vector3(0,1,0); }
-function lerpVec(a,b,t) { return a.clone().lerp(b, clamp01(t)); }
-function hashWord(w) { let h=2166136261; for (const ch of w) { h^=ch.charCodeAt(0); h=Math.imul(h,16777619); } return h>>>0; }
-function rand(seed) { let s=seed>>>0; return () => { s = Math.imul(1664525, s) + 1013904223 | 0; return ((s>>>0)/4294967296); }; }
-function wordVector(word) { const r=rand(hashWord(word)); return unit(new THREE.Vector3(r()*2-1, r()*2-1, r()*2-1)); }
-function transformVec(v, key) {
-  const angle = key.startsWith('a') ? 0.68 : key.startsWith('m') ? -0.52 : key.endsWith('o') ? 0.34 : key === 'n5' ? 0.25 : 0.12;
-  const axis = unit(new THREE.Vector3(key.length + 1, key.charCodeAt(0)%7 + 1, 3));
-  return unit(v.clone().applyAxisAngle(axis, angle));
-}
-function stateVectorAt(index, base) {
-  let v = base.clone();
-  for (let i=1; i<=index; i++) {
-    const key = path[i].key;
-    if (key.startsWith('a') || key.startsWith('m') || key === 'n5' || key === 'h' || key === 'y') v = transformVec(v, key);
-  }
-  return v;
-}
+function clamp01(x){ return Math.max(0, Math.min(1, x)); }
+function smoothstep01(x){ const t=clamp01(x); return t*t*(3-2*t); }
+function unit(v){ const n=v.length(); return n>1e-9 ? v.clone().multiplyScalar(1/n) : new THREE.Vector3(0,1,0); }
+function lerpVec(a,b,t){ return a.clone().lerp(b, clamp01(t)); }
+function endpoint(center, dir, radius=R){ return center.clone().add(unit(dir).multiplyScalar(radius)); }
+function hashWord(w){ let h=2166136261; for(const ch of w){ h^=ch.charCodeAt(0); h=Math.imul(h,16777619); } return h>>>0; }
+function rand(seed){ let s=seed>>>0; return () => { s = Math.imul(1664525, s) + 1013904223 | 0; return (s>>>0)/4294967296; }; }
+function wordDir(word){ const r=rand(hashWord(word)); return unit(new THREE.Vector3(r()*2-1, r()*2-1, r()*2-1)); }
+function rotateVec(v, label, amount){ const axis=unit(new THREE.Vector3(label.length+1, label.charCodeAt(0)%5+1, 3)); return unit(v.clone().applyAxisAngle(axis, amount)); }
+function addVec(a,b,scale=.45){ return unit(a.clone().add(b.clone().multiplyScalar(scale))); }
+function wordColor(i){ return ['#ff7b72','#f4a261','#ffd166','#52b788','#7dd3fc'][i % 5]; }
+function softmax(vals){ const m=Math.max(...vals); const ex=vals.map(v=>Math.exp(4*(v-m))); const s=ex.reduce((a,b)=>a+b,0); return ex.map(v=>v/s); }
+function stateVectors(base){ const attnNorm=unit(base); const attnOut=rotateVec(attnNorm,'attention',.72); const afterAttn=addVec(base, attnOut, .50); const mlpNorm=unit(afterAttn); const mlpOut=rotateVec(mlpNorm,'mlp',-.58); const afterMlp=addVec(afterAttn, mlpOut, .44); const hidden=unit(afterMlp); const logits=WORDS.map(w=>hidden.dot(wordDir(w))); const probs=softmax(logits); const top=probs.reduce((best,p,i)=>p>probs[best]?i:best,0); return {base, attnNorm, attnOut, afterAttn, mlpNorm, mlpOut, afterMlp, hidden, logits, probs, top}; }
+function residualCenter(stage,t){ if(stage<=0) return P.start; if(stage===1) return lerpVec(P.start,P.attnIn,smoothstep01(t)); if(stage<5) return P.attnIn; if(stage===5) return lerpVec(P.attnIn,P.mlpIn,smoothstep01(t)); if(stage<9) return P.mlpIn; if(stage===9) return lerpVec(P.mlpIn,P.outNorm,smoothstep01(t)); return P.outNorm; }
+function residualVecFor(stage, sv){ if(stage<4) return sv.base; if(stage<8) return stage===4 ? unit(sv.base.clone().lerp(sv.afterAttn, smoothstep01(appState.progress))) : sv.afterAttn; if(stage===8) return unit(sv.afterAttn.clone().lerp(sv.afterMlp, smoothstep01(appState.progress))); return sv.afterMlp; }
 
-function makeText(text, color=COLORS.white, w=220, h=64, font=26) {
-  const c=document.createElement('canvas'); c.width=w; c.height=h; const ctx=c.getContext('2d');
-  ctx.clearRect(0,0,w,h); ctx.font=`700 ${font}px Inter, sans-serif`; ctx.textAlign='center'; ctx.textBaseline='middle';
-  ctx.fillStyle=color; ctx.fillText(text, w/2, h/2);
-  const tex=new THREE.CanvasTexture(c); tex.colorSpace=THREE.SRGBColorSpace;
-  const mat=new THREE.SpriteMaterial({map:tex, transparent:true, depthWrite:false});
-  const sp=new THREE.Sprite(mat); sp.scale.set(w/120, h/120, 1); return sp;
-}
-function makeLine(color, dashed=false) {
-  const g=new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(), new THREE.Vector3()]);
-  const m=dashed ? new THREE.LineDashedMaterial({color, transparent:true, opacity:.45, dashSize:.06, gapSize:.05, depthWrite:false}) : new THREE.LineBasicMaterial({color, transparent:true, opacity:.5, depthWrite:false});
-  const l=new THREE.Line(g,m); l.visible=false; world.add(l); return l;
-}
-function setLine(l,a,b,opacity,color) { l.geometry.setFromPoints([a,b]); l.material.opacity=opacity; if(color) l.material.color.set(color); l.computeLineDistances?.(); l.visible=opacity>.005; }
+function makeText(text, color=COLORS.white, w=220, h=64, font=25){ const c=document.createElement('canvas'); c.width=w; c.height=h; const ctx=c.getContext('2d'); ctx.font=`700 ${font}px Inter, sans-serif`; ctx.textAlign='center'; ctx.textBaseline='middle'; ctx.fillStyle=color; ctx.fillText(text,w/2,h/2); const tex=new THREE.CanvasTexture(c); tex.colorSpace=THREE.SRGBColorSpace; const mat=new THREE.SpriteMaterial({map:tex,transparent:true,depthWrite:false}); const sp=new THREE.Sprite(mat); sp.scale.set(w/120,h/120,1); return sp; }
+function makeLine(color=COLORS.white,dashed=true){ const g=new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(),new THREE.Vector3()]); const m=dashed ? new THREE.LineDashedMaterial({color,transparent:true,opacity:.45,dashSize:.08,gapSize:.06,depthWrite:false}) : new THREE.LineBasicMaterial({color,transparent:true,opacity:.55,depthWrite:false}); const l=new THREE.Line(g,m); l.visible=false; world.add(l); return l; }
+function setLine(l,a,b,op=.45,color){ l.geometry.setFromPoints([a,b]); l.material.opacity=op; if(color) l.material.color.set(color); l.computeLineDistances?.(); l.visible=op>.004; }
+class Arrow{ constructor(color){ this.group=new THREE.Group(); this.line=makeLine(color,false); world.remove(this.line); this.group.add(this.line); this.cone=new THREE.Mesh(new THREE.ConeGeometry(.075,.20,18),new THREE.MeshBasicMaterial({color,transparent:true,opacity:1})); this.group.add(this.cone); world.add(this.group); } set(a,b,color,op=1){ const d=b.clone().sub(a); this.group.visible=op>.005&&d.length()>.001; setLine(this.line,a,b,op,color); this.cone.position.copy(b); this.cone.material.opacity=op; this.cone.material.color.set(color); this.cone.quaternion.setFromUnitVectors(new THREE.Vector3(0,1,0),unit(d)); } hide(){ this.group.visible=false; } }
 
-class Arrow {
-  constructor(color) { this.group=new THREE.Group(); this.line=makeLine(color,false); world.remove(this.line); this.group.add(this.line); const geom=new THREE.ConeGeometry(.07,.18,18); const mat=new THREE.MeshBasicMaterial({color, transparent:true, opacity:1}); this.cone=new THREE.Mesh(geom,mat); this.group.add(this.cone); world.add(this.group); }
-  set(a,b,color,opacity=1) { const dir=b.clone().sub(a); const len=dir.length(); this.group.visible=opacity>.005 && len>.001; setLine(this.line,a,b,opacity,color); this.line.material.opacity=opacity; this.cone.material.opacity=opacity; this.cone.material.color.set(color); this.cone.position.copy(b); this.cone.quaternion.setFromUnitVectors(new THREE.Vector3(0,1,0), unit(dir)); }
-}
+const labels=[]; function label(text,pos,color=COLORS.white,w=180){ const s=makeText(text,color,w,56,24); s.position.copy(pos); world.add(s); labels.push(s); return s; }
+function sphere(name,pos,color=COLORS.white){ const mesh=new THREE.Mesh(new THREE.SphereGeometry(R,32,18),new THREE.MeshBasicMaterial({color:COLORS.white,wireframe:true,transparent:true,opacity:.11,depthWrite:false})); mesh.position.copy(pos); world.add(mesh); label(name,pos.clone().add(new THREE.Vector3(0,R+.32,0)),color); return mesh; }
+function block(name,pos,color){ const geom=new THREE.BoxGeometry(1.35,.82,.58); const mesh=new THREE.Mesh(geom,new THREE.MeshBasicMaterial({color,transparent:true,opacity:.38,depthWrite:false})); mesh.position.copy(pos); const edges=new THREE.LineSegments(new THREE.EdgesGeometry(geom),new THREE.LineBasicMaterial({color,transparent:true,opacity:.95})); mesh.add(edges); world.add(mesh); label(name,pos.clone().add(new THREE.Vector3(0,R+.26,0)),color,190); return mesh; }
+const stationMeshes=[sphere('word input',P.start,COLORS.token),sphere('attn in',P.attnIn,COLORS.res),sphere('mlp in',P.mlpIn,COLORS.res),sphere('out norm',P.outNorm,COLORS.norm),sphere('LM Head',P.lmHead,COLORS.soft),sphere('softmax',P.softmax,COLORS.out),sphere('attn norm',P.attnNorm,COLORS.norm),block('attention',P.attnBlock,COLORS.attn),sphere('attn output',P.attnOut,COLORS.out),sphere('mlp norm',P.mlpNorm,COLORS.norm),block('mlp',P.mlpBlock,COLORS.mlp),sphere('mlp output',P.mlpOut,COLORS.out)];
+const blockMeshes=[stationMeshes[7],stationMeshes[10]];
+const trackLines=[]; for(let i=0;i<18;i++) trackLines.push(makeLine(COLORS.res,true));
+const dynLines=[]; for(let i=0;i<30;i++) dynLines.push(makeLine(COLORS.white,true));
+const arrows=[]; for(let i=0;i<20;i++) arrows.push(new Arrow(COLORS.token));
+const residualBall=new THREE.Mesh(new THREE.SphereGeometry(.16,24,14),new THREE.MeshBasicMaterial({color:COLORS.token})); world.add(residualBall);
+const beamLine=makeLine(COLORS.token,false);
+const wordMarkers=WORDS.map((w,i)=>{ const m=new THREE.Mesh(new THREE.SphereGeometry(.055,12,8),new THREE.MeshBasicMaterial({color:wordColor(i),transparent:true,opacity:.9})); world.add(m); label(w,P.start.clone().add(wordDir(w).multiplyScalar(R+.25)),wordColor(i),120); return m; });
+const readMarkers=WORDS.map((w,i)=>{ const m=new THREE.Mesh(new THREE.SphereGeometry(.06,12,8),new THREE.MeshBasicMaterial({color:wordColor(i),transparent:true,opacity:.9})); world.add(m); label(w,P.lmHead.clone().add(wordDir(w).multiplyScalar(R+.25)),wordColor(i),120); return m; });
 
-const stationMeshes = new Map();
-const stationLabels = new Map();
-const moduleMeshes = [];
-for (const node of path) {
-  const pos=v3(node.p);
-  let mesh;
-  if (node.kind === 'attn' || node.kind === 'mlp') {
-    const geom = new THREE.BoxGeometry(1.05, 0.78, 0.52);
-    const mat = new THREE.MeshBasicMaterial({color:colorFor(node.kind), transparent:true, opacity:.34, wireframe:false, depthWrite:false});
-    mesh = new THREE.Mesh(geom, mat);
-    const edges = new THREE.LineSegments(new THREE.EdgesGeometry(geom), new THREE.LineBasicMaterial({color:colorFor(node.kind), transparent:true, opacity:.9}));
-    mesh.add(edges);
-    moduleMeshes.push(mesh);
-  } else {
-    mesh=new THREE.Mesh(new THREE.SphereGeometry(R,24,14), new THREE.MeshBasicMaterial({color:COLORS.white, wireframe:true, transparent:true, opacity:.12, depthWrite:false}));
-  }
-  mesh.position.copy(pos); world.add(mesh); stationMeshes.set(node.key, mesh);
-  const label=makeText(node.key, colorFor(node.kind), 170, 58, node.key.startsWith('plus') ? 32 : 27); label.position.copy(pos.clone().add(new THREE.Vector3(0,R+.33,0))); world.add(label); stationLabels.set(node.key,label);
-}
-const pathLines=[]; for (let i=0;i<path.length-1;i++) pathLines.push(makeLine(COLORS.res,true));
-const branchPairs = [['r0','n1'],['n1','a1'],['a1','a1o'],['a1o','plus1'],['r1','n2'],['n2','m1'],['m1','m1o'],['m1o','plus2'],['r2','n3'],['n3','a2'],['a2','a2o'],['a2o','plus3'],['r3','n4'],['n4','m2'],['m2','m2o'],['m2o','plus4']];
-const branchLines = branchPairs.map(() => makeLine(COLORS.white,true));
-const arrows = path.map(() => new Arrow(COLORS.token));
-const shuttle = new THREE.Mesh(new THREE.SphereGeometry(.11,18,12), new THREE.MeshBasicMaterial({color:COLORS.token})); world.add(shuttle);
+const appState={stage:0,progress:0,playing:false,word:WORDS[0],started:performance.now(),cameraGuide:true};
+const stageNameEl=document.getElementById('stageName'), progressEl=document.getElementById('progress'), playBtn=document.getElementById('playBtn'), wordSelect=document.getElementById('wordSelect'), cameraToggle=document.getElementById('cameraToggle'), readout=document.getElementById('readout');
+WORDS.forEach(w=>{ const o=document.createElement('option'); o.value=w; o.textContent=w; wordSelect.appendChild(o); });
+function refreshUi(sv=stateVectors(wordDir(appState.word))){ stageNameEl.textContent=STAGES[appState.stage]; progressEl.value=Math.round(appState.progress*100); playBtn.textContent=appState.playing?'Pause':'Play'; wordSelect.value=appState.word; cameraToggle.checked=appState.cameraGuide; readout.innerHTML=WORDS.map((w,i)=>`<div class="row"><span style="color:${wordColor(i)}">${w}</span><span>${sv.probs[i].toFixed(3)}${i===sv.top?' ← top':''}</span></div>`).join(''); }
+function go(d){ appState.stage=Math.max(0,Math.min(STAGES.length-1,appState.stage+d)); appState.progress=0; appState.playing=false; appState.started=performance.now(); refreshUi(); }
+document.getElementById('prevBtn').onclick=()=>go(-1); document.getElementById('nextBtn').onclick=()=>go(1); playBtn.onclick=()=>{ appState.playing=!appState.playing; appState.started=performance.now()-appState.progress*STAGE_SECONDS*1000; refreshUi(); }; document.getElementById('replayBtn').onclick=()=>{ appState.progress=0; appState.playing=true; appState.started=performance.now(); refreshUi(); };
+progressEl.oninput=e=>{ appState.progress=Number(e.target.value)/100; appState.playing=false; refreshUi(); }; wordSelect.onchange=e=>{ appState.word=e.target.value; appState.stage=0; appState.progress=0; refreshUi(); }; cameraToggle.onchange=e=>{ appState.cameraGuide=e.target.checked; refreshUi(); };
+window.addEventListener('keydown',e=>{ if(['j','ArrowRight'].includes(e.key)){go(1);e.preventDefault();} else if(['k','ArrowLeft'].includes(e.key)){go(-1);e.preventDefault();} else if(e.key===' '){playBtn.onclick();e.preventDefault();} else if(e.key==='r'){document.getElementById('replayBtn').onclick();e.preventDefault();} else if(e.key==='c'){appState.cameraGuide=!appState.cameraGuide;refreshUi();e.preventDefault();} });
 
-const state = { stage:0, progress:0, playing:false, word:words[0], started:performance.now(), spin:true };
-const stageNameEl=document.getElementById('stageName'); const progressEl=document.getElementById('progress'); const playBtn=document.getElementById('playBtn'); const spinToggle=document.getElementById('spinToggle');
-const wordSelect=document.getElementById('wordSelect'); words.forEach(w=>{ const o=document.createElement('option'); o.value=w; o.textContent=w; wordSelect.appendChild(o); });
-const pathRows=document.getElementById('pathRows'); pathRows.innerHTML=path.map((p,i)=>`<div class="row"><span>${i+1}. ${p.key}</span><span style="color:${colorFor(p.kind)}">${p.label}</span></div>`).join('');
-function refreshUi(){ stageNameEl.textContent=stages[state.stage]; progressEl.value=Math.round(state.progress*100); playBtn.textContent=state.playing?'Pause':'Play'; wordSelect.value=state.word; spinToggle.checked=state.spin; }
-function go(delta){ state.stage=Math.max(0,Math.min(path.length-1,state.stage+delta)); state.progress=0; state.playing=false; state.started=performance.now(); refreshUi(); }
-document.getElementById('prevBtn').onclick=()=>go(-1); document.getElementById('nextBtn').onclick=()=>go(1);
-playBtn.onclick=()=>{ state.playing=!state.playing; state.started=performance.now()-state.progress*STAGE_SECONDS*1000; refreshUi(); };
-document.getElementById('replayBtn').onclick=()=>{ state.progress=0; state.playing=true; state.started=performance.now(); refreshUi(); };
-progressEl.oninput=e=>{ state.progress=Number(e.target.value)/100; state.playing=false; refreshUi(); };
-wordSelect.onchange=e=>{ state.word=e.target.value; state.progress=0; state.stage=0; refreshUi(); };
-spinToggle.onchange=e=>{ state.spin=e.target.checked; refreshUi(); };
-window.addEventListener('keydown', e=>{ if(['ArrowRight','j'].includes(e.key)){go(1);e.preventDefault();} else if(['ArrowLeft','k'].includes(e.key)){go(-1);e.preventDefault();} else if(e.key===' '){playBtn.onclick();e.preventDefault();} else if(e.key==='r'){document.getElementById('replayBtn').onclick();e.preventDefault();} else if(e.key==='s'){state.spin=!state.spin; refreshUi(); e.preventDefault();} });
-
-function render() {
-  const base=wordVector(state.word);
-  for (let i=0;i<path.length-1;i++) {
-    const a=v3(path[i].p), b=v3(path[i+1].p);
-    const active = i === state.stage-1 || i === state.stage;
-    setLine(pathLines[i], a, b, active ? .42 : .16, COLORS.res);
-  }
-  branchPairs.forEach((pair,i)=>{ const a=v3(path.find(p=>p.key===pair[0]).p), b=v3(path.find(p=>p.key===pair[1]).p); setLine(branchLines[i], a,b,.22, COLORS.white); });
-  arrows.forEach(a=>a.group.visible=false);
-  for (let i=0;i<=state.stage;i++) {
-    const node=path[i]; const center=v3(node.p); const vec=stateVectorAt(i, base); const end=center.clone().add(vec.multiplyScalar(R));
-    arrows[i].set(center,end,colorFor(node.kind), i===state.stage ? 1 : .30);
-  }
-  const current=v3(path[state.stage].p); const prev=state.stage>0 ? v3(path[state.stage-1].p) : current;
-  shuttle.position.copy(lerpVec(prev,current,state.progress));
-  stationMeshes.forEach((mesh,key)=>{ const i=path.findIndex(p=>p.key===key); const node=path[i]; const active=i===state.stage; if (node.kind === 'attn' || node.kind === 'mlp') { mesh.material.opacity = active ? .48 : .28; mesh.scale.setScalar(active ? 1.12 : 1.0); } else { mesh.material.opacity = active ? .22 : .08; } });
-  if (state.spin) moduleMeshes.forEach((m,i)=>{ m.rotation.y += 0.012 + i * 0.001; m.rotation.x = Math.sin(performance.now()*0.001 + i) * 0.10; });
-}
+function drawStaticTracks(){ const pairs=[[P.start,P.attnIn],[P.attnIn,P.mlpIn],[P.mlpIn,P.outNorm],[P.outNorm,P.lmHead],[P.lmHead,P.softmax],[P.attnIn,P.attnNorm],[P.attnNorm,P.attnBlock],[P.attnBlock,P.attnOut],[P.attnOut,P.attnIn],[P.mlpIn,P.mlpNorm],[P.mlpNorm,P.mlpBlock],[P.mlpBlock,P.mlpOut],[P.mlpOut,P.mlpIn]]; pairs.forEach((p,i)=>setLine(trackLines[i],p[0],p[1],.20,i<5?COLORS.res:COLORS.white)); }
+function clearDyn(){ dynLines.forEach(l=>l.visible=false); arrows.forEach(a=>a.hide()); beamLine.visible=false; }
+function renderNormCopy(sourceCenter,normCenter,sourceVec,normVec,t,lineIndex,arrowIndex){ const copyT=smoothstep01(t/.45); const projectT=smoothstep01((t-.35)/.65); const ghost=lerpVec(sourceCenter,normCenter,copyT); setLine(dynLines[lineIndex],sourceCenter,ghost,.35*copyT,COLORS.norm); arrows[arrowIndex].set(normCenter,lerpVec(normCenter,endpoint(normCenter,normVec),projectT),COLORS.norm,.35+.65*projectT); }
+function renderBlockFlow(normCenter,blockCenter,outCenter,inVec,outVec,t,lineIndex,arrowIndex,color){ const inT=smoothstep01(t/.50); const outT=smoothstep01((t-.35)/.65); setLine(dynLines[lineIndex],endpoint(normCenter,inVec),blockCenter,.42*inT,color); setLine(dynLines[lineIndex+1],blockCenter,endpoint(outCenter,outVec),.42*outT,color); arrows[arrowIndex].set(outCenter,endpoint(outCenter,outVec),COLORS.out,outT); }
+function renderAdd(resCenter,resVec,outCenter,outVec,newVec,t,lineIndex,arrowBase){ arrows[arrowBase].set(resCenter,endpoint(resCenter,resVec),COLORS.token,1); arrows[arrowBase+1].set(outCenter,endpoint(outCenter,outVec),COLORS.out,1); const chainStart=endpoint(resCenter,resVec); const chainEnd=chainStart.clone().add(outVec.clone().multiplyScalar(R*.55)); setLine(dynLines[lineIndex],chainStart,lerpVec(chainStart,chainEnd,smoothstep01(t)),.55,COLORS.plus); arrows[arrowBase+2].set(resCenter,endpoint(resCenter,newVec),COLORS.plus,smoothstep01(t)); }
+function renderLmHead(hidden,t,sv){ arrows[0].set(P.outNorm,endpoint(P.outNorm,hidden),COLORS.norm,1); WORDS.forEach((w,i)=>{ const tip=endpoint(P.lmHead,wordDir(w)); setLine(dynLines[i],endpoint(P.outNorm,hidden),tip,.16+.40*smoothstep01(t*WORDS.length-i),wordColor(i)); }); }
+function renderSoftmax(sv,t){ WORDS.forEach((w,i)=>{ const dir=wordDir(w); const p=sv.probs[i]; const end=P.softmax.clone().add(dir.multiplyScalar(R*(.18+p*1.8)*smoothstep01(t))); arrows[i].set(P.softmax,end,wordColor(i),.25+.75*smoothstep01(t)); if(i===sv.top){ readMarkers[i].scale.setScalar(1.7+.25*Math.sin(performance.now()*.01)); } else readMarkers[i].scale.setScalar(1); }); }
+function cameraFocus(){ const s=appState.stage; if(s<=1) return P.start.clone().lerp(P.attnIn,.55); if(s<=4) return new THREE.Vector3(-.85,1.15,0); if(s<=8) return new THREE.Vector3(2.1,-1.1,0); if(s<=10) return P.outNorm; if(s<=12) return new THREE.Vector3(6.9,.15,0); return new THREE.Vector3(1.4,.3,0); }
+function render(){ drawStaticTracks(); clearDyn(); const sv=stateVectors(wordDir(appState.word)); const t=appState.progress; const resC=residualCenter(appState.stage,t); const resV=residualVecFor(appState.stage,sv); residualBall.position.copy(endpoint(resC,resV,.08)); arrows[19].set(resC,endpoint(resC,resV),COLORS.token,1);
+  wordMarkers.forEach((m,i)=>{m.position.copy(P.start.clone().add(wordDir(WORDS[i]).multiplyScalar(R))); m.material.opacity=WORDS[i]===appState.word?1:.35; m.scale.setScalar(WORDS[i]===appState.word?1.7:1);}); readMarkers.forEach((m,i)=>{m.position.copy(P.lmHead.clone().add(wordDir(WORDS[i]).multiplyScalar(R))); m.material.opacity=.85;});
+  if(appState.stage===2) renderNormCopy(P.attnIn,P.attnNorm,sv.base,sv.attnNorm,t,0,0); if(appState.stage>=3) arrows[0].set(P.attnNorm,endpoint(P.attnNorm,sv.attnNorm),COLORS.norm,.75);
+  if(appState.stage===3) renderBlockFlow(P.attnNorm,P.attnBlock,P.attnOut,sv.attnNorm,sv.attnOut,t,1,1,COLORS.attn); if(appState.stage>=4) arrows[1].set(P.attnOut,endpoint(P.attnOut,sv.attnOut),COLORS.out,.85);
+  if(appState.stage===4) renderAdd(P.attnIn,sv.base,P.attnOut,sv.attnOut,sv.afterAttn,t,3,2);
+  if(appState.stage===6) renderNormCopy(P.mlpIn,P.mlpNorm,sv.afterAttn,sv.mlpNorm,t,5,5); if(appState.stage>=7) arrows[5].set(P.mlpNorm,endpoint(P.mlpNorm,sv.mlpNorm),COLORS.norm,.75);
+  if(appState.stage===7) renderBlockFlow(P.mlpNorm,P.mlpBlock,P.mlpOut,sv.mlpNorm,sv.mlpOut,t,6,6,COLORS.mlp); if(appState.stage>=8) arrows[6].set(P.mlpOut,endpoint(P.mlpOut,sv.mlpOut),COLORS.out,.85);
+  if(appState.stage===8) renderAdd(P.mlpIn,sv.afterAttn,P.mlpOut,sv.mlpOut,sv.afterMlp,t,8,7);
+  if(appState.stage===10) renderNormCopy(P.outNorm,P.outNorm,sv.afterMlp,sv.hidden,t,11,10); if(appState.stage>=11) arrows[10].set(P.outNorm,endpoint(P.outNorm,sv.hidden),COLORS.norm,1);
+  if(appState.stage===11) renderLmHead(sv.hidden,t,sv); if(appState.stage>=12) renderSoftmax(sv,t);
+  if(appState.stage===13){ const topWord=WORDS[sv.top]; setLine(beamLine,endpoint(P.softmax,wordDir(topWord)),endpoint(P.start,wordDir(topWord)),.72,COLORS.token); if(t>.96 && appState.word!==topWord){ appState.word=topWord; wordSelect.value=topWord; } }
+  blockMeshes.forEach((b,i)=>{ b.rotation.y += .01+i*.003; b.rotation.x = .08*Math.sin(performance.now()*.001+i); }); refreshUi(sv); }
 function resize(){ const w=canvas.clientWidth,h=canvas.clientHeight; renderer.setSize(w,h,false); camera.aspect=w/h; camera.updateProjectionMatrix(); }
-window.addEventListener('resize', resize); resize(); refreshUi();
-let last=performance.now(); function animate(ts){ if(state.playing){ state.progress=clamp01((ts-state.started)/(STAGE_SECONDS*1000)); if(state.progress>=1){ state.playing=false; if(state.stage<path.length-1){ state.stage++; state.progress=0; state.playing=true; state.started=ts; } } refreshUi(); } render(); if(state.spin){ const center=controls.target.clone(); camera.position.sub(center).applyAxisAngle(new THREE.Vector3(0,1,0),0.0018).add(center); } controls.update(); renderer.render(scene,camera); requestAnimationFrame(animate); last=ts; } requestAnimationFrame(animate);
+window.addEventListener('resize',resize); resize(); refreshUi();
+function animate(ts){ if(appState.playing){ appState.progress=clamp01((ts-appState.started)/(STAGE_SECONDS*1000)); if(appState.progress>=1){ appState.playing=false; if(appState.stage<STAGES.length-1){ appState.stage++; appState.progress=0; appState.playing=true; appState.started=ts; } } } render(); if(appState.cameraGuide){ const focus=cameraFocus(); controls.target.lerp(focus,.065); const off=camera.position.clone().sub(controls.target); if(off.length()>0.01){ const desired=controls.target.clone().add(off.normalize().multiplyScalar(appState.stage>=11?7.6:6.4)); camera.position.lerp(desired,.035); } } controls.update(); renderer.render(scene,camera); requestAnimationFrame(animate); }
+requestAnimationFrame(animate);
 </script>
 </body>
 </html>

--- a/report/threejs/end-to-end-transformer-hotkeys.html
+++ b/report/threejs/end-to-end-transformer-hotkeys.html
@@ -90,17 +90,19 @@ const STAGES = [
 ];
 const P = {
   start: new THREE.Vector3(-6.0, 0, 0),
-  attnIn: new THREE.Vector3(-2.8, 0, 0),
-  mlpIn: new THREE.Vector3(0.6, 0, 0),
-  outNorm: new THREE.Vector3(3.8, 0, 0),
-  lmHead: new THREE.Vector3(6.8, 0, 0),
-  softmax: new THREE.Vector3(9.5, 0, 0),
-  attnNorm: new THREE.Vector3(-2.8, 2.15, 0),
-  attnBlock: new THREE.Vector3(-.75, 2.15, 0),
-  attnOut: new THREE.Vector3(1.15, 2.15, 0),
-  mlpNorm: new THREE.Vector3(.6, -2.15, 0),
-  mlpBlock: new THREE.Vector3(2.65, -2.15, 0),
-  mlpOut: new THREE.Vector3(4.55, -2.15, 0),
+  attnIn: new THREE.Vector3(-3.2, 0, 0),
+  attnPickup: new THREE.Vector3(-0.35, 0, 0),
+  mlpIn: new THREE.Vector3(1.65, 0, 0),
+  mlpPickup: new THREE.Vector3(4.55, 0, 0),
+  outNorm: new THREE.Vector3(6.6, 0, 0),
+  lmHead: new THREE.Vector3(9.0, 0, 0),
+  softmax: new THREE.Vector3(11.4, 0, 0),
+  attnNorm: new THREE.Vector3(-3.2, 2.18, 0),
+  attnBlock: new THREE.Vector3(-1.72, 2.18, 0),
+  attnOut: new THREE.Vector3(-0.35, 2.18, 0),
+  mlpNorm: new THREE.Vector3(1.65, 2.18, 0),
+  mlpBlock: new THREE.Vector3(3.15, 2.18, 0),
+  mlpOut: new THREE.Vector3(4.55, 2.18, 0),
 };
 
 const canvas = document.getElementById('scene');
@@ -128,10 +130,12 @@ function addVec(a,b,scale=.45){ return unit(a.clone().add(b.clone().multiplyScal
 function wordColor(i){ return ['#ff7b72','#f4a261','#ffd166','#52b788','#7dd3fc'][i % 5]; }
 function softmax(vals){ const m=Math.max(...vals); const ex=vals.map(v=>Math.exp(4*(v-m))); const s=ex.reduce((a,b)=>a+b,0); return ex.map(v=>v/s); }
 function stateVectors(base){ const attnNorm=unit(base); const attnOut=rotateVec(attnNorm,'attention',.72); const afterAttn=addVec(base, attnOut, .50); const mlpNorm=unit(afterAttn); const mlpOut=rotateVec(mlpNorm,'mlp',-.58); const afterMlp=addVec(afterAttn, mlpOut, .44); const hidden=unit(afterMlp); const logits=WORDS.map(w=>hidden.dot(wordDir(w))); const probs=softmax(logits); const top=probs.reduce((best,p,i)=>p>probs[best]?i:best,0); return {base, attnNorm, attnOut, afterAttn, mlpNorm, mlpOut, afterMlp, hidden, logits, probs, top}; }
-function residualCenter(stage,t){ if(stage<=0) return P.start; if(stage===1) return lerpVec(P.start,P.attnIn,smoothstep01(t)); if(stage<5) return P.attnIn; if(stage===5) return lerpVec(P.attnIn,P.mlpIn,smoothstep01(t)); if(stage<9) return P.mlpIn; if(stage===9) return lerpVec(P.mlpIn,P.outNorm,smoothstep01(t)); return P.outNorm; }
+function residualCenter(stage,t){ if(stage<=0) return P.start; if(stage===1) return lerpVec(P.start,P.attnIn,smoothstep01(t)); if(stage===2) return P.attnIn; if(stage===3) return lerpVec(P.attnIn,P.attnPickup,smoothstep01(t)); if(stage===4) return P.attnPickup; if(stage===5) return lerpVec(P.attnPickup,P.mlpIn,smoothstep01(t)); if(stage===6) return P.mlpIn; if(stage===7) return lerpVec(P.mlpIn,P.mlpPickup,smoothstep01(t)); if(stage===8) return P.mlpPickup; if(stage===9) return lerpVec(P.mlpPickup,P.outNorm,smoothstep01(t)); return P.outNorm; }
 function residualVecFor(stage, sv){ if(stage<4) return sv.base; if(stage<8) return stage===4 ? unit(sv.base.clone().lerp(sv.afterAttn, smoothstep01(appState.progress))) : sv.afterAttn; if(stage===8) return unit(sv.afterAttn.clone().lerp(sv.afterMlp, smoothstep01(appState.progress))); return sv.afterMlp; }
 
 function makeText(text, color=COLORS.white, w=220, h=64, font=25){ const c=document.createElement('canvas'); c.width=w; c.height=h; const ctx=c.getContext('2d'); ctx.font=`700 ${font}px Inter, sans-serif`; ctx.textAlign='center'; ctx.textBaseline='middle'; ctx.fillStyle=color; ctx.fillText(text,w/2,h/2); const tex=new THREE.CanvasTexture(c); tex.colorSpace=THREE.SRGBColorSpace; const mat=new THREE.SpriteMaterial({map:tex,transparent:true,depthWrite:false}); const sp=new THREE.Sprite(mat); sp.scale.set(w/120,h/120,1); return sp; }
+function makeValueLabel(color=COLORS.white){ const c=document.createElement('canvas'); c.width=150; c.height=56; const ctx=c.getContext('2d'); const tex=new THREE.CanvasTexture(c); tex.colorSpace=THREE.SRGBColorSpace; const mat=new THREE.SpriteMaterial({map:tex,transparent:true,depthWrite:false}); const sp=new THREE.Sprite(mat); sp.scale.set(1.25,.47,1); sp.userData={canvas:c,ctx,tex,color}; sp.visible=false; world.add(sp); return sp; }
+function updateValueLabel(sp,text,pos,color=sp.userData.color,opacity=1){ const {canvas,ctx,tex}=sp.userData; ctx.clearRect(0,0,canvas.width,canvas.height); ctx.font='700 24px Inter, sans-serif'; ctx.textAlign='center'; ctx.textBaseline='middle'; ctx.fillStyle=color; ctx.fillText(text,canvas.width/2,canvas.height/2); tex.needsUpdate=true; sp.position.copy(pos); sp.material.opacity=opacity; sp.visible=opacity>.01; }
 function makeLine(color=COLORS.white,dashed=true){ const g=new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(),new THREE.Vector3()]); const m=dashed ? new THREE.LineDashedMaterial({color,transparent:true,opacity:.45,dashSize:.08,gapSize:.06,depthWrite:false}) : new THREE.LineBasicMaterial({color,transparent:true,opacity:.55,depthWrite:false}); const l=new THREE.Line(g,m); l.visible=false; world.add(l); return l; }
 function setLine(l,a,b,op=.45,color){ l.geometry.setFromPoints([a,b]); l.material.opacity=op; if(color) l.material.color.set(color); l.computeLineDistances?.(); l.visible=op>.004; }
 class Arrow{ constructor(color){ this.group=new THREE.Group(); this.line=makeLine(color,false); world.remove(this.line); this.group.add(this.line); this.cone=new THREE.Mesh(new THREE.ConeGeometry(.075,.20,18),new THREE.MeshBasicMaterial({color,transparent:true,opacity:1})); this.group.add(this.cone); world.add(this.group); } set(a,b,color,op=1){ const d=b.clone().sub(a); this.group.visible=op>.005&&d.length()>.001; setLine(this.line,a,b,op,color); this.cone.position.copy(b); this.cone.material.opacity=op; this.cone.material.color.set(color); this.cone.quaternion.setFromUnitVectors(new THREE.Vector3(0,1,0),unit(d)); } hide(){ this.group.visible=false; } }
@@ -139,8 +143,8 @@ class Arrow{ constructor(color){ this.group=new THREE.Group(); this.line=makeLin
 const labels=[]; function label(text,pos,color=COLORS.white,w=180){ const s=makeText(text,color,w,56,24); s.position.copy(pos); world.add(s); labels.push(s); return s; }
 function sphere(name,pos,color=COLORS.white){ const mesh=new THREE.Mesh(new THREE.SphereGeometry(R,32,18),new THREE.MeshBasicMaterial({color:COLORS.white,wireframe:true,transparent:true,opacity:.11,depthWrite:false})); mesh.position.copy(pos); world.add(mesh); label(name,pos.clone().add(new THREE.Vector3(0,R+.32,0)),color); return mesh; }
 function block(name,pos,color){ const geom=new THREE.BoxGeometry(1.35,.82,.58); const mesh=new THREE.Mesh(geom,new THREE.MeshBasicMaterial({color,transparent:true,opacity:.38,depthWrite:false})); mesh.position.copy(pos); const edges=new THREE.LineSegments(new THREE.EdgesGeometry(geom),new THREE.LineBasicMaterial({color,transparent:true,opacity:.95})); mesh.add(edges); world.add(mesh); label(name,pos.clone().add(new THREE.Vector3(0,R+.26,0)),color,190); return mesh; }
-const stationMeshes=[sphere('word input',P.start,COLORS.token),sphere('attn in',P.attnIn,COLORS.res),sphere('mlp in',P.mlpIn,COLORS.res),sphere('out norm',P.outNorm,COLORS.norm),sphere('LM Head',P.lmHead,COLORS.soft),sphere('softmax',P.softmax,COLORS.out),sphere('attn norm',P.attnNorm,COLORS.norm),block('attention',P.attnBlock,COLORS.attn),sphere('attn output',P.attnOut,COLORS.out),sphere('mlp norm',P.mlpNorm,COLORS.norm),block('mlp',P.mlpBlock,COLORS.mlp),sphere('mlp output',P.mlpOut,COLORS.out)];
-const blockMeshes=[stationMeshes[7],stationMeshes[10]];
+const stationMeshes=[sphere('word input',P.start,COLORS.token),sphere('attn unload',P.attnIn,COLORS.res),sphere('attn pickup',P.attnPickup,COLORS.plus),sphere('mlp unload',P.mlpIn,COLORS.res),sphere('mlp pickup',P.mlpPickup,COLORS.plus),sphere('out norm',P.outNorm,COLORS.norm),sphere('LM Head',P.lmHead,COLORS.soft),sphere('softmax',P.softmax,COLORS.out),sphere('attn norm',P.attnNorm,COLORS.norm),block('attention',P.attnBlock,COLORS.attn),sphere('attn output',P.attnOut,COLORS.out),sphere('mlp norm',P.mlpNorm,COLORS.norm),block('mlp',P.mlpBlock,COLORS.mlp),sphere('mlp output',P.mlpOut,COLORS.out)];
+const blockMeshes=[stationMeshes[9],stationMeshes[12]];
 const trackLines=[]; for(let i=0;i<18;i++) trackLines.push(makeLine(COLORS.res,true));
 const dynLines=[]; for(let i=0;i<30;i++) dynLines.push(makeLine(COLORS.white,true));
 const arrows=[]; for(let i=0;i<20;i++) arrows.push(new Arrow(COLORS.token));
@@ -148,6 +152,8 @@ const residualBall=new THREE.Mesh(new THREE.SphereGeometry(.16,24,14),new THREE.
 const beamLine=makeLine(COLORS.token,false);
 const wordMarkers=WORDS.map((w,i)=>{ const m=new THREE.Mesh(new THREE.SphereGeometry(.055,12,8),new THREE.MeshBasicMaterial({color:wordColor(i),transparent:true,opacity:.9})); world.add(m); label(w,P.start.clone().add(wordDir(w).multiplyScalar(R+.25)),wordColor(i),120); return m; });
 const readMarkers=WORDS.map((w,i)=>{ const m=new THREE.Mesh(new THREE.SphereGeometry(.06,12,8),new THREE.MeshBasicMaterial({color:wordColor(i),transparent:true,opacity:.9})); world.add(m); label(w,P.lmHead.clone().add(wordDir(w).multiplyScalar(R+.25)),wordColor(i),120); return m; });
+const dotValueLabels=WORDS.map((_,i)=>makeValueLabel(wordColor(i)));
+const softmaxLabels=WORDS.map((_,i)=>makeValueLabel(wordColor(i)));
 
 const appState={stage:0,progress:0,playing:false,word:WORDS[0],started:performance.now(),cameraGuide:true};
 const stageNameEl=document.getElementById('stageName'), progressEl=document.getElementById('progress'), playBtn=document.getElementById('playBtn'), wordSelect=document.getElementById('wordSelect'), cameraToggle=document.getElementById('cameraToggle'), readout=document.getElementById('readout');
@@ -158,22 +164,22 @@ document.getElementById('prevBtn').onclick=()=>go(-1); document.getElementById('
 progressEl.oninput=e=>{ appState.progress=Number(e.target.value)/100; appState.playing=false; refreshUi(); }; wordSelect.onchange=e=>{ appState.word=e.target.value; appState.stage=0; appState.progress=0; refreshUi(); }; cameraToggle.onchange=e=>{ appState.cameraGuide=e.target.checked; refreshUi(); };
 window.addEventListener('keydown',e=>{ if(['j','ArrowRight'].includes(e.key)){go(1);e.preventDefault();} else if(['k','ArrowLeft'].includes(e.key)){go(-1);e.preventDefault();} else if(e.key===' '){playBtn.onclick();e.preventDefault();} else if(e.key==='r'){document.getElementById('replayBtn').onclick();e.preventDefault();} else if(e.key==='c'){appState.cameraGuide=!appState.cameraGuide;refreshUi();e.preventDefault();} });
 
-function drawStaticTracks(){ const pairs=[[P.start,P.attnIn],[P.attnIn,P.mlpIn],[P.mlpIn,P.outNorm],[P.outNorm,P.lmHead],[P.lmHead,P.softmax],[P.attnIn,P.attnNorm],[P.attnNorm,P.attnBlock],[P.attnBlock,P.attnOut],[P.attnOut,P.attnIn],[P.mlpIn,P.mlpNorm],[P.mlpNorm,P.mlpBlock],[P.mlpBlock,P.mlpOut],[P.mlpOut,P.mlpIn]]; pairs.forEach((p,i)=>setLine(trackLines[i],p[0],p[1],.20,i<5?COLORS.res:COLORS.white)); }
-function clearDyn(){ dynLines.forEach(l=>l.visible=false); arrows.forEach(a=>a.hide()); beamLine.visible=false; }
+function drawStaticTracks(){ const pairs=[[P.start,P.attnIn],[P.attnIn,P.attnPickup],[P.attnPickup,P.mlpIn],[P.mlpIn,P.mlpPickup],[P.mlpPickup,P.outNorm],[P.outNorm,P.lmHead],[P.lmHead,P.softmax],[P.attnIn,P.attnNorm],[P.attnNorm,P.attnBlock],[P.attnBlock,P.attnOut],[P.attnOut,P.attnPickup],[P.mlpIn,P.mlpNorm],[P.mlpNorm,P.mlpBlock],[P.mlpBlock,P.mlpOut],[P.mlpOut,P.mlpPickup]]; pairs.forEach((p,i)=>setLine(trackLines[i],p[0],p[1],.20,i<7?COLORS.res:COLORS.white)); }
+function clearDyn(){ dynLines.forEach(l=>l.visible=false); arrows.forEach(a=>a.hide()); beamLine.visible=false; dotValueLabels.forEach(l=>l.visible=false); softmaxLabels.forEach(l=>l.visible=false); }
 function renderNormCopy(sourceCenter,normCenter,sourceVec,normVec,t,lineIndex,arrowIndex){ const copyT=smoothstep01(t/.45); const projectT=smoothstep01((t-.35)/.65); const ghost=lerpVec(sourceCenter,normCenter,copyT); setLine(dynLines[lineIndex],sourceCenter,ghost,.35*copyT,COLORS.norm); arrows[arrowIndex].set(normCenter,lerpVec(normCenter,endpoint(normCenter,normVec),projectT),COLORS.norm,.35+.65*projectT); }
 function renderBlockFlow(normCenter,blockCenter,outCenter,inVec,outVec,t,lineIndex,arrowIndex,color){ const inT=smoothstep01(t/.50); const outT=smoothstep01((t-.35)/.65); setLine(dynLines[lineIndex],endpoint(normCenter,inVec),blockCenter,.42*inT,color); setLine(dynLines[lineIndex+1],blockCenter,endpoint(outCenter,outVec),.42*outT,color); arrows[arrowIndex].set(outCenter,endpoint(outCenter,outVec),COLORS.out,outT); }
 function renderAdd(resCenter,resVec,outCenter,outVec,newVec,t,lineIndex,arrowBase){ arrows[arrowBase].set(resCenter,endpoint(resCenter,resVec),COLORS.token,1); arrows[arrowBase+1].set(outCenter,endpoint(outCenter,outVec),COLORS.out,1); const chainStart=endpoint(resCenter,resVec); const chainEnd=chainStart.clone().add(outVec.clone().multiplyScalar(R*.55)); setLine(dynLines[lineIndex],chainStart,lerpVec(chainStart,chainEnd,smoothstep01(t)),.55,COLORS.plus); arrows[arrowBase+2].set(resCenter,endpoint(resCenter,newVec),COLORS.plus,smoothstep01(t)); }
-function renderLmHead(hidden,t,sv){ arrows[0].set(P.outNorm,endpoint(P.outNorm,hidden),COLORS.norm,1); WORDS.forEach((w,i)=>{ const tip=endpoint(P.lmHead,wordDir(w)); setLine(dynLines[i],endpoint(P.outNorm,hidden),tip,.16+.40*smoothstep01(t*WORDS.length-i),wordColor(i)); }); }
-function renderSoftmax(sv,t){ WORDS.forEach((w,i)=>{ const dir=wordDir(w); const p=sv.probs[i]; const end=P.softmax.clone().add(dir.multiplyScalar(R*(.18+p*1.8)*smoothstep01(t))); arrows[i].set(P.softmax,end,wordColor(i),.25+.75*smoothstep01(t)); if(i===sv.top){ readMarkers[i].scale.setScalar(1.7+.25*Math.sin(performance.now()*.01)); } else readMarkers[i].scale.setScalar(1); }); }
-function cameraFocus(){ const s=appState.stage; if(s<=1) return P.start.clone().lerp(P.attnIn,.55); if(s<=4) return new THREE.Vector3(-.85,1.15,0); if(s<=8) return new THREE.Vector3(2.1,-1.1,0); if(s<=10) return P.outNorm; if(s<=12) return new THREE.Vector3(6.9,.15,0); return new THREE.Vector3(1.4,.3,0); }
+function renderLmHead(hidden,t,sv){ arrows[0].set(P.outNorm,endpoint(P.outNorm,hidden),COLORS.norm,1); WORDS.forEach((w,i)=>{ const dir=wordDir(w); const tip=endpoint(P.lmHead,dir); const local=smoothstep01(t*WORDS.length-i); setLine(dynLines[i],endpoint(P.outNorm,hidden),tip,.16+.40*local,wordColor(i)); updateValueLabel(dotValueLabels[i],sv.logits[i].toFixed(2),tip.clone().add(new THREE.Vector3(.16,.10-.05*i,.12)),wordColor(i),local); const scaledEnd=P.lmHead.clone().add(dir.multiplyScalar(R*Math.max(.08,Math.abs(sv.logits[i])))); arrows[11+i].set(P.lmHead,scaledEnd,wordColor(i),.20+.55*local); }); }
+function renderSoftmax(sv,t){ WORDS.forEach((w,i)=>{ const dir=wordDir(w); const p=sv.probs[i]; const local=smoothstep01(t); const end=P.softmax.clone().add(dir.multiplyScalar(R*(.18+p*1.8)*local)); arrows[i].set(P.softmax,end,wordColor(i),.25+.75*local); updateValueLabel(softmaxLabels[i],p.toFixed(2),end.clone().add(new THREE.Vector3(.15,.08-.04*i,.1)),wordColor(i),local); if(i===sv.top){ readMarkers[i].scale.setScalar(1.7+.25*Math.sin(performance.now()*.01)); wordMarkers[i].scale.setScalar(1.8); } else { readMarkers[i].scale.setScalar(1); if(WORDS[i]!==appState.word) wordMarkers[i].scale.setScalar(1); } }); }
+function cameraFocus(){ const s=appState.stage; if(s<=1) return P.start.clone().lerp(P.attnIn,.55); if(s<=4) return new THREE.Vector3(-1.7,1.0,0); if(s<=8) return new THREE.Vector3(3.0,1.0,0); if(s<=10) return P.outNorm; if(s<=12) return new THREE.Vector3(9.2,.15,0); return new THREE.Vector3(2.7,.3,0); }
 function render(){ drawStaticTracks(); clearDyn(); const sv=stateVectors(wordDir(appState.word)); const t=appState.progress; const resC=residualCenter(appState.stage,t); const resV=residualVecFor(appState.stage,sv); residualBall.position.copy(endpoint(resC,resV,.08)); arrows[19].set(resC,endpoint(resC,resV),COLORS.token,1);
   wordMarkers.forEach((m,i)=>{m.position.copy(P.start.clone().add(wordDir(WORDS[i]).multiplyScalar(R))); m.material.opacity=WORDS[i]===appState.word?1:.35; m.scale.setScalar(WORDS[i]===appState.word?1.7:1);}); readMarkers.forEach((m,i)=>{m.position.copy(P.lmHead.clone().add(wordDir(WORDS[i]).multiplyScalar(R))); m.material.opacity=.85;});
   if(appState.stage===2) renderNormCopy(P.attnIn,P.attnNorm,sv.base,sv.attnNorm,t,0,0); if(appState.stage>=3) arrows[0].set(P.attnNorm,endpoint(P.attnNorm,sv.attnNorm),COLORS.norm,.75);
   if(appState.stage===3) renderBlockFlow(P.attnNorm,P.attnBlock,P.attnOut,sv.attnNorm,sv.attnOut,t,1,1,COLORS.attn); if(appState.stage>=4) arrows[1].set(P.attnOut,endpoint(P.attnOut,sv.attnOut),COLORS.out,.85);
-  if(appState.stage===4) renderAdd(P.attnIn,sv.base,P.attnOut,sv.attnOut,sv.afterAttn,t,3,2);
+  if(appState.stage===4) renderAdd(P.attnPickup,sv.base,P.attnOut,sv.attnOut,sv.afterAttn,t,3,2);
   if(appState.stage===6) renderNormCopy(P.mlpIn,P.mlpNorm,sv.afterAttn,sv.mlpNorm,t,5,5); if(appState.stage>=7) arrows[5].set(P.mlpNorm,endpoint(P.mlpNorm,sv.mlpNorm),COLORS.norm,.75);
   if(appState.stage===7) renderBlockFlow(P.mlpNorm,P.mlpBlock,P.mlpOut,sv.mlpNorm,sv.mlpOut,t,6,6,COLORS.mlp); if(appState.stage>=8) arrows[6].set(P.mlpOut,endpoint(P.mlpOut,sv.mlpOut),COLORS.out,.85);
-  if(appState.stage===8) renderAdd(P.mlpIn,sv.afterAttn,P.mlpOut,sv.mlpOut,sv.afterMlp,t,8,7);
+  if(appState.stage===8) renderAdd(P.mlpPickup,sv.afterAttn,P.mlpOut,sv.mlpOut,sv.afterMlp,t,8,7);
   if(appState.stage===10) renderNormCopy(P.outNorm,P.outNorm,sv.afterMlp,sv.hidden,t,11,10); if(appState.stage>=11) arrows[10].set(P.outNorm,endpoint(P.outNorm,sv.hidden),COLORS.norm,1);
   if(appState.stage===11) renderLmHead(sv.hidden,t,sv); if(appState.stage>=12) renderSoftmax(sv,t);
   if(appState.stage===13){ const topWord=WORDS[sv.top]; setLine(beamLine,endpoint(P.softmax,wordDir(topWord)),endpoint(P.start,wordDir(topWord)),.72,COLORS.token); if(t>.96 && appState.word!==topWord){ appState.word=topWord; wordSelect.value=topWord; } }


### PR DESCRIPTION
### Motivation
- Make the final `Wo` matrix visually distinct from the output display so the flow is clearer: show the final context/v interacting with `Wo` and then show the output sphere performing the rotational projection to the final output direction. 

### Description
- Added a new `Output` center at `CENTERS.Output` and placed a dedicated `Output` sphere, and renamed the old `Wo` sphere to `Wo output matrix` to keep `Wo` and the output sphere separate in `report/threejs/attention-read-activate-write-quant-compare-v3-hotkeys.html`.
- Updated explanatory UI text and the stage label for the Wo/output stage to describe the two-step interaction (`v/context → Wo` then rotation onto `Output`).
- Reworked `renderContextAndOutput` to: carry the final context/v direction into the `Wo` location (`dyn.woContextGhost`), then render the `Output` sphere rotation from the initial context direction to the final output direction with additional transfer lines and labels for each step.
- Moved compare visuals and output arrows to reference `CENTERS.Output`, and updated stage emphasis and camera focus so stages 9/19 and the compare stage emphasize `v`, `Wo`, and `Output` (including camera focus changes).

### Testing
- Ran `git diff --check` to verify there are no whitespace/patch issues; the check succeeded.
- Ran `node --check /tmp/attention_check.js` (stripped imports JS syntax check) to validate the modified inline script parses; the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36faddcfbc83269f6dc357a8f54fc5)