### PR TITLE
feat(data): add Shakespeare articulatory multicontext dataset and demo

### DIFF
--- a/data/shakespeare_char_articulatory/README.md
+++ b/data/shakespeare_char_articulatory/README.md
@@ -1,0 +1,11 @@
+# Shakespeare character articulatory multicontext
+
+Builds aligned multicontext lanes from Tiny Shakespeare: lowercase text, case class (uppercase/lowercase/other), and approximate articulatory-phonetic lanes for letters with an `other` category for non-letters. The source text is Tiny Shakespeare from Andrej Karpathy's char-rnn examples.
+
+Run:
+
+```bash
+data/shakespeare_char_articulatory/get_dataset.sh
+```
+
+The script writes one nanoGPT character dataset per lane under `data/shakespeare_char_articulatory/<lane>/` and a `manifest.json` listing the `--multicontext_datasets` arguments.

--- a/data/shakespeare_char_articulatory/get_dataset.sh
+++ b/data/shakespeare_char_articulatory/get_dataset.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+python3 "${SCRIPT_DIR}/prepare_articulatory_multicontext.py" "$@"

--- a/data/shakespeare_char_articulatory/prepare_articulatory_multicontext.py
+++ b/data/shakespeare_char_articulatory/prepare_articulatory_multicontext.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Create Tiny Shakespeare multicontext lanes for case and articulatory features."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from urllib.request import urlretrieve
+
+URL = "https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt"
+LANES = [
+    "lowercase", "case", "phonetic_class", "place", "manner", "voicing",
+    "vowel_height", "vowel_backness", "vowel_rounding",
+]
+APPROX = {
+    "a": ("vowel", "open", "front", "unrounded"),
+    "e": ("vowel", "mid", "front", "unrounded"),
+    "i": ("vowel", "close", "front", "unrounded"),
+    "o": ("vowel", "mid", "back", "rounded"),
+    "u": ("vowel", "close", "back", "rounded"),
+}
+CONSONANTS = {
+    "b": ("bilabial", "stop", "voiced"), "c": ("velar", "stop", "voiceless"),
+    "d": ("alveolar", "stop", "voiced"), "f": ("labiodental", "fricative", "voiceless"),
+    "g": ("velar", "stop", "voiced"), "h": ("glottal", "fricative", "voiceless"),
+    "j": ("postalveolar", "affricate", "voiced"), "k": ("velar", "stop", "voiceless"),
+    "l": ("alveolar", "lateral", "voiced"), "m": ("bilabial", "nasal", "voiced"),
+    "n": ("alveolar", "nasal", "voiced"), "p": ("bilabial", "stop", "voiceless"),
+    "q": ("velar", "stop", "voiceless"), "r": ("alveolar", "approximant", "voiced"),
+    "s": ("alveolar", "fricative", "voiceless"), "t": ("alveolar", "stop", "voiceless"),
+    "v": ("labiodental", "fricative", "voiced"), "w": ("labiovelar", "approximant", "voiced"),
+    "x": ("velar", "fricative", "voiceless"), "y": ("palatal", "approximant", "voiced"),
+    "z": ("alveolar", "fricative", "voiced"),
+}
+SYMBOLS = {
+    "case": {"lower": "l", "upper": "u", "other": "_"},
+    "phonetic_class": {"vowel": "V", "consonant": "C", "other": "_"},
+    "place": {"bilabial":"B","labiodental":"F","alveolar":"A","postalveolar":"P","palatal":"Y","velar":"K","glottal":"H","labiovelar":"W","vowel":"V","other":"_"},
+    "manner": {"stop":"S","fricative":"F","affricate":"A","nasal":"N","lateral":"L","approximant":"R","vowel":"V","other":"_"},
+    "voicing": {"voiced":"v","voiceless":"x","vowel":"V","other":"_"},
+    "vowel_height": {"close":"c","mid":"m","open":"o","consonant":"C","other":"_"},
+    "vowel_backness": {"front":"f","back":"b","consonant":"C","other":"_"},
+    "vowel_rounding": {"rounded":"r","unrounded":"u","consonant":"C","other":"_"},
+}
+
+
+def features(ch: str) -> dict[str, str]:
+    lo = ch.lower()
+    out = {"lowercase": lo if ch.isalpha() else ch, "case": "upper" if ch.isupper() else "lower" if ch.islower() else "other"}
+    if lo in APPROX:
+        _, height, backness, rounding = APPROX[lo]
+        out.update(phonetic_class="vowel", place="vowel", manner="vowel", voicing="vowel", vowel_height=height, vowel_backness=backness, vowel_rounding=rounding)
+    elif lo in CONSONANTS:
+        place, manner, voicing = CONSONANTS[lo]
+        out.update(phonetic_class="consonant", place=place, manner=manner, voicing=voicing, vowel_height="consonant", vowel_backness="consonant", vowel_rounding="consonant")
+    else:
+        out.update(phonetic_class="other", place="other", manner="other", voicing="other", vowel_height="other", vowel_backness="other", vowel_rounding="other")
+    return out
+
+
+def write_lane(root: Path, lane: str, text: str, prepare_py: Path, percentage_train: float) -> str:
+    d = root / lane
+    d.mkdir(parents=True, exist_ok=True)
+    vals = []
+    for ch in text:
+        f = features(ch)
+        vals.append(f["lowercase"] if lane == "lowercase" else SYMBOLS[lane][f[lane]])
+    lane_text = "".join(vals)
+    (d / "input.txt").write_text(lane_text, encoding="utf-8")
+    if lane == "lowercase":
+        token_text = "".join(sorted(set(lane_text)))
+    else:
+        token_text = "".join(dict.fromkeys(SYMBOLS[lane].values()))
+    (d / "tokensfile.txt").write_text(token_text, encoding="utf-8")
+    for link_name, target in {"prepare.py": prepare_py, "nanogpt_tokenizers.py": prepare_py.with_name("nanogpt_tokenizers.py"), "utils": prepare_py.with_name("utils")}.items():
+        link_path = d / link_name
+        if link_path.exists() or link_path.is_symlink():
+            if link_path.is_dir() and not link_path.is_symlink():
+                shutil.rmtree(link_path)
+            else:
+                link_path.unlink()
+        link_path.symlink_to(Path(os.path.relpath(target, d)), target.is_dir())
+    subprocess.run(["python3", "prepare.py", "--method", "char", "-t", "tokensfile.txt", "--percentage_train", "1.0"], cwd=d, check=True)
+    subprocess.run(["python3", "prepare.py", "--method", "char", "-t", "input.txt", "--reuse_chars", "--percentage_train", str(percentage_train)], cwd=d, check=True)
+    return f"{root.name}/{lane}"
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--source", default=None, help="Optional source text; downloads Tiny Shakespeare if omitted.")
+    p.add_argument("--output_root", default="shakespeare_char_articulatory")
+    p.add_argument("--percentage_train", type=float, default=0.9)
+    args = p.parse_args()
+    here = Path(__file__).resolve().parent
+    data_root = here.parent
+    root = data_root / args.output_root
+    root.mkdir(parents=True, exist_ok=True)
+    source = root / "source.txt"
+    if args.source:
+        shutil.copyfile(args.source, source)
+    elif not source.exists():
+        urlretrieve(URL, source)
+    text = source.read_text(encoding="utf-8")
+    prepare_py = data_root / "template" / "prepare.py"
+    datasets = [write_lane(root, lane, text, prepare_py, args.percentage_train) for lane in LANES]
+    manifest = {"source": str(source), "output_root": args.output_root, "multicontext_datasets": datasets, "lanes": LANES}
+    (root / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    print(" ".join(datasets))
+
+if __name__ == "__main__":
+    main()

--- a/data/shakespeare_char_articulatory/recombine_case_sample.py
+++ b/data/shakespeare_char_articulatory/recombine_case_sample.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Split sample.py multicontext output and recombine lowercase + case lanes."""
+from __future__ import annotations
+import argparse
+from pathlib import Path
+
+
+def extract_sections(text: str) -> dict[str, str]:
+    sections: dict[str, str] = {}
+    cur = None
+    buf: list[str] = []
+    for line in text.splitlines():
+        if line == "---------------":
+            if cur is not None:
+                sections[cur] = "\n".join(buf).strip("\n")
+            cur, buf = None, []
+            continue
+        stripped = line.strip()
+        if stripped.startswith("shakespeare_char_articulatory/") and stripped.endswith(":"):
+            if cur is not None:
+                sections[cur] = "\n".join(buf).strip("\n")
+            cur = stripped[:-1]
+            buf = []
+        elif cur is not None:
+            buf.append(line)
+    if cur is not None:
+        sections[cur] = "\n".join(buf).strip("\n")
+    return sections
+
+
+def apply_case(lower: str, case: str) -> str:
+    out = []
+    for ch, marker in zip(lower, case):
+        out.append(ch.upper() if marker == "u" else ch)
+    return "".join(out)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("sample_file")
+    p.add_argument("--out_dir", required=True)
+    args = p.parse_args()
+    raw = Path(args.sample_file).read_text(encoding="utf-8")
+    sections = extract_sections(raw)
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for name, content in sections.items():
+        lane = name.rsplit("/", 1)[-1]
+        path = out_dir / f"{lane}.txt"
+        path.write_text(content + "\n", encoding="utf-8")
+        print(f"wrote {path}")
+    lower = sections.get("shakespeare_char_articulatory/lowercase", "")
+    case = sections.get("shakespeare_char_articulatory/case", "")
+    final = apply_case(lower, case)
+    final_path = out_dir / "recombined_lowercase_plus_case.txt"
+    final_path.write_text(final + "\n", encoding="utf-8")
+    print("\nRecombined lowercase + capitalization output:\n")
+    print(final)
+    print(f"\nwrote {final_path}")
+
+if __name__ == "__main__":
+    main()

--- a/demos/shakespeare_articulatory_multicontext_demo.sh
+++ b/demos/shakespeare_articulatory_multicontext_demo.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT_DIR="${OUT_DIR:-out_mc_shakespeare_articulatory}"
+SAMPLE_DIR="${SAMPLE_DIR:-${OUT_DIR}/samples}"
+MAX_ITERS="${MAX_ITERS:-2000}"
+MAX_NEW_TOKENS="${MAX_NEW_TOKENS:-512}"
+
+# Build aligned lanes: lowercase, case, and articulatory-phonetic annotations.
+data/shakespeare_char_articulatory/get_dataset.sh
+
+DATASETS=(
+  shakespeare_char_articulatory/lowercase
+  shakespeare_char_articulatory/case
+  shakespeare_char_articulatory/phonetic_class
+  shakespeare_char_articulatory/place
+  shakespeare_char_articulatory/manner
+  shakespeare_char_articulatory/voicing
+  shakespeare_char_articulatory/vowel_height
+  shakespeare_char_articulatory/vowel_backness
+  shakespeare_char_articulatory/vowel_rounding
+)
+
+python3 train.py \
+  --training_mode multicontext \
+  --multicontext \
+  --multicontext_datasets "${DATASETS[@]}" \
+  --max_iters "${MAX_ITERS}" \
+  --dropout 0.2 \
+  --top_k 1 \
+  --sample_each_eval \
+  --use_qk_norm \
+  --use_qk_norm_scale \
+  --use_rotary_embeddings \
+  --no-use_abs_pos_embeddings \
+  --out_dir "${OUT_DIR}" \
+  --compile
+
+mkdir -p "${SAMPLE_DIR}"
+RAW_SAMPLE="${SAMPLE_DIR}/sample_raw.txt"
+python3 sample.py \
+  --out_dir "${OUT_DIR}" \
+  --multicontext \
+  --multicontext_datasets "${DATASETS[@]}" \
+  --multicontext_start "but " "u___" "CVCC" "VAVA" "VSFS" "Vxvx" "oCC_" "fCC_" "uCC_" \
+  --max_new_tokens "${MAX_NEW_TOKENS}" \
+  --top_k 1 \
+  --num_samples 1 \
+  --sample_file "${RAW_SAMPLE}" | tee "${SAMPLE_DIR}/sample_stdout.txt"
+
+python3 data/shakespeare_char_articulatory/recombine_case_sample.py \
+  "${RAW_SAMPLE}" \
+  --out_dir "${SAMPLE_DIR}" | tee "${SAMPLE_DIR}/recombined_stdout.txt"


### PR DESCRIPTION
### Motivation
- Provide a multicontext dataset that separates characters into lowercase/uppercase/other and adds aligned articulatory-phonetic feature lanes so the model can learn correlated channels (case, phonetic class, place, manner, voicing, vowel features) alongside text.
- Enable end-to-end multicontext training and sampling that writes per-lane sampled outputs and reconstructs a final lowercase+capitalization output for human-readable evaluation.

### Description
- Add `data/shakespeare_char_articulatory/prepare_articulatory_multicontext.py` which downloads (or reads) Tiny Shakespeare, computes per-character features using `APPROX` and `CONSONANTS` mappings, writes per-lane `input.txt` and `tokensfile.txt`, links `prepare.py`, `nanogpt_tokenizers.py`, and `utils`, runs the repo `prepare.py` to create tokenized dataset files, and writes a `manifest.json` with `multicontext_datasets`.
- Add `data/shakespeare_char_articulatory/get_dataset.sh` as the simple entrypoint and `data/shakespeare_char_articulatory/README.md` documenting the dataset and usage.
- Add `data/shakespeare_char_articulatory/recombine_case_sample.py` which parses `sample.py` multicontext output, writes one file per lane, and reconstructs a final `recombined_lowercase_plus_case.txt` by applying the sampled case markers to the sampled lowercase lane.
- Add `demos/shakespeare_articulatory_multicontext_demo.sh` that runs dataset preparation, launches `train.py` in `--training_mode multicontext`, runs `sample.py` with the multicontext channels, saves `sample.py` stdout to a file, and runs the recombination helper to produce per-lane output files and the final reconstructed output.

### Testing
- Ran a syntax check on the demo with `bash -n demos/shakespeare_articulatory_multicontext_demo.sh`, which succeeded.
- Compiled the new Python modules with `python3 -m py_compile data/shakespeare_char_articulatory/prepare_articulatory_multicontext.py data/shakespeare_char_articulatory/recombine_case_sample.py`, which succeeded.
- Exercised the recombination helper on a synthetic `sample.py`-style fragment using `python3 data/shakespeare_char_articulatory/recombine_case_sample.py <sample_file> --out_dir <tmp>`, which produced per-lane files and the recombined `recombined_lowercase_plus_case.txt` successfully.
- Attempted full dataset generation via `python3 data/shakespeare_char_articulatory/prepare_articulatory_multicontext.py --source <file> --output_root ...`, but this run failed in the current environment due to missing runtime dependency `numpy` when invoking the shared `prepare.py` (automated dataset creation could not complete).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36fd2871ec8326ab766641c6cc5865)