### PR TITLE
Add min-angle token range highlighting

### DIFF
--- a/huggingface_model/gemma/270M/gemma_angle_webapp/app/static/app.js
+++ b/huggingface_model/gemma/270M/gemma_angle_webapp/app/static/app.js
@@ -1175,6 +1175,23 @@ function buildAngleTicks(maxAngle) {
   return { ticks, yMax };
 }
 
+function getMinDistanceHighlightRange() {
+  const startInput = byId('minDistanceHighlightStart');
+  const endInput = byId('minDistanceHighlightEnd');
+  if (!startInput || !endInput) return null;
+  const startText = startInput.value.trim();
+  const endText = endInput.value.trim();
+  if (startText === '' && endText === '') return null;
+
+  const startValue = startText === '' ? Number(endText) : Number(startText);
+  const endValue = endText === '' ? Number(startText) : Number(endText);
+  if (!Number.isFinite(startValue) || !Number.isFinite(endValue)) return null;
+
+  const low = Math.max(0, Math.floor(Math.min(startValue, endValue)));
+  const high = Math.max(0, Math.floor(Math.max(startValue, endValue)));
+  return { low, high };
+}
+
 function drawMinDistancePlot(rows) {
   const canvas = byId('minDistancePlot');
   const card = byId('minDistancePlotCard');
@@ -1184,6 +1201,7 @@ function drawMinDistancePlot(rows) {
   const mutedColor = style.getPropertyValue('--muted').trim() || '#9ca3af';
   const borderColor = style.getPropertyValue('--border').trim() || '#374151';
   const accentColor = style.getPropertyValue('--accent-strong').trim() || '#60a5fa';
+  const highlightColor = '#f97316';
 
   const sortedRows = [...(rows || [])].sort((a, b) => (
     Number(a.min_angle_deg) - Number(b.min_angle_deg)
@@ -1295,7 +1313,35 @@ function drawMinDistancePlot(rows) {
     }
   }
 
-  byId('minDistancePlotCaption').textContent = 'Y axis is the minimum non-self angle. X axis is rank after sorting tokens from lowest to highest minimum angle.';
+  const highlightRange = getMinDistanceHighlightRange();
+  let highlightCount = 0;
+  if (highlightRange) {
+    ctx.fillStyle = highlightColor;
+    const highlightRadius = rowCount > 20000 ? 2.5 : 4.5;
+    for (let index = 0; index < rowCount; index += 1) {
+      const row = sortedRows[index];
+      const tokenId = Number(row.token_id);
+      if (!Number.isFinite(tokenId) || tokenId < highlightRange.low || tokenId > highlightRange.high) continue;
+      highlightCount += 1;
+      const x = xForRank(index);
+      const y = yForAngle(Number(row.min_angle_deg || 0));
+      if (rowCount > 20000) {
+        ctx.fillRect(x - highlightRadius / 2, y - highlightRadius / 2, highlightRadius, highlightRadius);
+      } else {
+        ctx.beginPath();
+        ctx.arc(x, y, highlightRadius, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    }
+  }
+
+  let caption = 'Y axis is the minimum non-self angle. X axis is rank after sorting tokens from lowest to highest minimum angle.';
+  if (highlightRange) {
+    caption += ` Orange dots highlight ${highlightCount.toLocaleString()} token${highlightCount === 1 ? '' : 's'} with IDs ${highlightRange.low.toLocaleString()}–${highlightRange.high.toLocaleString()}.`;
+  } else {
+    caption += ' Enter a token ID range above to overlay matching tokens as orange dots.';
+  }
+  byId('minDistancePlotCaption').textContent = caption;
 }
 
 function sortedMinDistanceRowsForTable() {
@@ -1350,6 +1396,12 @@ function resetMinDistancesOutput() {
   table.classList.add('hidden');
   table.querySelector('tbody').innerHTML = '';
   setExportVisible('exportMinDistancesCsv', false);
+}
+
+function refreshMinDistanceHighlight() {
+  if (state.minDistanceRows.length > 0) {
+    drawMinDistancePlot(state.minDistanceRows);
+  }
 }
 
 async function computeMinAngularDistances() {
@@ -2657,6 +2709,20 @@ window.addEventListener('DOMContentLoaded', () => {
   byId('recursiveGroupHighlightMinEdges').addEventListener('change', refreshRecursiveGroupMinEdgeHighlight);
   byId('minDistanceSort').addEventListener('change', () => {
     if (state.minDistanceRows.length > 0) renderMinDistanceTable();
+  });
+  for (const controlId of ['minDistanceHighlightStart', 'minDistanceHighlightEnd']) {
+    byId(controlId).addEventListener('input', refreshMinDistanceHighlight);
+    byId(controlId).addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        refreshMinDistanceHighlight();
+      }
+    });
+  }
+  byId('clearMinDistanceHighlight').addEventListener('click', () => {
+    byId('minDistanceHighlightStart').value = '';
+    byId('minDistanceHighlightEnd').value = '';
+    refreshMinDistanceHighlight();
   });
 
   for (const controlId of ['recursiveGroupLimit', 'recursiveGroupMaxAngle', 'recursiveGroupBlockSize', 'recursiveGroupComputeDevice']) {

--- a/huggingface_model/gemma/270M/gemma_angle_webapp/app/static/app.js
+++ b/huggingface_model/gemma/270M/gemma_angle_webapp/app/static/app.js
@@ -10,6 +10,7 @@ const state = {
   pairwiseSelectedBinIndex: null,
   pairwiseBinTokens: [],
   minDistanceRows: [],
+  minDistanceHighlightedRows: [],
   recursiveGroup: null,
   recursiveGroupNetwork: null,
   recursiveGroupNetworkData: null,
@@ -138,6 +139,40 @@ function exportHtmlTableAsCsv(tableId, filename) {
 
   const csv = [headers, ...rows].map((row) => row.map(csvEscape).join(',')).join('\n') + '\n';
   downloadBlob(csv, filename, 'text/csv;charset=utf-8');
+}
+
+function minDistanceRowsToCsv(rows) {
+  const headers = [
+    'Min-angle rank',
+    'Token ID',
+    'Raw token',
+    'Display',
+    'Vector length',
+    'Min angle °',
+    'Other token ID',
+    'Other raw token',
+    'Other display',
+    'Other vector length',
+  ];
+  const body = rows.map((row) => [
+    row.min_angle_rank,
+    row.token_id,
+    row.token_raw,
+    row.token_display,
+    row.magnitude,
+    row.min_angle_deg,
+    row.other_token_id,
+    row.other_token_raw,
+    row.other_token_display,
+    row.other_magnitude,
+  ]);
+  return [headers, ...body].map((csvRow) => csvRow.map(csvEscape).join(',')).join('\n') + '\n';
+}
+
+function exportHighlightedMinDistanceRowsCsv() {
+  const rows = highlightedMinDistanceRows();
+  if (rows.length === 0) return;
+  downloadBlob(minDistanceRowsToCsv(rows), 'highlighted_minimum_angular_distances.csv', 'text/csv;charset=utf-8');
 }
 
 function exportCanvasAsPng(canvasId, filename) {
@@ -1175,21 +1210,66 @@ function buildAngleTicks(maxAngle) {
   return { ticks, yMax };
 }
 
-function getMinDistanceHighlightRange() {
+function getMinDistanceHighlightSpec() {
   const startInput = byId('minDistanceHighlightStart');
   const endInput = byId('minDistanceHighlightEnd');
-  if (!startInput || !endInput) return null;
+  const idsInput = byId('minDistanceHighlightIds');
+  if (!startInput || !endInput || !idsInput) return null;
   const startText = startInput.value.trim();
   const endText = endInput.value.trim();
-  if (startText === '' && endText === '') return null;
+  const idsText = idsInput.value.trim();
+  if (startText === '' && endText === '' && idsText === '') return null;
 
+  let range = null;
   const startValue = startText === '' ? Number(endText) : Number(startText);
   const endValue = endText === '' ? Number(startText) : Number(endText);
-  if (!Number.isFinite(startValue) || !Number.isFinite(endValue)) return null;
+  if (startText !== '' || endText !== '') {
+    if (Number.isFinite(startValue) && Number.isFinite(endValue)) {
+      range = {
+        low: Math.max(0, Math.floor(Math.min(startValue, endValue))),
+        high: Math.max(0, Math.floor(Math.max(startValue, endValue))),
+      };
+    }
+  }
 
-  const low = Math.max(0, Math.floor(Math.min(startValue, endValue)));
-  const high = Math.max(0, Math.floor(Math.max(startValue, endValue)));
-  return { low, high };
+  const exactIds = new Set();
+  for (const part of idsText.split(/[,\s]+/)) {
+    if (!part) continue;
+    const value = Number(part);
+    if (Number.isFinite(value) && value >= 0) exactIds.add(Math.floor(value));
+  }
+
+  if (!range && exactIds.size === 0) return null;
+  return { range, exactIds };
+}
+
+function minDistanceRowMatchesHighlight(row, highlightSpec) {
+  if (!highlightSpec) return false;
+  const tokenId = Number(row.token_id);
+  if (!Number.isFinite(tokenId)) return false;
+  if (highlightSpec.exactIds.has(tokenId)) return true;
+  return Boolean(highlightSpec.range && tokenId >= highlightSpec.range.low && tokenId <= highlightSpec.range.high);
+}
+
+function minDistanceHighlightDescription(highlightSpec) {
+  if (!highlightSpec) return '';
+  const parts = [];
+  if (highlightSpec.range) {
+    parts.push(`IDs ${highlightSpec.range.low.toLocaleString()}–${highlightSpec.range.high.toLocaleString()}`);
+  }
+  if (highlightSpec.exactIds.size > 0) {
+    const ids = Array.from(highlightSpec.exactIds).sort((a, b) => a - b);
+    const preview = ids.slice(0, 12).map((id) => id.toLocaleString()).join(', ');
+    const suffix = ids.length > 12 ? `, … +${(ids.length - 12).toLocaleString()} more` : '';
+    parts.push(`exact IDs ${preview}${suffix}`);
+  }
+  return parts.join(' and ');
+}
+
+function highlightedMinDistanceRows() {
+  const highlightSpec = getMinDistanceHighlightSpec();
+  if (!highlightSpec) return [];
+  return sortedMinDistanceRowsForTable().filter((row) => minDistanceRowMatchesHighlight(row, highlightSpec));
 }
 
 function drawMinDistancePlot(rows) {
@@ -1313,16 +1393,15 @@ function drawMinDistancePlot(rows) {
     }
   }
 
-  const highlightRange = getMinDistanceHighlightRange();
-  let highlightCount = 0;
-  if (highlightRange) {
+  const highlightSpec = getMinDistanceHighlightSpec();
+  state.minDistanceHighlightedRows = [];
+  if (highlightSpec) {
     ctx.fillStyle = highlightColor;
     const highlightRadius = rowCount > 20000 ? 2.5 : 4.5;
     for (let index = 0; index < rowCount; index += 1) {
       const row = sortedRows[index];
-      const tokenId = Number(row.token_id);
-      if (!Number.isFinite(tokenId) || tokenId < highlightRange.low || tokenId > highlightRange.high) continue;
-      highlightCount += 1;
+      if (!minDistanceRowMatchesHighlight(row, highlightSpec)) continue;
+      state.minDistanceHighlightedRows.push(row);
       const x = xForRank(index);
       const y = yForAngle(Number(row.min_angle_deg || 0));
       if (rowCount > 20000) {
@@ -1336,12 +1415,15 @@ function drawMinDistancePlot(rows) {
   }
 
   let caption = 'Y axis is the minimum non-self angle. X axis is rank after sorting tokens from lowest to highest minimum angle.';
-  if (highlightRange) {
-    caption += ` Orange dots highlight ${highlightCount.toLocaleString()} token${highlightCount === 1 ? '' : 's'} with IDs ${highlightRange.low.toLocaleString()}–${highlightRange.high.toLocaleString()}.`;
+  if (highlightSpec) {
+    const highlightCount = state.minDistanceHighlightedRows.length;
+    const description = minDistanceHighlightDescription(highlightSpec);
+    caption += ` Orange dots highlight ${highlightCount.toLocaleString()} token${highlightCount === 1 ? '' : 's'} matching ${description}.`;
   } else {
-    caption += ' Enter a token ID range above to overlay matching tokens as orange dots.';
+    caption += ' Enter a token ID range or comma-separated token IDs above to overlay matching tokens as orange dots.';
   }
   byId('minDistancePlotCaption').textContent = caption;
+  setExportVisible('exportMinDistanceHighlightCsv', state.minDistanceHighlightedRows.length > 0);
 }
 
 function sortedMinDistanceRowsForTable() {
@@ -1388,6 +1470,7 @@ function renderMinDistanceTable() {
 
 function resetMinDistancesOutput() {
   state.minDistanceRows = [];
+  state.minDistanceHighlightedRows = [];
   const output = byId('minDistancesOutput');
   if (!output) return;
   setOutput('minDistancesOutput', 'Load a model, then compute each token’s closest non-self angular neighbor. CUDA is used automatically when available.', true);
@@ -1396,6 +1479,7 @@ function resetMinDistancesOutput() {
   table.classList.add('hidden');
   table.querySelector('tbody').innerHTML = '';
   setExportVisible('exportMinDistancesCsv', false);
+  setExportVisible('exportMinDistanceHighlightCsv', false);
 }
 
 function refreshMinDistanceHighlight() {
@@ -1410,10 +1494,12 @@ async function computeMinAngularDistances() {
   const computeDevice = byId('minDistanceComputeDevice').value.trim() || 'auto';
 
   state.minDistanceRows = [];
+  state.minDistanceHighlightedRows = [];
   byId('minDistancePlotCard').classList.add('hidden');
   byId('minDistancesTable').classList.add('hidden');
   byId('minDistancesTable').querySelector('tbody').innerHTML = '';
   setExportVisible('exportMinDistancesCsv', false);
+  setExportVisible('exportMinDistanceHighlightCsv', false);
   setOutput('minDistancesOutput', 'Computing closest non-self angular neighbor for every token… The full pairwise matrix is not cached or written to disk.', true);
   button.disabled = true;
   button.textContent = 'Computing…';
@@ -1444,7 +1530,9 @@ async function computeMinAngularDistances() {
     renderMinDistanceTable();
   } catch (error) {
     state.minDistanceRows = [];
+    state.minDistanceHighlightedRows = [];
     setExportVisible('exportMinDistancesCsv', false);
+    setExportVisible('exportMinDistanceHighlightCsv', false);
     setOutput('minDistancesOutput', `<strong>Minimum-distance computation failed:</strong> ${escapeHtml(error.message)}`);
   } finally {
     button.disabled = false;
@@ -2645,6 +2733,7 @@ function setupExportButtons() {
   byId('exportPairwiseBinTokensCsv').addEventListener('click', () => exportHtmlTableAsCsv('pairwiseBinTokensTable', `pairwise_bin_${filenamePart(state.pairwiseSelectedBinIndex, 'selected')}_tokens.csv`));
   byId('exportMinDistancePlotPng').addEventListener('click', () => exportCanvasAsPng('minDistancePlot', 'minimum_angular_distances.png'));
   byId('exportMinDistancesCsv').addEventListener('click', () => exportHtmlTableAsCsv('minDistancesTable', 'minimum_angular_distances.csv'));
+  byId('exportMinDistanceHighlightCsv').addEventListener('click', exportHighlightedMinDistanceRowsCsv);
   byId('exportRecursiveGroupGraphSvg').addEventListener('click', exportRecursiveGroupGraphSvg);
   byId('exportRecursiveGroupGraphPng').addEventListener('click', exportRecursiveGroupGraphPng);
   byId('exportRecursiveGroupAdjacencyCsv').addEventListener('click', exportRecursiveGroupAdjacencyCsv);
@@ -2710,7 +2799,7 @@ window.addEventListener('DOMContentLoaded', () => {
   byId('minDistanceSort').addEventListener('change', () => {
     if (state.minDistanceRows.length > 0) renderMinDistanceTable();
   });
-  for (const controlId of ['minDistanceHighlightStart', 'minDistanceHighlightEnd']) {
+  for (const controlId of ['minDistanceHighlightStart', 'minDistanceHighlightEnd', 'minDistanceHighlightIds']) {
     byId(controlId).addEventListener('input', refreshMinDistanceHighlight);
     byId(controlId).addEventListener('keydown', (event) => {
       if (event.key === 'Enter') {
@@ -2722,6 +2811,7 @@ window.addEventListener('DOMContentLoaded', () => {
   byId('clearMinDistanceHighlight').addEventListener('click', () => {
     byId('minDistanceHighlightStart').value = '';
     byId('minDistanceHighlightEnd').value = '';
+    byId('minDistanceHighlightIds').value = '';
     refreshMinDistanceHighlight();
   });
 

--- a/huggingface_model/gemma/270M/gemma_angle_webapp/app/templates/index.html
+++ b/huggingface_model/gemma/270M/gemma_angle_webapp/app/templates/index.html
@@ -319,11 +319,24 @@
       <div id="minDistancesOutput" class="output muted">Load a model, then compute each token’s closest non-self angular neighbor. CUDA is used automatically when available.</div>
 
       <div id="minDistancePlotCard" class="plot-card hidden">
+        <div class="analysis-controls min-distance-highlight-controls">
+          <div>
+            <label for="minDistanceHighlightStart">Highlight token ID start</label>
+            <input id="minDistanceHighlightStart" type="number" min="0" step="1" placeholder="e.g. 100" />
+          </div>
+          <div>
+            <label for="minDistanceHighlightEnd">Highlight token ID end</label>
+            <input id="minDistanceHighlightEnd" type="number" min="0" step="1" placeholder="e.g. 199" />
+          </div>
+          <div class="analysis-checkbox">
+            <button id="clearMinDistanceHighlight" type="button" class="secondary">Clear highlight</button>
+          </div>
+        </div>
         <canvas id="minDistancePlot" width="1100" height="460" aria-label="Minimum angular distance sorted scatter plot"></canvas>
         <div class="export-actions">
           <button id="exportMinDistancePlotPng" type="button" class="export-button">Export graph PNG</button>
         </div>
-        <p id="minDistancePlotCaption" class="selection">Y axis is the minimum non-self angle. X axis is rank after sorting tokens from lowest to highest minimum angle.</p>
+        <p id="minDistancePlotCaption" class="selection">Y axis is the minimum non-self angle. X axis is rank after sorting tokens from lowest to highest minimum angle. Enter a token ID range above to overlay matching tokens as orange dots.</p>
       </div>
 
       <div class="export-actions">

--- a/huggingface_model/gemma/270M/gemma_angle_webapp/app/templates/index.html
+++ b/huggingface_model/gemma/270M/gemma_angle_webapp/app/templates/index.html
@@ -328,6 +328,10 @@
             <label for="minDistanceHighlightEnd">Highlight token ID end</label>
             <input id="minDistanceHighlightEnd" type="number" min="0" step="1" placeholder="e.g. 199" />
           </div>
+          <div>
+            <label for="minDistanceHighlightIds">Highlight exact token IDs</label>
+            <input id="minDistanceHighlightIds" type="text" placeholder="e.g. 42, 1001, 50256" autocomplete="off" spellcheck="false" />
+          </div>
           <div class="analysis-checkbox">
             <button id="clearMinDistanceHighlight" type="button" class="secondary">Clear highlight</button>
           </div>
@@ -335,8 +339,9 @@
         <canvas id="minDistancePlot" width="1100" height="460" aria-label="Minimum angular distance sorted scatter plot"></canvas>
         <div class="export-actions">
           <button id="exportMinDistancePlotPng" type="button" class="export-button">Export graph PNG</button>
+          <button id="exportMinDistanceHighlightCsv" type="button" class="export-button hidden">Export highlighted rows CSV</button>
         </div>
-        <p id="minDistancePlotCaption" class="selection">Y axis is the minimum non-self angle. X axis is rank after sorting tokens from lowest to highest minimum angle. Enter a token ID range above to overlay matching tokens as orange dots.</p>
+        <p id="minDistancePlotCaption" class="selection">Y axis is the minimum non-self angle. X axis is rank after sorting tokens from lowest to highest minimum angle. Enter a token ID range or comma-separated token IDs above to overlay matching tokens as orange dots.</p>
       </div>
 
       <div class="export-actions">

--- a/huggingface_model/gemma/270M/gemma_angle_webapp/tests/test_static_ui_behavior.py
+++ b/huggingface_model/gemma/270M/gemma_angle_webapp/tests/test_static_ui_behavior.py
@@ -140,6 +140,7 @@ def test_export_buttons_exist_for_tables_and_graphs() -> None:
         "exportPairwiseBinTokensCsv",
         "exportMinDistancePlotPng",
         "exportMinDistancesCsv",
+        "exportMinDistanceHighlightCsv",
     ]:
         assert f'id="{export_id}"' in html
         assert export_id in js
@@ -158,12 +159,19 @@ def test_minimum_angular_distance_ui_exists() -> None:
     assert 'id="minDistanceBlockSize"' in html
     assert 'id="minDistanceComputeDevice"' in html
     assert 'id="minDistanceSort"' in html
+    assert 'id="minDistanceHighlightStart"' in html
+    assert 'id="minDistanceHighlightEnd"' in html
+    assert 'id="minDistanceHighlightIds"' in html
+    assert 'id="clearMinDistanceHighlight"' in html
+    assert 'id="exportMinDistanceHighlightCsv"' in html
     assert 'id="minDistancePlot"' in html
     assert 'id="minDistancesTable"' in html
     assert "Closest non-self token for every token" in html
     assert "fetchJson(`/api/min-angular-distances?" in js
     assert "computeMinAngularDistances" in js
     assert "drawMinDistancePlot" in js
+    assert "getMinDistanceHighlightSpec" in js
+    assert "exportHighlightedMinDistanceRowsCsv" in js
     assert "renderMinDistanceTable" in js
     assert "resetMinDistancesOutput" in js
     assert "min-distance-scroll" in css


### PR DESCRIPTION
### Motivation
- Make it easy to visually locate where a contiguous range of token IDs appears on the minimum-angular-distance scatter plot so users can inspect vocabulary slices at a glance.

### Description
- Add UI controls (start/end number inputs and a `Clear highlight` button) in the min-angle plot card in `templates/index.html` to accept a token ID range.
- Implement `getMinDistanceHighlightRange()` to parse one-sided or reversed ranges and return a normalized `{ low, high }` range.
- Update `drawMinDistancePlot()` in `static/app.js` to overlay matching tokens as orange dots (`#f97316`) on the sorted min-angle scatter and to update the plot caption with the highlighted count/range.
- Add `refreshMinDistanceHighlight()` and wire input/Enter events plus the clear button so the highlight redraws live as the range changes.

### Testing
- Ran `pytest -q huggingface_model/gemma/270M/gemma_angle_webapp/tests/test_static_ui_behavior.py` and the UI-related assertions passed (14 tests passed).
- Attempted to run the full app test suite `pytest -q huggingface_model/gemma/270M/gemma_angle_webapp/tests`, but collection failed in this environment due to the missing `torch` dependency (environmental issue), so non-UI tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36f300e7508326b278e98bebc0ee77)