### PR TITLE
feat(data): add Dukascopy FX M1 dataset + multicontext demo

### DIFF
--- a/data/dukascopy_fx_m1/README.md
+++ b/data/dukascopy_fx_m1/README.md
@@ -1,0 +1,68 @@
+# Dukascopy FX M1 CSV Multicontext Data
+
+This folder contains a small Dukascopy FX minute-candle workflow for the regular
+integer CSV multicontext pipeline used by `data/csv_mc_int`.
+
+## 1. Download raw candles
+
+```bash
+python3 data/dukascopy_fx_m1/download_dukascopy_fx_m1.py \
+  --start 2025-01-02 --end 2025-01-03 \
+  --universe majors \
+  --out data/dukascopy_fx_m1/raw \
+  --side BID \
+  --max-workers 4 --rps 2
+```
+
+The downloader writes one gzipped CSV per instrument/day, for example
+`data/dukascopy_fx_m1/raw/eurusd/2025-01-02_bid_m1.csv.gz`, with columns:
+
+```text
+timestamp_utc,open,high,low,close,volume
+```
+
+Dukascopy's historical data URLs use zero-based months; the downloader handles
+that internally.
+
+## 2. Build integer multicontext datasets
+
+```bash
+data/dukascopy_fx_m1/get_dataset.sh data/dukascopy_fx_m1/raw/eurusd
+```
+
+`get_dataset.sh` first converts the raw floating-point candle CSV into
+`data/dukascopy_fx_m1/input.csv` with integer columns:
+
+- `minute_of_day` in `[0, 1439]`
+- `open_ticks`, `high_ticks`, `low_ticks`, `close_ticks` as rounded
+  `price * DUKASCOPY_PRICE_SCALE` (default `100000`)
+- `volume_ticks` as rounded `volume * DUKASCOPY_VOLUME_SCALE` (default `1000`)
+
+Then it calls `data/csv_mc_int/get_dataset.sh`, producing per-column datasets
+under `data/dukascopy_fx_m1/` and a `manifest.json` containing the ordered
+`multicontext_datasets` list consumed by the demo script.
+
+Environment overrides:
+
+- `DUKASCOPY_MC_OUTPUT_ROOT` (default `dukascopy_fx_m1`)
+- `DUKASCOPY_PRICE_MIN` / `DUKASCOPY_PRICE_MAX` (default `0` / `300000`)
+- `DUKASCOPY_VOLUME_MAX` (default `100000000`)
+- `DUKASCOPY_PRICE_SCALE` (default `100000`)
+- `DUKASCOPY_VOLUME_SCALE` (default `1000`)
+- `DUKASCOPY_INCLUDE_WEEKDAY=1` to add a `weekday` context
+
+## 3. Train/sample demo
+
+```bash
+demos/dukascopy_fx_m1_csv_mc_int_demo.sh data/dukascopy_fx_m1/raw/eurusd
+```
+
+The demo mirrors `demos/csv_mc_int_demo.sh`: it reads the generated manifest,
+trains regular `--training_mode multicontext`, and samples CSV continuations
+using `sample.py --multicontext_csv_input`.
+
+## Source and license
+
+Raw candle data is downloaded from Dukascopy's public historical data feed:
+<https://datafeed.dukascopy.com/datafeed>. Review Dukascopy's terms before
+redistributing downloaded data.

--- a/data/dukascopy_fx_m1/README.md
+++ b/data/dukascopy_fx_m1/README.md
@@ -92,8 +92,25 @@ Demo download overrides:
 - `DUKASCOPY_DEMO_MAX_WORKERS` (default `4`)
 - `DUKASCOPY_DEMO_RPS` (default `2`)
 
+## 4. Prediction-vs-reality viewer
+
+The demo now finishes by calling `data/timeseries_viewer/generate_timeseries_comparison.py`.
+That viewer withholds a tail slice from `data/dukascopy_fx_m1/input.csv`, uses the
+preceding rows as the inference prompt, samples every requested random seed at
+`top_k=1` and `top_k=5`, and writes a self-contained HTML graph comparing those
+forecasts against the held-out ground truth.
+
+Viewer overrides:
+
+- `DUKASCOPY_VIEWER_SEEDS` (default `1337 1338 1339`)
+- `DUKASCOPY_VIEWER_TOP_K` (default `1 5`)
+- `DUKASCOPY_VIEWER_HOLDOUT_ROWS` (default `128`)
+- `DUKASCOPY_VIEWER_PROMPT_ROWS` (default `512`)
+- `DUKASCOPY_VIEWER_WORK_DIR` (default `$DUKASCOPY_MC_OUT_DIR/timeseries_viewer`)
+
 ## Source and license
 
 Raw candle data is downloaded from Dukascopy's public historical data feed:
 <https://datafeed.dukascopy.com/datafeed>. Review Dukascopy's terms before
 redistributing downloaded data.
+

--- a/data/dukascopy_fx_m1/README.md
+++ b/data/dukascopy_fx_m1/README.md
@@ -31,12 +31,25 @@ data/dukascopy_fx_m1/get_dataset.sh data/dukascopy_fx_m1/raw/eurusd
 ```
 
 `get_dataset.sh` first converts the raw floating-point candle CSV into
-`data/dukascopy_fx_m1/input.csv` with integer columns:
+`data/dukascopy_fx_m1/input.csv` with compact integer columns:
 
+- `minute_mod_10` in `[0, 9]`
+- `minute_of_hour` in `[0, 59]`
 - `minute_of_day` in `[0, 1439]`
-- `open_ticks`, `high_ticks`, `low_ticks`, `close_ticks` as rounded
-  `price * DUKASCOPY_PRICE_SCALE` (default `100000`)
-- `volume_ticks` as rounded `volume * DUKASCOPY_VOLUME_SCALE` (default `1000`)
+- `minute_of_week` in `[0, 10079]`
+- `minute_of_year` in `[0, 527039]` (leap-year-safe minute index)
+- `open_delta_state`, `high_delta_state`, `low_delta_state`,
+  `close_delta_state`, and `volume_delta_state` as compact derivative states
+
+For each OHLCV tick column, the converter computes the present tick value minus
+the previous tick value, derives default 5th/95th percentile saturation
+thresholds, clips outliers to those thresholds, and buckets the clipped
+derivative into `DUKASCOPY_DELTA_STATES` discrete states. The raw absolute tick
+values are not used as model tokens, which keeps vocabularies much smaller than
+full price/volume ranges.
+
+The converter also writes `stats.json` plus dependency-free PNG histograms for
+both the original tick values and derivative values under `data/dukascopy_fx_m1/stats/`.
 
 Then it calls `data/csv_mc_int/get_dataset.sh`, producing per-column datasets
 under `data/dukascopy_fx_m1/` and a `manifest.json` containing the ordered
@@ -45,11 +58,13 @@ under `data/dukascopy_fx_m1/` and a `manifest.json` containing the ordered
 Environment overrides:
 
 - `DUKASCOPY_MC_OUTPUT_ROOT` (default `dukascopy_fx_m1`)
-- `DUKASCOPY_PRICE_MIN` / `DUKASCOPY_PRICE_MAX` (default `0` / `300000`)
-- `DUKASCOPY_VOLUME_MAX` (default `100000000`)
 - `DUKASCOPY_PRICE_SCALE` (default `100000`)
 - `DUKASCOPY_VOLUME_SCALE` (default `1000`)
-- `DUKASCOPY_INCLUDE_WEEKDAY=1` to add a `weekday` context
+- `DUKASCOPY_DELTA_STATES` (default `257`)
+- `DUKASCOPY_DELTA_LOWER_PERCENTILE` / `DUKASCOPY_DELTA_UPPER_PERCENTILE` (default `5` / `95`)
+- `DUKASCOPY_DELTA_THRESHOLDS`, space-separated overrides like `open:-20:20 volume:-5000:5000`
+- `DUKASCOPY_LOG_DELTA=1` to apply signed `log1p` before derivative bucketing
+- `DUKASCOPY_STATS_DIR` (default `data/dukascopy_fx_m1/stats`)
 
 ## 3. Train/sample demo
 

--- a/data/dukascopy_fx_m1/README.md
+++ b/data/dukascopy_fx_m1/README.md
@@ -36,8 +36,8 @@ data/dukascopy_fx_m1/get_dataset.sh data/dukascopy_fx_m1/raw/eurusd
 - `minute_mod_10` in `[0, 9]`
 - `minute_of_hour` in `[0, 59]`
 - `minute_of_day` in `[0, 1439]`
-- `minute_of_week` in `[0, 10079]`
-- `minute_of_year` in `[0, 527039]` (leap-year-safe minute index)
+- `day_of_week` in `[0, 6]` (Monday=0)
+- `week_of_year` in `[1, 53]` (ISO week number)
 - `open_delta_state`, `high_delta_state`, `low_delta_state`,
   `close_delta_state`, and `volume_delta_state` as compact derivative states
 
@@ -65,6 +65,10 @@ Environment overrides:
 - `DUKASCOPY_DELTA_THRESHOLDS`, space-separated overrides like `open:-20:20 volume:-5000:5000`
 - `DUKASCOPY_LOG_DELTA=1` to apply signed `log1p` before derivative bucketing
 - `DUKASCOPY_STATS_DIR` (default `data/dukascopy_fx_m1/stats`)
+
+The time features therefore represent modulo position within 10 minutes, 1 hour,
+24 hours, 1 week, and 1 year without expanding the weekly/yearly features to
+minute-level vocabularies.
 
 ## 3. Train/sample demo
 

--- a/data/dukascopy_fx_m1/README.md
+++ b/data/dukascopy_fx_m1/README.md
@@ -54,12 +54,24 @@ Environment overrides:
 ## 3. Train/sample demo
 
 ```bash
-demos/dukascopy_fx_m1_csv_mc_int_demo.sh data/dukascopy_fx_m1/raw/eurusd
+demos/dukascopy_fx_m1_csv_mc_int_demo.sh
 ```
 
 The demo mirrors `demos/csv_mc_int_demo.sh`: it reads the generated manifest,
 trains regular `--training_mode multicontext`, and samples CSV continuations
-using `sample.py --multicontext_csv_input`.
+using `sample.py --multicontext_csv_input`. If the default raw input
+`data/dukascopy_fx_m1/raw/eurusd` does not exist yet, the demo first downloads
+one day of BID data for the built-in majors universe, then builds the EUR/USD
+dataset from the downloaded CSVs.
+
+Demo download overrides:
+
+- `DUKASCOPY_DEMO_START` / `DUKASCOPY_DEMO_END` (default `2025-01-02` / `2025-01-03`)
+- `DUKASCOPY_DEMO_SIDE` (default `BID`)
+- `DUKASCOPY_DEMO_UNIVERSE` (default `majors`)
+- `DUKASCOPY_DEMO_RAW_OUT` (default `data/dukascopy_fx_m1/raw`)
+- `DUKASCOPY_DEMO_MAX_WORKERS` (default `4`)
+- `DUKASCOPY_DEMO_RPS` (default `2`)
 
 ## Source and license
 

--- a/data/dukascopy_fx_m1/README.md
+++ b/data/dukascopy_fx_m1/README.md
@@ -96,14 +96,14 @@ Demo download overrides:
 
 The demo now finishes by calling `data/timeseries_viewer/generate_timeseries_comparison.py`.
 That viewer withholds a tail slice from `data/dukascopy_fx_m1/input.csv`, uses the
-preceding rows as the inference prompt, samples every requested random seed at
-`top_k=1` and `top_k=5`, and writes a self-contained HTML graph comparing those
+preceding rows as the inference prompt, samples five random seeds each at
+`top_k=1`, `top_k=5`, and `top_k=10`, and writes a self-contained HTML graph comparing those
 forecasts against the held-out ground truth.
 
 Viewer overrides:
 
-- `DUKASCOPY_VIEWER_SEEDS` (default `1337 1338 1339`)
-- `DUKASCOPY_VIEWER_TOP_K` (default `1 5`)
+- `DUKASCOPY_VIEWER_SEEDS` (default `1337 1338 1339 1340 1341`)
+- `DUKASCOPY_VIEWER_TOP_K` (default `1 5 10`)
 - `DUKASCOPY_VIEWER_HOLDOUT_ROWS` (default `128`)
 - `DUKASCOPY_VIEWER_PROMPT_ROWS` (default `512`)
 - `DUKASCOPY_VIEWER_WORK_DIR` (default `$DUKASCOPY_MC_OUT_DIR/timeseries_viewer`)

--- a/data/dukascopy_fx_m1/download_dukascopy_fx_m1.py
+++ b/data/dukascopy_fx_m1/download_dukascopy_fx_m1.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Download Dukascopy 1-minute FX candles (M1) for many pairs.
+
+The downloader writes one gzipped CSV per instrument/day with columns:
+timestamp_utc, open, high, low, close, volume.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import gzip
+import lzma
+import os
+import re
+import struct
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from typing import Any, Iterable, List, Optional, Set, Tuple
+
+
+DUKASCOPY_DATAFEED_BASE = "https://datafeed.dukascopy.com/datafeed"
+DEFAULT_MAJORS: List[str] = [
+    "eurusd",
+    "gbpusd",
+    "usdjpy",
+    "usdchf",
+    "usdcad",
+    "audusd",
+    "nzdusd",
+]
+DUKASCOPY_NODE_FX_CROSSES = "https://www.dukascopy-node.app/instruments/fx_crosses"
+CANDLE_STRUCT_FMT = ">5if"
+CANDLE_STRUCT_SIZE = struct.calcsize(CANDLE_STRUCT_FMT)
+
+
+class RateLimiter:
+    """Simple global rate limiter shared across worker threads."""
+
+    def __init__(self, rps: float):
+        self.rps = float(rps)
+        self.min_interval = 1.0 / self.rps if self.rps > 0 else 0.0
+        self._lock = threading.Lock()
+        self._next_time = 0.0
+
+    def wait(self) -> None:
+        if self.min_interval <= 0:
+            return
+        with self._lock:
+            now = time.monotonic()
+            if now < self._next_time:
+                time.sleep(self._next_time - now)
+                now = time.monotonic()
+            self._next_time = now + self.min_interval
+
+
+_thread_local = threading.local()
+
+
+def _get_session(user_agent: str) -> Any:
+    import requests
+
+    sess = getattr(_thread_local, "session", None)
+    if sess is None:
+        sess = requests.Session()
+        sess.headers.update({"User-Agent": user_agent, "Accept": "*/*"})
+        _thread_local.session = sess
+    return sess
+
+
+def parse_date(s: str) -> dt.date:
+    return dt.date.fromisoformat(s)
+
+
+def daterange(start: dt.date, end: dt.date) -> Iterable[dt.date]:
+    d = start
+    while d < end:
+        yield d
+        d += dt.timedelta(days=1)
+
+
+def load_pairs_from_file(path: str) -> List[str]:
+    pairs: Set[str] = set()
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.split("#", 1)[0].strip().lower()
+            if not line:
+                continue
+            if not re.fullmatch(r"[a-z0-9]{6}", line):
+                raise ValueError(f"Invalid instrument id in {path}: {line!r} (expected 6 chars like 'eurusd')")
+            pairs.add(line)
+    return sorted(pairs)
+
+
+def fetch_instrument_ids_from_dukascopy_node(url: str, timeout_s: int, user_agent: str) -> List[str]:
+    import requests
+
+    r = requests.get(url, timeout=timeout_s, headers={"User-Agent": user_agent})
+    r.raise_for_status()
+    html = r.text
+    candidates: Set[str] = set()
+    for pattern in (r'href="/instrument/([A-Za-z0-9]{6})"', r"<code[^>]*>\s*([A-Za-z0-9]{6})\s*</code>", r"`\s*([A-Za-z0-9]{6})\s*`"):
+        for match in re.findall(pattern, html, flags=re.I):
+            candidates.add(match.lower())
+    return sorted(candidates)
+
+
+def guess_tick_scale(instrument_id: str, default_non_jpy: int = 5, jpy_scale: int = 3) -> int:
+    return jpy_scale if len(instrument_id) == 6 and instrument_id.lower().endswith("jpy") else default_non_jpy
+
+
+def build_candle_url(instrument_id: str, day: dt.date, side: str) -> str:
+    return (
+        f"{DUKASCOPY_DATAFEED_BASE}/{instrument_id.upper()}/"
+        f"{day.year}/{day.month - 1:02d}/{day.day:02d}/"
+        f"{side.upper()}_candles_min_1.bi5"
+    )
+
+
+def decode_bi5_candles(bi5_bytes: bytes, day: dt.date, tick_scale: int) -> List[Tuple[str, str, str, str, str, str]]:
+    decompressed = lzma.decompress(bi5_bytes)
+    midnight = dt.datetime(day.year, day.month, day.day, tzinfo=dt.timezone.utc)
+    price_div = 10**tick_scale
+    price_fmt = f"{{:.{tick_scale}f}}"
+    rows: List[Tuple[str, str, str, str, str, str]] = []
+    usable = len(decompressed) - (len(decompressed) % CANDLE_STRUCT_SIZE)
+    for off in range(0, usable, CANDLE_STRUCT_SIZE):
+        t_sec, o_i, c_i, lo_i, hi_i, vol = struct.unpack(CANDLE_STRUCT_FMT, decompressed[off : off + CANDLE_STRUCT_SIZE])
+        ts_s = (midnight + dt.timedelta(seconds=int(t_sec))).isoformat().replace("+00:00", "Z")
+        rows.append((ts_s, price_fmt.format(o_i / price_div), price_fmt.format(hi_i / price_div), price_fmt.format(lo_i / price_div), price_fmt.format(c_i / price_div), f"{float(vol):.6f}".rstrip("0").rstrip(".")))
+    return rows
+
+
+def write_csv_gz(path: str, rows: List[Tuple[str, str, str, str, str, str]]) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with gzip.open(path, "wt", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["timestamp_utc", "open", "high", "low", "close", "volume"])
+        writer.writerows(rows)
+
+
+@dataclass(frozen=True)
+class Job:
+    instrument_id: str
+    day: dt.date
+
+
+def download_and_convert_one(job: Job, out_dir: str, side: str, overwrite: bool, timeout_s: int, retries: int, backoff_s: float, limiter: Optional[RateLimiter], user_agent: str, default_non_jpy_scale: int, jpy_scale: int) -> Tuple[Job, str]:
+    instrument = job.instrument_id.lower()
+    out_path = os.path.join(out_dir, instrument, f"{job.day.isoformat()}_{side.lower()}_m1.csv.gz")
+    if not overwrite and os.path.exists(out_path):
+        return job, "SKIP_EXISTS"
+    url = build_candle_url(instrument, job.day, side)
+    tick_scale = guess_tick_scale(instrument, default_non_jpy_scale, jpy_scale)
+    last_err: Optional[str] = None
+    for attempt in range(retries + 1):
+        try:
+            if limiter:
+                limiter.wait()
+            response = _get_session(user_agent).get(url, timeout=timeout_s)
+            if response.status_code == 404:
+                return job, "NO_DATA_404"
+            if response.status_code == 429:
+                sleep_s = backoff_s * (2**attempt)
+                time.sleep(sleep_s)
+                last_err = f"429_RATE_LIMIT (slept {sleep_s:.1f}s)"
+                continue
+            response.raise_for_status()
+            rows = decode_bi5_candles(response.content, job.day, tick_scale)
+            if not rows:
+                return job, "EMPTY_DECODED"
+            write_csv_gz(out_path, rows)
+            return job, f"OK ({len(rows)} rows)"
+        except Exception as exc:  # noqa: BLE001 - report per-job failures and continue other jobs.
+            last_err = f"{type(exc).__name__}: {exc}"
+            if attempt < retries:
+                time.sleep(backoff_s * (2**attempt))
+    return job, f"FAIL ({last_err})"
+
+
+def resolve_instruments(universe: str, pairs_file: Optional[str], timeout_s: int, user_agent: str) -> List[str]:
+    if universe == "majors":
+        return list(DEFAULT_MAJORS)
+    if universe == "file":
+        if not pairs_file:
+            raise ValueError("--pairs-file is required when --universe=file")
+        return load_pairs_from_file(pairs_file)
+    crosses = fetch_instrument_ids_from_dukascopy_node(DUKASCOPY_NODE_FX_CROSSES, timeout_s, user_agent)
+    if universe == "crosses":
+        return crosses
+    if universe == "all":
+        return sorted(set(DEFAULT_MAJORS).union(crosses))
+    raise ValueError(f"Unknown universe: {universe!r}. Use majors|crosses|all|file")
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--start", required=True, help="Start date (YYYY-MM-DD), inclusive")
+    parser.add_argument("--end", required=True, help="End date (YYYY-MM-DD), exclusive")
+    parser.add_argument("--out", default="data/dukascopy_fx_m1/raw", help="Output directory")
+    parser.add_argument("--side", default="BID", choices=["BID", "ASK"], help="Price side to download")
+    parser.add_argument("--universe", default="majors", choices=["majors", "crosses", "all", "file"])
+    parser.add_argument("--pairs-file", default=None, help="File with one instrument id per line (for --universe=file)")
+    parser.add_argument("--max-workers", type=int, default=4, help="Parallel workers")
+    parser.add_argument("--rps", type=float, default=2.0, help="Global requests/sec limit")
+    parser.add_argument("--timeout", type=int, default=30, help="HTTP timeout (seconds)")
+    parser.add_argument("--retries", type=int, default=2, help="Retries per file on transient errors")
+    parser.add_argument("--backoff", type=float, default=1.0, help="Base backoff seconds for retries")
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite existing output files")
+    parser.add_argument("--user-agent", default="dukascopy-m1-downloader/1.2", help="Custom User-Agent header")
+    parser.add_argument("--tick-scale-non-jpy", type=int, default=5, help="Heuristic tick scale for non-JPY quotes")
+    parser.add_argument("--tick-scale-jpy", type=int, default=3, help="Heuristic tick scale for JPY quote pairs")
+    args = parser.parse_args(argv)
+
+    start = parse_date(args.start)
+    end = parse_date(args.end)
+    if end <= start:
+        print("ERROR: --end must be after --start (end is exclusive).", file=sys.stderr)
+        return 2
+    instruments = resolve_instruments(args.universe.lower(), args.pairs_file, args.timeout, args.user_agent)
+    if not instruments:
+        print("ERROR: instrument list resolved to empty.", file=sys.stderr)
+        return 2
+    days = list(daterange(start, end))
+    jobs = [Job(inst, day) for inst in instruments for day in days]
+    limiter = RateLimiter(args.rps) if args.rps > 0 else None
+    print(f"Universe={args.universe} instruments={len(instruments)} days={len(days)} jobs={len(jobs)}")
+    print(f"Output dir: {os.path.abspath(args.out)}")
+    print(f"Side: {args.side} | workers={args.max_workers} | rps={args.rps}")
+    ok = skipped = failed = 0
+    with ThreadPoolExecutor(max_workers=args.max_workers) as executor:
+        futures = [executor.submit(download_and_convert_one, job, args.out, args.side, args.overwrite, args.timeout, args.retries, args.backoff, limiter, args.user_agent, args.tick_scale_non_jpy, args.tick_scale_jpy) for job in jobs]
+        for i, future in enumerate(as_completed(futures), start=1):
+            job, status = future.result()
+            ok += int(status.startswith("OK"))
+            skipped += int(status.startswith(("SKIP", "NO_DATA", "EMPTY")))
+            failed += int(not status.startswith(("OK", "SKIP", "NO_DATA", "EMPTY")))
+            print(f"{job.instrument_id} {job.day}: {status}")
+            if i % 50 == 0 or i == len(jobs):
+                print(f"Progress: ok={ok} skipped={skipped} failed={failed} / {len(jobs)}")
+    print(f"Done: ok={ok} skipped={skipped} failed={failed} total={len(jobs)}")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/data/dukascopy_fx_m1/get_dataset.sh
+++ b/data/dukascopy_fx_m1/get_dataset.sh
@@ -9,31 +9,47 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 RAW_INPUT="${1:-${SCRIPT_DIR}/raw/eurusd}"
 INTEGER_CSV="${DUKASCOPY_MC_INPUT_CSV:-${SCRIPT_DIR}/input.csv}"
 OUTPUT_ROOT="${DUKASCOPY_MC_OUTPUT_ROOT:-dukascopy_fx_m1}"
-PRICE_MIN="${DUKASCOPY_PRICE_MIN:-0}"
-PRICE_MAX="${DUKASCOPY_PRICE_MAX:-300000}"
-VOLUME_MAX="${DUKASCOPY_VOLUME_MAX:-100000000}"
+STATS_DIR="${DUKASCOPY_STATS_DIR:-${SCRIPT_DIR}/stats}"
+DELTA_STATES="${DUKASCOPY_DELTA_STATES:-257}"
 
-python3 "${SCRIPT_DIR}/prepare_dukascopy_csv_for_mc_int.py" \
-  "$RAW_INPUT" \
-  --output_csv "$INTEGER_CSV" \
-  --price-scale "${DUKASCOPY_PRICE_SCALE:-100000}" \
-  --volume-scale "${DUKASCOPY_VOLUME_SCALE:-1000}" \
-  ${DUKASCOPY_INCLUDE_WEEKDAY:+--include-weekday}
+PREPARE_ARGS=(
+  "$RAW_INPUT"
+  --output_csv "$INTEGER_CSV"
+  --stats-dir "$STATS_DIR"
+  --price-scale "${DUKASCOPY_PRICE_SCALE:-100000}"
+  --volume-scale "${DUKASCOPY_VOLUME_SCALE:-1000}"
+  --delta-states "$DELTA_STATES"
+  --lower-percentile "${DUKASCOPY_DELTA_LOWER_PERCENTILE:-5}"
+  --upper-percentile "${DUKASCOPY_DELTA_UPPER_PERCENTILE:-95}"
+)
+
+if [[ -n "${DUKASCOPY_LOG_DELTA:-}" ]]; then
+  PREPARE_ARGS+=(--log-delta)
+fi
+
+if [[ -n "${DUKASCOPY_DELTA_THRESHOLDS:-}" ]]; then
+  read -r -a THRESHOLD_SPECS <<<"$DUKASCOPY_DELTA_THRESHOLDS"
+  for spec in "${THRESHOLD_SPECS[@]}"; do
+    PREPARE_ARGS+=(--delta-threshold "$spec")
+  done
+fi
+
+python3 "${SCRIPT_DIR}/prepare_dukascopy_csv_for_mc_int.py" "${PREPARE_ARGS[@]}"
 
 CSV_MC_ARGS=(
   "$INTEGER_CSV"
   --output_root "$OUTPUT_ROOT"
   --train_ratio "${DUKASCOPY_TRAIN_RATIO:-0.9}"
+  --range minute_mod_10:0:9
+  --range minute_of_hour:0:59
   --range minute_of_day:0:1439
-  --range open_ticks:"$PRICE_MIN":"$PRICE_MAX"
-  --range high_ticks:"$PRICE_MIN":"$PRICE_MAX"
-  --range low_ticks:"$PRICE_MIN":"$PRICE_MAX"
-  --range close_ticks:"$PRICE_MIN":"$PRICE_MAX"
-  --range volume_ticks:0:"$VOLUME_MAX"
+  --range minute_of_week:0:10079
+  --range minute_of_year:0:527039
+  --range open_delta_state:0:$((DELTA_STATES - 1))
+  --range high_delta_state:0:$((DELTA_STATES - 1))
+  --range low_delta_state:0:$((DELTA_STATES - 1))
+  --range close_delta_state:0:$((DELTA_STATES - 1))
+  --range volume_delta_state:0:$((DELTA_STATES - 1))
 )
-
-if [[ -n "${DUKASCOPY_INCLUDE_WEEKDAY:-}" ]]; then
-  CSV_MC_ARGS+=(--range weekday:0:6)
-fi
 
 "${REPO_ROOT}/data/csv_mc_int/get_dataset.sh" "${CSV_MC_ARGS[@]}"

--- a/data/dukascopy_fx_m1/get_dataset.sh
+++ b/data/dukascopy_fx_m1/get_dataset.sh
@@ -43,8 +43,8 @@ CSV_MC_ARGS=(
   --range minute_mod_10:0:9
   --range minute_of_hour:0:59
   --range minute_of_day:0:1439
-  --range minute_of_week:0:10079
-  --range minute_of_year:0:527039
+  --range day_of_week:0:6
+  --range week_of_year:1:53
   --range open_delta_state:0:$((DELTA_STATES - 1))
   --range high_delta_state:0:$((DELTA_STATES - 1))
   --range low_delta_state:0:$((DELTA_STATES - 1))

--- a/data/dukascopy_fx_m1/get_dataset.sh
+++ b/data/dukascopy_fx_m1/get_dataset.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Convert downloaded Dukascopy M1 CSV(.gz) candles into regular integer
+# multicontext datasets by reusing data/csv_mc_int's pipeline.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+RAW_INPUT="${1:-${SCRIPT_DIR}/raw/eurusd}"
+INTEGER_CSV="${DUKASCOPY_MC_INPUT_CSV:-${SCRIPT_DIR}/input.csv}"
+OUTPUT_ROOT="${DUKASCOPY_MC_OUTPUT_ROOT:-dukascopy_fx_m1}"
+PRICE_MIN="${DUKASCOPY_PRICE_MIN:-0}"
+PRICE_MAX="${DUKASCOPY_PRICE_MAX:-300000}"
+VOLUME_MAX="${DUKASCOPY_VOLUME_MAX:-100000000}"
+
+python3 "${SCRIPT_DIR}/prepare_dukascopy_csv_for_mc_int.py" \
+  "$RAW_INPUT" \
+  --output_csv "$INTEGER_CSV" \
+  --price-scale "${DUKASCOPY_PRICE_SCALE:-100000}" \
+  --volume-scale "${DUKASCOPY_VOLUME_SCALE:-1000}" \
+  ${DUKASCOPY_INCLUDE_WEEKDAY:+--include-weekday}
+
+CSV_MC_ARGS=(
+  "$INTEGER_CSV"
+  --output_root "$OUTPUT_ROOT"
+  --train_ratio "${DUKASCOPY_TRAIN_RATIO:-0.9}"
+  --range minute_of_day:0:1439
+  --range open_ticks:"$PRICE_MIN":"$PRICE_MAX"
+  --range high_ticks:"$PRICE_MIN":"$PRICE_MAX"
+  --range low_ticks:"$PRICE_MIN":"$PRICE_MAX"
+  --range close_ticks:"$PRICE_MIN":"$PRICE_MAX"
+  --range volume_ticks:0:"$VOLUME_MAX"
+)
+
+if [[ -n "${DUKASCOPY_INCLUDE_WEEKDAY:-}" ]]; then
+  CSV_MC_ARGS+=(--range weekday:0:6)
+fi
+
+"${REPO_ROOT}/data/csv_mc_int/get_dataset.sh" "${CSV_MC_ARGS[@]}"

--- a/data/dukascopy_fx_m1/prepare_dukascopy_csv_for_mc_int.py
+++ b/data/dukascopy_fx_m1/prepare_dukascopy_csv_for_mc_int.py
@@ -1,16 +1,22 @@
 #!/usr/bin/env python3
-"""Convert Dukascopy M1 CSV(.gz) candles into integer columns for csv_mc_int."""
+"""Convert Dukascopy M1 CSV(.gz) candles into compact integer columns."""
 
 from __future__ import annotations
 
 import argparse
 import csv
 import gzip
+import json
+import math
+import struct
+import zlib
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Sequence
 
-PRICE_COLUMNS = ("open", "high", "low", "close")
+TICK_COLUMNS = ("open", "high", "low", "close", "volume")
+DELTA_STATE_COLUMNS = tuple(f"{column}_delta_state" for column in TICK_COLUMNS)
+TIME_COLUMNS = ("minute_mod_10", "minute_of_hour", "minute_of_day", "minute_of_week", "minute_of_year")
 
 
 def open_text(path: Path):
@@ -38,50 +44,229 @@ def iter_input_paths(paths: Iterable[str]) -> list[Path]:
     return resolved
 
 
+def percentile(values: Sequence[int], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return float(ordered[0])
+    rank = (len(ordered) - 1) * (pct / 100.0)
+    lo = math.floor(rank)
+    hi = math.ceil(rank)
+    if lo == hi:
+        return float(ordered[lo])
+    weight = rank - lo
+    return float(ordered[lo] * (1.0 - weight) + ordered[hi] * weight)
+
+
+def make_delta_thresholds(values: Sequence[int], lower_pct: float, upper_pct: float, minimum_width: float) -> tuple[float, float]:
+    negative_magnitudes = [abs(value) for value in values if value < 0]
+    positive_values = [value for value in values if value > 0]
+    lower = -percentile(negative_magnitudes, upper_pct) if negative_magnitudes else 0.0
+    upper = percentile(positive_values, upper_pct) if positive_values else 0.0
+    # Fall back to all-value percentiles for degenerate constant-zero columns,
+    # then force a non-empty range that still includes zero.
+    if lower >= upper:
+        lower = min(0.0, percentile(values, lower_pct))
+        upper = max(0.0, percentile(values, upper_pct))
+    if lower >= upper:
+        half_width = max(minimum_width / 2.0, 1.0)
+        lower = -half_width
+        upper = half_width
+    return lower, upper
+
+
+def signed_log1p(value: float) -> float:
+    return math.copysign(math.log1p(abs(value)), value)
+
+
+def encode_delta_state(value: int, lower: float, upper: float, states: int, use_log: bool) -> int:
+    clipped = min(max(float(value), lower), upper)
+    lo = float(lower)
+    hi = float(upper)
+    if use_log:
+        clipped = signed_log1p(clipped)
+        lo = signed_log1p(lo)
+        hi = signed_log1p(hi)
+    if hi <= lo:
+        return states // 2
+    scaled = (clipped - lo) / (hi - lo)
+    return min(max(round(scaled * (states - 1)), 0), states - 1)
+
+
+def png_chunk(tag: bytes, payload: bytes) -> bytes:
+    return struct.pack("!I", len(payload)) + tag + payload + struct.pack("!I", zlib.crc32(tag + payload) & 0xFFFFFFFF)
+
+
+def write_histogram_png(path: Path, values: Sequence[int], bins: int = 80, width: int = 960, height: int = 540) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not values:
+        values = [0]
+    v_min = min(values)
+    v_max = max(values)
+    if v_min == v_max:
+        v_min -= 1
+        v_max += 1
+    bins = max(1, bins)
+    counts = [0] * bins
+    span = v_max - v_min
+    for value in values:
+        idx = min(int((value - v_min) / span * bins), bins - 1)
+        counts[idx] += 1
+
+    pixels = bytearray([255, 255, 255] * width * height)
+
+    def set_px(x: int, y: int, color: tuple[int, int, int]) -> None:
+        if 0 <= x < width and 0 <= y < height:
+            off = (y * width + x) * 3
+            pixels[off : off + 3] = bytes(color)
+
+    margin_l, margin_r, margin_t, margin_b = 72, 24, 36, 60
+    plot_w = width - margin_l - margin_r
+    plot_h = height - margin_t - margin_b
+    axis = (40, 40, 40)
+    bar = (65, 105, 225)
+    grid = (225, 225, 225)
+    for i in range(6):
+        y = margin_t + round(i * plot_h / 5)
+        for x in range(margin_l, margin_l + plot_w + 1):
+            set_px(x, y, grid)
+    for x in range(margin_l, margin_l + plot_w + 1):
+        set_px(x, margin_t + plot_h, axis)
+    for y in range(margin_t, margin_t + plot_h + 1):
+        set_px(margin_l, y, axis)
+
+    max_count = max(counts) or 1
+    for idx, count in enumerate(counts):
+        x0 = margin_l + round(idx * plot_w / bins)
+        x1 = min(margin_l + round((idx + 1) * plot_w / bins), margin_l + plot_w)
+        bar_h = round((count / max_count) * (plot_h - 1))
+        for x in range(x0, max(x0 + 1, x1 - 1)):
+            for y in range(margin_t + plot_h - bar_h, margin_t + plot_h):
+                set_px(x, y, bar)
+
+    # Minimal machine-readable labels in sidecar JSON are more useful than
+    # bitmap text here; the PNG intentionally remains dependency-free.
+    raw_rows = [b"\x00" + bytes(pixels[y * width * 3 : (y + 1) * width * 3]) for y in range(height)]
+    png = b"\x89PNG\r\n\x1a\n" + png_chunk(b"IHDR", struct.pack("!IIBBBBB", width, height, 8, 2, 0, 0, 0)) + png_chunk(b"IDAT", zlib.compress(b"".join(raw_rows), 9)) + png_chunk(b"IEND", b"")
+    path.write_bytes(png)
+
+
+def time_features(ts: datetime) -> list[int]:
+    minute_of_day = ts.hour * 60 + ts.minute
+    minute_of_week = ts.weekday() * 24 * 60 + minute_of_day
+    minute_of_year = (ts.timetuple().tm_yday - 1) * 24 * 60 + minute_of_day
+    return [minute_of_day % 10, ts.minute, minute_of_day, minute_of_week, minute_of_year]
+
+
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Build an integer training CSV from Dukascopy candle CSV files.")
+    parser = argparse.ArgumentParser(description="Build a compact integer training CSV from Dukascopy candle CSV files.")
     parser.add_argument("inputs", nargs="+", help="Input .csv/.csv.gz files or directories containing them.")
     parser.add_argument("--output_csv", default="data/dukascopy_fx_m1/input.csv", help="Integer CSV to write for data/csv_mc_int/get_dataset.sh.")
+    parser.add_argument("--stats-dir", default="data/dukascopy_fx_m1/stats", help="Directory for stats JSON and histogram PNGs.")
     parser.add_argument("--price-scale", type=int, default=100000, help="Multiplier applied to OHLC prices before rounding to integer ticks.")
     parser.add_argument("--volume-scale", type=int, default=1000, help="Multiplier applied to volume before rounding to integer ticks.")
-    parser.add_argument("--include-weekday", action="store_true", help="Include UTC weekday column (0=Monday ... 6=Sunday).")
+    parser.add_argument("--delta-states", type=int, default=257, help="Number of discrete states for each saturated derivative column.")
+    parser.add_argument("--lower-percentile", type=float, default=5.0, help="Lower derivative percentile used as the default negative saturation threshold.")
+    parser.add_argument("--upper-percentile", type=float, default=95.0, help="Upper derivative percentile used as the default positive saturation threshold.")
+    parser.add_argument("--delta-threshold", action="append", default=[], help="Override a column threshold as <open|high|low|close|volume>:<min>:<max>.")
+    parser.add_argument("--log-delta", action="store_true", help="Apply signed log1p preprocessing before bucketing saturated derivative values.")
     args = parser.parse_args()
+
+    if args.delta_states < 2:
+        raise ValueError("--delta-states must be at least 2")
+    if not (0.0 <= args.lower_percentile < args.upper_percentile <= 100.0):
+        raise ValueError("Expected 0 <= --lower-percentile < --upper-percentile <= 100")
 
     input_paths = iter_input_paths(args.inputs)
     if not input_paths:
         raise ValueError("No input CSV files found")
 
+    manual_thresholds: dict[str, tuple[float, float]] = {}
+    for spec in args.delta_threshold:
+        parts = spec.split(":")
+        if len(parts) != 3 or parts[0] not in TICK_COLUMNS:
+            raise ValueError("--delta-threshold must be <open|high|low|close|volume>:<min>:<max>")
+        lo, hi = float(parts[1]), float(parts[2])
+        if lo >= hi:
+            raise ValueError(f"Invalid threshold for {parts[0]}: min must be < max")
+        manual_thresholds[parts[0]] = (lo, hi)
+
+    rows: list[dict[str, object]] = []
+    raw_ticks: dict[str, list[int]] = {column: [] for column in TICK_COLUMNS}
+    for input_path in input_paths:
+        with open_text(input_path) as in_f:
+            reader = csv.DictReader(in_f)
+            missing = {"timestamp_utc", *TICK_COLUMNS}.difference(reader.fieldnames or [])
+            if missing:
+                raise ValueError(f"{input_path} missing required columns: {sorted(missing)}")
+            for row in reader:
+                ticks = {column: round(float(row[column]) * (args.volume_scale if column == "volume" else args.price_scale)) for column in TICK_COLUMNS}
+                ts = parse_timestamp_utc(row["timestamp_utc"])
+                rows.append({"ts": ts, "ticks": ticks})
+                for column, value in ticks.items():
+                    raw_ticks[column].append(value)
+
+    if len(rows) < 2:
+        raise ValueError(f"Need at least two candle rows for train/val split; found {len(rows)}")
+
+    deltas: dict[str, list[int]] = {column: [] for column in TICK_COLUMNS}
+    previous: dict[str, int] | None = None
+    for row in rows:
+        ticks = row["ticks"]
+        assert isinstance(ticks, dict)
+        for column in TICK_COLUMNS:
+            current = int(ticks[column])
+            deltas[column].append(0 if previous is None else current - previous[column])
+        previous = {column: int(ticks[column]) for column in TICK_COLUMNS}
+
+    thresholds: dict[str, tuple[float, float]] = {}
+    stats_dir = Path(args.stats_dir)
+    stats_dir.mkdir(parents=True, exist_ok=True)
+    stats = {
+        "rows": len(rows),
+        "delta_states": args.delta_states,
+        "lower_percentile": args.lower_percentile,
+        "upper_percentile": args.upper_percentile,
+        "log_delta": bool(args.log_delta),
+        "columns": {},
+    }
+    for column in TICK_COLUMNS:
+        thresholds[column] = manual_thresholds.get(column) or make_delta_thresholds(deltas[column], args.lower_percentile, args.upper_percentile, 1.0)
+        lower, upper = thresholds[column]
+        stats["columns"][column] = {
+            "raw_ticks_min": min(raw_ticks[column]),
+            "raw_ticks_max": max(raw_ticks[column]),
+            "delta_min": min(deltas[column]),
+            "delta_max": max(deltas[column]),
+            "delta_saturation_min": lower,
+            "delta_saturation_max": upper,
+            "raw_histogram_png": str(stats_dir / f"{column}_ticks_hist.png"),
+            "delta_histogram_png": str(stats_dir / f"{column}_delta_hist.png"),
+        }
+        write_histogram_png(stats_dir / f"{column}_ticks_hist.png", raw_ticks[column])
+        write_histogram_png(stats_dir / f"{column}_delta_hist.png", deltas[column])
+
     output_csv = Path(args.output_csv)
     output_csv.parent.mkdir(parents=True, exist_ok=True)
-    header = ["minute_of_day"]
-    if args.include_weekday:
-        header.append("weekday")
-    header.extend(["open_ticks", "high_ticks", "low_ticks", "close_ticks", "volume_ticks"])
-
-    rows_written = 0
+    header = [*TIME_COLUMNS, *DELTA_STATE_COLUMNS]
     with output_csv.open("w", newline="", encoding="utf-8") as out_f:
         writer = csv.writer(out_f)
         writer.writerow(header)
-        for input_path in input_paths:
-            with open_text(input_path) as in_f:
-                reader = csv.DictReader(in_f)
-                missing = {"timestamp_utc", "volume", *PRICE_COLUMNS}.difference(reader.fieldnames or [])
-                if missing:
-                    raise ValueError(f"{input_path} missing required columns: {sorted(missing)}")
-                for row in reader:
-                    ts = parse_timestamp_utc(row["timestamp_utc"])
-                    out_row = [ts.hour * 60 + ts.minute]
-                    if args.include_weekday:
-                        out_row.append(ts.weekday())
-                    for column in PRICE_COLUMNS:
-                        out_row.append(round(float(row[column]) * args.price_scale))
-                    out_row.append(round(float(row["volume"]) * args.volume_scale))
-                    writer.writerow(out_row)
-                    rows_written += 1
+        for row_idx, row in enumerate(rows):
+            ts = row["ts"]
+            assert isinstance(ts, datetime)
+            out_row = time_features(ts)
+            for column in TICK_COLUMNS:
+                lower, upper = thresholds[column]
+                out_row.append(encode_delta_state(deltas[column][row_idx], lower, upper, args.delta_states, args.log_delta))
+            writer.writerow(out_row)
 
-    if rows_written < 2:
-        raise ValueError(f"Need at least two candle rows for train/val split; wrote {rows_written}")
-    print(f"Wrote {rows_written} rows to {output_csv}")
+    with (stats_dir / "stats.json").open("w", encoding="utf-8") as f:
+        json.dump(stats, f, indent=2)
+
+    print(f"Wrote {len(rows)} rows to {output_csv}")
+    print(f"Wrote derivative stats and histograms to {stats_dir}")
 
 
 if __name__ == "__main__":

--- a/data/dukascopy_fx_m1/prepare_dukascopy_csv_for_mc_int.py
+++ b/data/dukascopy_fx_m1/prepare_dukascopy_csv_for_mc_int.py
@@ -16,7 +16,7 @@ from typing import Iterable, Sequence
 
 TICK_COLUMNS = ("open", "high", "low", "close", "volume")
 DELTA_STATE_COLUMNS = tuple(f"{column}_delta_state" for column in TICK_COLUMNS)
-TIME_COLUMNS = ("minute_mod_10", "minute_of_hour", "minute_of_day", "minute_of_week", "minute_of_year")
+TIME_COLUMNS = ("minute_mod_10", "minute_of_hour", "minute_of_day", "day_of_week", "week_of_year")
 
 
 def open_text(path: Path):
@@ -154,9 +154,9 @@ def write_histogram_png(path: Path, values: Sequence[int], bins: int = 80, width
 
 def time_features(ts: datetime) -> list[int]:
     minute_of_day = ts.hour * 60 + ts.minute
-    minute_of_week = ts.weekday() * 24 * 60 + minute_of_day
-    minute_of_year = (ts.timetuple().tm_yday - 1) * 24 * 60 + minute_of_day
-    return [minute_of_day % 10, ts.minute, minute_of_day, minute_of_week, minute_of_year]
+    day_of_week = ts.weekday()
+    week_of_year = ts.isocalendar().week
+    return [minute_of_day % 10, ts.minute, minute_of_day, day_of_week, week_of_year]
 
 
 def main() -> None:

--- a/data/dukascopy_fx_m1/prepare_dukascopy_csv_for_mc_int.py
+++ b/data/dukascopy_fx_m1/prepare_dukascopy_csv_for_mc_int.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Convert Dukascopy M1 CSV(.gz) candles into integer columns for csv_mc_int."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import gzip
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+PRICE_COLUMNS = ("open", "high", "low", "close")
+
+
+def open_text(path: Path):
+    if path.suffix == ".gz":
+        return gzip.open(path, "rt", newline="", encoding="utf-8")
+    return path.open("r", newline="", encoding="utf-8")
+
+
+def parse_timestamp_utc(text: str) -> datetime:
+    value = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def iter_input_paths(paths: Iterable[str]) -> list[Path]:
+    resolved: list[Path] = []
+    for raw in paths:
+        path = Path(raw)
+        if path.is_dir():
+            resolved.extend(sorted(path.rglob("*.csv")))
+            resolved.extend(sorted(path.rglob("*.csv.gz")))
+        else:
+            resolved.append(path)
+    return resolved
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build an integer training CSV from Dukascopy candle CSV files.")
+    parser.add_argument("inputs", nargs="+", help="Input .csv/.csv.gz files or directories containing them.")
+    parser.add_argument("--output_csv", default="data/dukascopy_fx_m1/input.csv", help="Integer CSV to write for data/csv_mc_int/get_dataset.sh.")
+    parser.add_argument("--price-scale", type=int, default=100000, help="Multiplier applied to OHLC prices before rounding to integer ticks.")
+    parser.add_argument("--volume-scale", type=int, default=1000, help="Multiplier applied to volume before rounding to integer ticks.")
+    parser.add_argument("--include-weekday", action="store_true", help="Include UTC weekday column (0=Monday ... 6=Sunday).")
+    args = parser.parse_args()
+
+    input_paths = iter_input_paths(args.inputs)
+    if not input_paths:
+        raise ValueError("No input CSV files found")
+
+    output_csv = Path(args.output_csv)
+    output_csv.parent.mkdir(parents=True, exist_ok=True)
+    header = ["minute_of_day"]
+    if args.include_weekday:
+        header.append("weekday")
+    header.extend(["open_ticks", "high_ticks", "low_ticks", "close_ticks", "volume_ticks"])
+
+    rows_written = 0
+    with output_csv.open("w", newline="", encoding="utf-8") as out_f:
+        writer = csv.writer(out_f)
+        writer.writerow(header)
+        for input_path in input_paths:
+            with open_text(input_path) as in_f:
+                reader = csv.DictReader(in_f)
+                missing = {"timestamp_utc", "volume", *PRICE_COLUMNS}.difference(reader.fieldnames or [])
+                if missing:
+                    raise ValueError(f"{input_path} missing required columns: {sorted(missing)}")
+                for row in reader:
+                    ts = parse_timestamp_utc(row["timestamp_utc"])
+                    out_row = [ts.hour * 60 + ts.minute]
+                    if args.include_weekday:
+                        out_row.append(ts.weekday())
+                    for column in PRICE_COLUMNS:
+                        out_row.append(round(float(row[column]) * args.price_scale))
+                    out_row.append(round(float(row["volume"]) * args.volume_scale))
+                    writer.writerow(out_row)
+                    rows_written += 1
+
+    if rows_written < 2:
+        raise ValueError(f"Need at least two candle rows for train/val split; wrote {rows_written}")
+    print(f"Wrote {rows_written} rows to {output_csv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/timeseries_viewer/README.md
+++ b/data/timeseries_viewer/README.md
@@ -1,0 +1,41 @@
+# Time-series Prediction Viewer
+
+`generate_timeseries_comparison.py` builds a small holdout comparison bundle for
+integer multicontext CSV time series:
+
+1. Split a prepared full CSV into an inference prompt and a tail holdout set.
+2. Run `sample.py` for every requested random seed at both `top_k=1` and
+   `top_k=5` (configurable).
+3. Write an HTML page that overlays the prompt tail, ground-truth holdout, and
+   every sampled forecast for each column.
+
+The generated HTML is self-contained and uses browser canvas rendering, so it
+has no Plotly or JavaScript package dependency.
+
+## Dukascopy example
+
+After training `demos/dukascopy_fx_m1_csv_mc_int_demo.sh`, run:
+
+```bash
+python3 data/timeseries_viewer/generate_timeseries_comparison.py \
+  --input_csv data/dukascopy_fx_m1/input.csv \
+  --manifest data/dukascopy_fx_m1/manifest.json \
+  --checkpoint_dir out/dukascopy_fx_m1 \
+  --work_dir out/dukascopy_fx_m1/timeseries_viewer \
+  --holdout_rows 128 \
+  --prompt_rows 512 \
+  --seeds 1337 1338 1339 \
+  --top_k 1 5
+```
+
+Open:
+
+```text
+out/dukascopy_fx_m1/timeseries_viewer/timeseries_prediction_vs_truth.html
+```
+
+The holdout rows are excluded from the prompt sent to `sample.py`, so they are
+only used as ground truth for the graph.
+
+For a quick viewer smoke test without a checkpoint, add `--skip_sampling`; this
+writes the prompt, holdout CSV, and HTML with just the ground-truth series.

--- a/data/timeseries_viewer/README.md
+++ b/data/timeseries_viewer/README.md
@@ -9,8 +9,8 @@ integer multicontext CSV time series:
 3. Write an HTML page that overlays the prompt tail, ground-truth holdout, and
    every sampled forecast for every column at the same time.
 
-The generated HTML is self-contained and uses browser canvas rendering, so it
-has no Plotly or JavaScript package dependency.
+The generated HTML uses one Plotly graph per column and loads Plotly from the
+official CDN, so no Python Plotly package is required to generate the file.
 
 ## Dukascopy example
 

--- a/data/timeseries_viewer/README.md
+++ b/data/timeseries_viewer/README.md
@@ -4,10 +4,10 @@
 integer multicontext CSV time series:
 
 1. Split a prepared full CSV into an inference prompt and a tail holdout set.
-2. Run `sample.py` for every requested random seed at both `top_k=1` and
-   `top_k=5` (configurable).
+2. Run `sample.py` for every requested random seed at `top_k=1`, `top_k=5`, and
+   `top_k=10` (configurable).
 3. Write an HTML page that overlays the prompt tail, ground-truth holdout, and
-   every sampled forecast for each column.
+   every sampled forecast for every column at the same time.
 
 The generated HTML is self-contained and uses browser canvas rendering, so it
 has no Plotly or JavaScript package dependency.
@@ -24,8 +24,8 @@ python3 data/timeseries_viewer/generate_timeseries_comparison.py \
   --work_dir out/dukascopy_fx_m1/timeseries_viewer \
   --holdout_rows 128 \
   --prompt_rows 512 \
-  --seeds 1337 1338 1339 \
-  --top_k 1 5
+  --seeds 1337 1338 1339 1340 1341 \
+  --top_k 1 5 10
 ```
 
 Open:

--- a/data/timeseries_viewer/generate_timeseries_comparison.py
+++ b/data/timeseries_viewer/generate_timeseries_comparison.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Sample multicontext time-series forecasts and render prediction vs truth HTML."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import html
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class SeriesRun:
+    label: str
+    top_k: int
+    seed: int
+    csv_path: Path
+
+
+def read_csv_rows(path: Path) -> tuple[list[str], list[list[str]]]:
+    with path.open("r", newline="", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        try:
+            header = next(reader)
+        except StopIteration as exc:
+            raise ValueError(f"CSV is empty: {path}") from exc
+        rows = [row for row in reader if row]
+    return header, rows
+
+
+def write_csv(path: Path, header: list[str], rows: Iterable[list[str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(header)
+        writer.writerows(rows)
+
+
+def numeric_rows(rows: list[list[str]]) -> list[list[float | None]]:
+    parsed: list[list[float | None]] = []
+    for row in rows:
+        parsed_row: list[float | None] = []
+        for cell in row:
+            try:
+                parsed_row.append(float(cell))
+            except ValueError:
+                parsed_row.append(None)
+        parsed.append(parsed_row)
+    return parsed
+
+
+def load_manifest_datasets(path: Path) -> list[str]:
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    datasets = manifest.get("multicontext_datasets")
+    if not isinstance(datasets, list) or not datasets:
+        raise ValueError(f"manifest has no multicontext_datasets: {path}")
+    return [str(dataset) for dataset in datasets]
+
+
+def run_sample(
+    *,
+    repo_root: Path,
+    checkpoint_dir: Path,
+    prompt_csv: Path,
+    output_csv: Path,
+    datasets: list[str],
+    max_new_tokens: int,
+    top_k: int,
+    seed: int,
+    device: str,
+    dtype: str,
+    compile_model: bool,
+) -> None:
+    cmd = [
+        sys.executable,
+        "sample.py",
+        "--out_dir",
+        str(checkpoint_dir),
+        "--device",
+        device,
+        "--dtype",
+        dtype,
+        "--multicontext",
+        "--multicontext_datasets",
+        *datasets,
+        "--multicontext_csv_input",
+        str(prompt_csv),
+        "--multicontext_csv_output_file",
+        str(output_csv),
+        "--no-multicontext_csv_output_include_prompt",
+        "--max_new_tokens",
+        str(max_new_tokens),
+        "--top_k",
+        str(top_k),
+        "--seed",
+        str(seed),
+        "--num_samples",
+        "1",
+        "--no-print_model_info",
+    ]
+    if compile_model:
+        cmd.append("--compile")
+    else:
+        cmd.append("--no-compile")
+    print("Running:", " ".join(cmd))
+    subprocess.run(cmd, cwd=repo_root, check=True)
+
+
+def write_viewer_html(
+    *,
+    output_html: Path,
+    title: str,
+    header: list[str],
+    prompt_rows: list[list[str]],
+    truth_rows: list[list[str]],
+    runs: list[SeriesRun],
+) -> None:
+    samples = []
+    for run in runs:
+        if not run.csv_path.exists():
+            continue
+        sample_header, sample_rows = read_csv_rows(run.csv_path)
+        samples.append(
+            {
+                "label": run.label,
+                "top_k": run.top_k,
+                "seed": run.seed,
+                "header": sample_header,
+                "rows": numeric_rows(sample_rows),
+            }
+        )
+
+    payload = {
+        "title": title,
+        "header": header,
+        "promptRows": numeric_rows(prompt_rows),
+        "truthRows": numeric_rows(truth_rows),
+        "samples": samples,
+        "createdAt": datetime.now().isoformat(timespec="seconds"),
+    }
+    json_payload = json.dumps(payload).replace("</", "<\\/")
+    escaped_title = html.escape(title)
+    output_html.parent.mkdir(parents=True, exist_ok=True)
+    output_html.write_text(
+        f"""<!doctype html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\" />
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+  <title>{escaped_title}</title>
+  <style>
+    :root {{ color-scheme: dark; font-family: system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", sans-serif; }}
+    body {{ margin: 0; padding: 20px; background: #101114; color: #eee; }}
+    h1 {{ margin-top: 0; font-size: 22px; }}
+    .panel {{ background: #191b20; border: 1px solid #333842; border-radius: 10px; padding: 14px; margin-bottom: 16px; }}
+    .controls {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; align-items: end; }}
+    label {{ display: grid; gap: 5px; font-size: 13px; color: #cdd1d7; }}
+    select, input {{ width: 100%; box-sizing: border-box; padding: 8px; border-radius: 7px; border: 1px solid #454b57; background: #0d0e11; color: #eee; }}
+    canvas {{ width: 100%; height: 260px; background: #08090b; border: 1px solid #343a46; border-radius: 8px; }}
+    .chart {{ margin-bottom: 18px; }}
+    .legend {{ display: flex; flex-wrap: wrap; gap: 10px; font-size: 12px; margin-top: 8px; }}
+    .legend span {{ display: inline-flex; align-items: center; gap: 5px; }}
+    .swatch {{ width: 18px; height: 3px; display: inline-block; }}
+    .meta {{ color: #aeb4bf; font-size: 13px; }}
+  </style>
+</head>
+<body>
+  <h1>{escaped_title}</h1>
+  <section class=\"panel controls\">
+    <label>Column<select id=\"columnSelect\"></select></label>
+    <label><input id=\"showPrompt\" type=\"checkbox\" checked /> Show prompt tail</label>
+    <label><input id=\"showTruth\" type=\"checkbox\" checked /> Show ground truth holdout</label>
+    <label><input id=\"showSamples\" type=\"checkbox\" checked /> Show sampled forecasts</label>
+  </section>
+  <section class=\"panel\">
+    <div class=\"meta\" id=\"meta\"></div>
+    <div id=\"charts\"></div>
+  </section>
+<script id=\"payload\" type=\"application/json\">{json_payload}</script>
+<script>
+const data = JSON.parse(document.getElementById('payload').textContent);
+const colors = ['#ffb000', '#00d1ff', '#f05cff', '#5cff92', '#ff6b6b', '#9b8cff', '#f6ff5c', '#58a6ff'];
+const select = document.getElementById('columnSelect');
+data.header.forEach((name, idx) => select.append(new Option(name, String(idx))));
+document.getElementById('meta').textContent = `created ${{data.createdAt}} · prompt rows ${{data.promptRows.length}} · holdout rows ${{data.truthRows.length}} · samples ${{data.samples.length}}`;
+['columnSelect', 'showPrompt', 'showTruth', 'showSamples'].forEach(id => document.getElementById(id).addEventListener('change', render));
+function finite(v) {{ return typeof v === 'number' && Number.isFinite(v); }}
+function seriesValues(rows, col) {{ return rows.map(r => r[col]).filter(finite); }}
+function extent(seriesList) {{
+  const vals = seriesList.flat().filter(finite);
+  if (!vals.length) return [0, 1];
+  let lo = Math.min(...vals), hi = Math.max(...vals);
+  if (lo === hi) {{ lo -= 1; hi += 1; }}
+  return [lo, hi];
+}}
+function drawLine(ctx, values, xStart, xScale, yScale, yMax, color, width, dash=[]) {{
+  ctx.save(); ctx.strokeStyle = color; ctx.lineWidth = width; ctx.setLineDash(dash); ctx.beginPath();
+  let started = false;
+  values.forEach((v, i) => {{
+    if (!finite(v)) return;
+    const x = 50 + (xStart + i) * xScale;
+    const y = 18 + (yMax - v) * yScale;
+    if (!started) {{ ctx.moveTo(x, y); started = true; }} else {{ ctx.lineTo(x, y); }}
+  }});
+  ctx.stroke(); ctx.restore();
+}}
+function render() {{
+  const col = Number(select.value || 0);
+  const charts = document.getElementById('charts'); charts.innerHTML = '';
+  const holder = document.createElement('div'); holder.className = 'chart';
+  const title = document.createElement('h2'); title.textContent = data.header[col]; title.style.fontSize = '16px';
+  const canvas = document.createElement('canvas'); canvas.width = 1200; canvas.height = 320;
+  const legend = document.createElement('div'); legend.className = 'legend';
+  holder.append(title, canvas, legend); charts.append(holder);
+  const prompt = data.promptRows.slice(Math.max(0, data.promptRows.length - 128)).map(r => r[col]);
+  const truth = data.truthRows.map(r => r[col]);
+  const sampleSeries = data.samples.map(s => ({{label: s.label, values: s.rows.map(r => r[col])}}));
+  const visibleSeries = [];
+  if (document.getElementById('showPrompt').checked) visibleSeries.push(prompt);
+  if (document.getElementById('showTruth').checked) visibleSeries.push(truth);
+  if (document.getElementById('showSamples').checked) sampleSeries.forEach(s => visibleSeries.push(s.values));
+  const [yMin, yMax] = extent(visibleSeries);
+  const totalX = prompt.length + Math.max(truth.length, ...sampleSeries.map(s => s.values.length), 1);
+  const plotW = canvas.width - 70, plotH = canvas.height - 50;
+  const xScale = plotW / Math.max(totalX - 1, 1), yScale = plotH / (yMax - yMin);
+  const ctx = canvas.getContext('2d'); ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.strokeStyle = '#38404d'; ctx.lineWidth = 1;
+  for (let i = 0; i <= 5; i++) {{ const y = 18 + i * plotH / 5; ctx.beginPath(); ctx.moveTo(50, y); ctx.lineTo(50 + plotW, y); ctx.stroke(); }}
+  ctx.fillStyle = '#cfd6e4'; ctx.font = '12px ui-monospace, monospace'; ctx.fillText(yMax.toFixed(2), 6, 24); ctx.fillText(yMin.toFixed(2), 6, 18 + plotH);
+  const splitX = 50 + Math.max(prompt.length - 1, 0) * xScale; ctx.strokeStyle = '#666'; ctx.setLineDash([4,4]); ctx.beginPath(); ctx.moveTo(splitX, 18); ctx.lineTo(splitX, 18 + plotH); ctx.stroke(); ctx.setLineDash([]);
+  function addLegend(label, color) {{ const item = document.createElement('span'); item.innerHTML = `<i class=\"swatch\" style=\"background:${{color}}\"></i>${{label}}`; legend.append(item); }}
+  if (document.getElementById('showPrompt').checked) {{ drawLine(ctx, prompt, 0, xScale, yScale, yMax, '#8a96a8', 2); addLegend('prompt tail', '#8a96a8'); }}
+  if (document.getElementById('showTruth').checked) {{ drawLine(ctx, truth, prompt.length, xScale, yScale, yMax, '#ffffff', 3); addLegend('ground truth holdout', '#ffffff'); }}
+  if (document.getElementById('showSamples').checked) sampleSeries.forEach((s, idx) => {{ const c = colors[idx % colors.length]; drawLine(ctx, s.values, prompt.length, xScale, yScale, yMax, c, 2, [6,3]); addLegend(s.label, c); }});
+}}
+render();
+</script>
+</body>
+</html>
+""",
+        encoding="utf-8",
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run seeded top-k samples and render prediction-vs-ground-truth time-series HTML.")
+    parser.add_argument("--input_csv", default="data/dukascopy_fx_m1/input.csv", help="Prepared integer CSV containing the full series.")
+    parser.add_argument("--manifest", default="data/dukascopy_fx_m1/manifest.json", help="Dataset manifest with multicontext_datasets.")
+    parser.add_argument("--checkpoint_dir", default="out/dukascopy_fx_m1", help="Checkpoint directory passed to sample.py --out_dir.")
+    parser.add_argument("--work_dir", default="out/dukascopy_fx_m1/timeseries_viewer", help="Directory for prompt, truth, samples, and HTML.")
+    parser.add_argument("--holdout_rows", type=int, default=128, help="Tail rows excluded from prompt and used as ground truth.")
+    parser.add_argument("--prompt_rows", type=int, default=512, help="Rows immediately before holdout used as inference prompt; 0 uses all prior rows.")
+    parser.add_argument("--seeds", nargs="+", type=int, default=[1337, 1338, 1339], help="Random seeds to sample for each top-k value.")
+    parser.add_argument("--top_k", nargs="+", type=int, default=[1, 5], help="Top-k settings to run for every seed.")
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--dtype", default="bfloat16", choices=["float32", "float16", "bfloat16"])
+    parser.add_argument("--compile", dest="compile_model", default=True, action=argparse.BooleanOptionalAction)
+    parser.add_argument("--skip_sampling", action="store_true", help="Only write prompt/truth and HTML; useful for checking the viewer without a checkpoint.")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    input_csv = Path(args.input_csv)
+    if not input_csv.is_absolute():
+        input_csv = repo_root / input_csv
+    manifest_path = Path(args.manifest)
+    if not manifest_path.is_absolute():
+        manifest_path = repo_root / manifest_path
+    checkpoint_dir = Path(args.checkpoint_dir)
+    if not checkpoint_dir.is_absolute():
+        checkpoint_dir = repo_root / checkpoint_dir
+    work_dir = Path(args.work_dir)
+    if not work_dir.is_absolute():
+        work_dir = repo_root / work_dir
+
+    header, rows = read_csv_rows(input_csv)
+    if args.holdout_rows <= 0:
+        raise ValueError("--holdout_rows must be positive")
+    if len(rows) <= args.holdout_rows:
+        raise ValueError(f"Need more rows than holdout_rows={args.holdout_rows}; found {len(rows)}")
+    prompt_source = rows[: -args.holdout_rows]
+    prompt_rows = prompt_source if args.prompt_rows == 0 else prompt_source[-args.prompt_rows :]
+    truth_rows = rows[-args.holdout_rows :]
+    prompt_csv = work_dir / "prompt.csv"
+    truth_csv = work_dir / "ground_truth_holdout.csv"
+    write_csv(prompt_csv, header, prompt_rows)
+    write_csv(truth_csv, header, truth_rows)
+
+    datasets = load_manifest_datasets(manifest_path)
+    runs: list[SeriesRun] = []
+    samples_dir = work_dir / "samples"
+    if not args.skip_sampling:
+        for top_k in args.top_k:
+            for seed in args.seeds:
+                label = f"top_k={top_k} seed={seed}"
+                output_csv = samples_dir / f"sample_topk{top_k}_seed{seed}.csv"
+                run_sample(
+                    repo_root=repo_root,
+                    checkpoint_dir=checkpoint_dir,
+                    prompt_csv=prompt_csv,
+                    output_csv=output_csv,
+                    datasets=datasets,
+                    max_new_tokens=args.holdout_rows,
+                    top_k=top_k,
+                    seed=seed,
+                    device=args.device,
+                    dtype=args.dtype,
+                    compile_model=args.compile_model,
+                )
+                runs.append(SeriesRun(label=label, top_k=top_k, seed=seed, csv_path=output_csv))
+    else:
+        for path in sorted(samples_dir.glob("sample_topk*_seed*.csv")):
+            runs.append(SeriesRun(label=path.stem, top_k=-1, seed=-1, csv_path=path))
+
+    output_html = work_dir / "timeseries_prediction_vs_truth.html"
+    write_viewer_html(
+        output_html=output_html,
+        title="Time-series prediction vs ground truth",
+        header=header,
+        prompt_rows=prompt_rows,
+        truth_rows=truth_rows,
+        runs=runs,
+    )
+    print(f"Prompt CSV: {prompt_csv}")
+    print(f"Ground truth CSV: {truth_csv}")
+    print(f"Viewer HTML: {output_html}")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/timeseries_viewer/generate_timeseries_comparison.py
+++ b/data/timeseries_viewer/generate_timeseries_comparison.py
@@ -159,24 +159,36 @@ def write_viewer_html(
     body {{ margin: 0; padding: 20px; background: #101114; color: #eee; }}
     h1 {{ margin-top: 0; font-size: 22px; }}
     .panel {{ background: #191b20; border: 1px solid #333842; border-radius: 10px; padding: 14px; margin-bottom: 16px; }}
-    .controls {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; align-items: end; }}
-    label {{ display: grid; gap: 5px; font-size: 13px; color: #cdd1d7; }}
-    select, input {{ width: 100%; box-sizing: border-box; padding: 8px; border-radius: 7px; border: 1px solid #454b57; background: #0d0e11; color: #eee; }}
-    canvas {{ width: 100%; height: 260px; background: #08090b; border: 1px solid #343a46; border-radius: 8px; }}
-    .chart {{ margin-bottom: 18px; }}
+    .controls {{ display: grid; grid-template-columns: minmax(220px, 1fr) minmax(320px, 3fr); gap: 16px; align-items: start; }}
+    .global-toggles, .sample-toggles {{ display: flex; flex-wrap: wrap; gap: 10px 14px; }}
+    label {{ display: inline-flex; gap: 6px; align-items: center; font-size: 13px; color: #cdd1d7; }}
+    input {{ accent-color: #58a6ff; }}
+    canvas {{ width: 100%; height: 240px; background: #08090b; border: 1px solid #343a46; border-radius: 8px; }}
+    .chart {{ margin-bottom: 22px; }}
+    .chart h2 {{ margin: 0 0 8px; font-size: 16px; }}
     .legend {{ display: flex; flex-wrap: wrap; gap: 10px; font-size: 12px; margin-top: 8px; }}
     .legend span {{ display: inline-flex; align-items: center; gap: 5px; }}
     .swatch {{ width: 18px; height: 3px; display: inline-block; }}
-    .meta {{ color: #aeb4bf; font-size: 13px; }}
+    .meta {{ color: #aeb4bf; font-size: 13px; margin-bottom: 14px; }}
+    .hint {{ color: #aeb4bf; font-size: 12px; margin-top: 8px; }}
   </style>
 </head>
 <body>
   <h1>{escaped_title}</h1>
   <section class=\"panel controls\">
-    <label>Column<select id=\"columnSelect\"></select></label>
-    <label><input id=\"showPrompt\" type=\"checkbox\" checked /> Show prompt tail</label>
-    <label><input id=\"showTruth\" type=\"checkbox\" checked /> Show ground truth holdout</label>
-    <label><input id=\"showSamples\" type=\"checkbox\" checked /> Show sampled forecasts</label>
+    <div>
+      <strong>Global series</strong>
+      <div class=\"global-toggles\">
+        <label><input id=\"showPrompt\" type=\"checkbox\" checked /> prompt tail</label>
+        <label><input id=\"showTruth\" type=\"checkbox\" checked /> ground truth holdout</label>
+      </div>
+      <div class=\"hint\">All columns are shown below at the same time.</div>
+    </div>
+    <div>
+      <strong>Inference runs</strong>
+      <div class=\"sample-toggles\" id=\"sampleToggles\"></div>
+      <div class=\"hint\">Turn individual seeds/top-k runs on or off without regenerating the page.</div>
+    </div>
   </section>
   <section class=\"panel\">
     <div class=\"meta\" id=\"meta\"></div>
@@ -185,13 +197,19 @@ def write_viewer_html(
 <script id=\"payload\" type=\"application/json\">{json_payload}</script>
 <script>
 const data = JSON.parse(document.getElementById('payload').textContent);
-const colors = ['#ffb000', '#00d1ff', '#f05cff', '#5cff92', '#ff6b6b', '#9b8cff', '#f6ff5c', '#58a6ff'];
-const select = document.getElementById('columnSelect');
-data.header.forEach((name, idx) => select.append(new Option(name, String(idx))));
-document.getElementById('meta').textContent = `created ${{data.createdAt}} · prompt rows ${{data.promptRows.length}} · holdout rows ${{data.truthRows.length}} · samples ${{data.samples.length}}`;
-['columnSelect', 'showPrompt', 'showTruth', 'showSamples'].forEach(id => document.getElementById(id).addEventListener('change', render));
+const colors = ['#ffb000', '#00d1ff', '#f05cff', '#5cff92', '#ff6b6b', '#9b8cff', '#f6ff5c', '#58a6ff', '#ffa657', '#7ee787', '#d2a8ff', '#ff7b72', '#a5d6ff', '#f2cc60', '#56d364'];
+document.getElementById('meta').textContent = `created ${{data.createdAt}} · columns ${{data.header.length}} · prompt rows ${{data.promptRows.length}} · holdout rows ${{data.truthRows.length}} · inference runs ${{data.samples.length}}`;
+const sampleToggles = document.getElementById('sampleToggles');
+data.samples.forEach((sample, idx) => {{
+  const id = `sample_${{idx}}`;
+  const label = document.createElement('label');
+  label.innerHTML = `<input id="${{id}}" data-sample-idx="${{idx}}" type="checkbox" checked /> <span class="swatch" style="background:${{colors[idx % colors.length]}}"></span>${{sample.label}}`;
+  sampleToggles.append(label);
+}});
+document.getElementById('showPrompt').addEventListener('change', render);
+document.getElementById('showTruth').addEventListener('change', render);
+sampleToggles.addEventListener('change', render);
 function finite(v) {{ return typeof v === 'number' && Number.isFinite(v); }}
-function seriesValues(rows, col) {{ return rows.map(r => r[col]).filter(finite); }}
 function extent(seriesList) {{
   const vals = seriesList.flat().filter(finite);
   if (!vals.length) return [0, 1];
@@ -210,21 +228,29 @@ function drawLine(ctx, values, xStart, xScale, yScale, yMax, color, width, dash=
   }});
   ctx.stroke(); ctx.restore();
 }}
-function render() {{
-  const col = Number(select.value || 0);
-  const charts = document.getElementById('charts'); charts.innerHTML = '';
+function addLegend(legend, label, color) {{
+  const item = document.createElement('span');
+  item.innerHTML = `<i class="swatch" style="background:${{color}}"></i>${{label}}`;
+  legend.append(item);
+}}
+function enabledSamplesForColumn(col) {{
+  return data.samples
+    .map((sample, idx) => ({{idx, label: sample.label, values: sample.rows.map(r => r[col])}}))
+    .filter(s => {{ const box = document.getElementById(`sample_${{s.idx}}`); return box && box.checked; }});
+}}
+function renderColumn(col, charts) {{
   const holder = document.createElement('div'); holder.className = 'chart';
-  const title = document.createElement('h2'); title.textContent = data.header[col]; title.style.fontSize = '16px';
-  const canvas = document.createElement('canvas'); canvas.width = 1200; canvas.height = 320;
+  const title = document.createElement('h2'); title.textContent = data.header[col];
+  const canvas = document.createElement('canvas'); canvas.width = 1200; canvas.height = 300;
   const legend = document.createElement('div'); legend.className = 'legend';
   holder.append(title, canvas, legend); charts.append(holder);
   const prompt = data.promptRows.slice(Math.max(0, data.promptRows.length - 128)).map(r => r[col]);
   const truth = data.truthRows.map(r => r[col]);
-  const sampleSeries = data.samples.map(s => ({{label: s.label, values: s.rows.map(r => r[col])}}));
+  const sampleSeries = enabledSamplesForColumn(col);
   const visibleSeries = [];
   if (document.getElementById('showPrompt').checked) visibleSeries.push(prompt);
   if (document.getElementById('showTruth').checked) visibleSeries.push(truth);
-  if (document.getElementById('showSamples').checked) sampleSeries.forEach(s => visibleSeries.push(s.values));
+  sampleSeries.forEach(s => visibleSeries.push(s.values));
   const [yMin, yMax] = extent(visibleSeries);
   const totalX = prompt.length + Math.max(truth.length, ...sampleSeries.map(s => s.values.length), 1);
   const plotW = canvas.width - 70, plotH = canvas.height - 50;
@@ -234,10 +260,13 @@ function render() {{
   for (let i = 0; i <= 5; i++) {{ const y = 18 + i * plotH / 5; ctx.beginPath(); ctx.moveTo(50, y); ctx.lineTo(50 + plotW, y); ctx.stroke(); }}
   ctx.fillStyle = '#cfd6e4'; ctx.font = '12px ui-monospace, monospace'; ctx.fillText(yMax.toFixed(2), 6, 24); ctx.fillText(yMin.toFixed(2), 6, 18 + plotH);
   const splitX = 50 + Math.max(prompt.length - 1, 0) * xScale; ctx.strokeStyle = '#666'; ctx.setLineDash([4,4]); ctx.beginPath(); ctx.moveTo(splitX, 18); ctx.lineTo(splitX, 18 + plotH); ctx.stroke(); ctx.setLineDash([]);
-  function addLegend(label, color) {{ const item = document.createElement('span'); item.innerHTML = `<i class=\"swatch\" style=\"background:${{color}}\"></i>${{label}}`; legend.append(item); }}
-  if (document.getElementById('showPrompt').checked) {{ drawLine(ctx, prompt, 0, xScale, yScale, yMax, '#8a96a8', 2); addLegend('prompt tail', '#8a96a8'); }}
-  if (document.getElementById('showTruth').checked) {{ drawLine(ctx, truth, prompt.length, xScale, yScale, yMax, '#ffffff', 3); addLegend('ground truth holdout', '#ffffff'); }}
-  if (document.getElementById('showSamples').checked) sampleSeries.forEach((s, idx) => {{ const c = colors[idx % colors.length]; drawLine(ctx, s.values, prompt.length, xScale, yScale, yMax, c, 2, [6,3]); addLegend(s.label, c); }});
+  if (document.getElementById('showPrompt').checked) {{ drawLine(ctx, prompt, 0, xScale, yScale, yMax, '#8a96a8', 2); addLegend(legend, 'prompt tail', '#8a96a8'); }}
+  if (document.getElementById('showTruth').checked) {{ drawLine(ctx, truth, prompt.length, xScale, yScale, yMax, '#ffffff', 3); addLegend(legend, 'ground truth holdout', '#ffffff'); }}
+  sampleSeries.forEach(s => {{ const c = colors[s.idx % colors.length]; drawLine(ctx, s.values, prompt.length, xScale, yScale, yMax, c, 2, [6,3]); addLegend(legend, s.label, c); }});
+}}
+function render() {{
+  const charts = document.getElementById('charts'); charts.innerHTML = '';
+  data.header.forEach((_, col) => renderColumn(col, charts));
 }}
 render();
 </script>
@@ -247,7 +276,6 @@ render();
         encoding="utf-8",
     )
 
-
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run seeded top-k samples and render prediction-vs-ground-truth time-series HTML.")
     parser.add_argument("--input_csv", default="data/dukascopy_fx_m1/input.csv", help="Prepared integer CSV containing the full series.")
@@ -256,8 +284,8 @@ def main() -> None:
     parser.add_argument("--work_dir", default="out/dukascopy_fx_m1/timeseries_viewer", help="Directory for prompt, truth, samples, and HTML.")
     parser.add_argument("--holdout_rows", type=int, default=128, help="Tail rows excluded from prompt and used as ground truth.")
     parser.add_argument("--prompt_rows", type=int, default=512, help="Rows immediately before holdout used as inference prompt; 0 uses all prior rows.")
-    parser.add_argument("--seeds", nargs="+", type=int, default=[1337, 1338, 1339], help="Random seeds to sample for each top-k value.")
-    parser.add_argument("--top_k", nargs="+", type=int, default=[1, 5], help="Top-k settings to run for every seed.")
+    parser.add_argument("--seeds", nargs="+", type=int, default=[1337, 1338, 1339, 1340, 1341], help="Random seeds to sample for each top-k value.")
+    parser.add_argument("--top_k", nargs="+", type=int, default=[1, 5, 10], help="Top-k settings to run for every seed.")
     parser.add_argument("--device", default="cuda:0")
     parser.add_argument("--dtype", default="bfloat16", choices=["float32", "float16", "bfloat16"])
     parser.add_argument("--compile", dest="compile_model", default=True, action=argparse.BooleanOptionalAction)

--- a/data/timeseries_viewer/generate_timeseries_comparison.py
+++ b/data/timeseries_viewer/generate_timeseries_comparison.py
@@ -154,6 +154,7 @@ def write_viewer_html(
   <meta charset=\"utf-8\" />
   <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
   <title>{escaped_title}</title>
+  <script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script>
   <style>
     :root {{ color-scheme: dark; font-family: system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", sans-serif; }}
     body {{ margin: 0; padding: 20px; background: #101114; color: #eee; }}
@@ -163,11 +164,9 @@ def write_viewer_html(
     .global-toggles, .sample-toggles {{ display: flex; flex-wrap: wrap; gap: 10px 14px; }}
     label {{ display: inline-flex; gap: 6px; align-items: center; font-size: 13px; color: #cdd1d7; }}
     input {{ accent-color: #58a6ff; }}
-    canvas {{ width: 100%; height: 240px; background: #08090b; border: 1px solid #343a46; border-radius: 8px; }}
     .chart {{ margin-bottom: 22px; }}
     .chart h2 {{ margin: 0 0 8px; font-size: 16px; }}
-    .legend {{ display: flex; flex-wrap: wrap; gap: 10px; font-size: 12px; margin-top: 8px; }}
-    .legend span {{ display: inline-flex; align-items: center; gap: 5px; }}
+    .plot {{ width: 100%; height: 340px; border: 1px solid #343a46; border-radius: 8px; overflow: hidden; }}
     .swatch {{ width: 18px; height: 3px; display: inline-block; }}
     .meta {{ color: #aeb4bf; font-size: 13px; margin-bottom: 14px; }}
     .hint {{ color: #aeb4bf; font-size: 12px; margin-top: 8px; }}
@@ -182,7 +181,7 @@ def write_viewer_html(
         <label><input id=\"showPrompt\" type=\"checkbox\" checked /> prompt tail</label>
         <label><input id=\"showTruth\" type=\"checkbox\" checked /> ground truth holdout</label>
       </div>
-      <div class=\"hint\">All columns are shown below at the same time.</div>
+      <div class=\"hint\">All columns are shown below at the same time as Plotly graphs.</div>
     </div>
     <div>
       <strong>Inference runs</strong>
@@ -209,72 +208,67 @@ data.samples.forEach((sample, idx) => {{
 document.getElementById('showPrompt').addEventListener('change', render);
 document.getElementById('showTruth').addEventListener('change', render);
 sampleToggles.addEventListener('change', render);
-function finite(v) {{ return typeof v === 'number' && Number.isFinite(v); }}
-function extent(seriesList) {{
-  const vals = seriesList.flat().filter(finite);
-  if (!vals.length) return [0, 1];
-  let lo = Math.min(...vals), hi = Math.max(...vals);
-  if (lo === hi) {{ lo -= 1; hi += 1; }}
-  return [lo, hi];
-}}
-function drawLine(ctx, values, xStart, xScale, yScale, yMax, color, width, dash=[]) {{
-  ctx.save(); ctx.strokeStyle = color; ctx.lineWidth = width; ctx.setLineDash(dash); ctx.beginPath();
-  let started = false;
-  values.forEach((v, i) => {{
-    if (!finite(v)) return;
-    const x = 50 + (xStart + i) * xScale;
-    const y = 18 + (yMax - v) * yScale;
-    if (!started) {{ ctx.moveTo(x, y); started = true; }} else {{ ctx.lineTo(x, y); }}
-  }});
-  ctx.stroke(); ctx.restore();
-}}
-function addLegend(legend, label, color) {{
-  const item = document.createElement('span');
-  item.innerHTML = `<i class="swatch" style="background:${{color}}"></i>${{label}}`;
-  legend.append(item);
-}}
+function finiteOrNull(v) {{ return typeof v === 'number' && Number.isFinite(v) ? v : null; }}
+function xRange(start, length) {{ return Array.from({{length}}, (_, idx) => start + idx); }}
 function enabledSamplesForColumn(col) {{
   return data.samples
-    .map((sample, idx) => ({{idx, label: sample.label, values: sample.rows.map(r => r[col])}}))
+    .map((sample, idx) => ({{idx, label: sample.label, values: sample.rows.map(r => finiteOrNull(r[col]))}}))
     .filter(s => {{ const box = document.getElementById(`sample_${{s.idx}}`); return box && box.checked; }});
+}}
+function trace(name, x, y, color, width, dash='solid') {{
+  return {{
+    type: 'scatter',
+    mode: 'lines',
+    name,
+    x,
+    y,
+    line: {{color, width, dash}},
+    hovertemplate: 'row=%{{x}}<br>value=%{{y}}<extra>' + name + '</extra>'
+  }};
 }}
 function renderColumn(col, charts) {{
   const holder = document.createElement('div'); holder.className = 'chart';
   const title = document.createElement('h2'); title.textContent = data.header[col];
-  const canvas = document.createElement('canvas'); canvas.width = 1200; canvas.height = 300;
-  const legend = document.createElement('div'); legend.className = 'legend';
-  holder.append(title, canvas, legend); charts.append(holder);
-  const prompt = data.promptRows.slice(Math.max(0, data.promptRows.length - 128)).map(r => r[col]);
-  const truth = data.truthRows.map(r => r[col]);
-  const sampleSeries = enabledSamplesForColumn(col);
-  const visibleSeries = [];
-  if (document.getElementById('showPrompt').checked) visibleSeries.push(prompt);
-  if (document.getElementById('showTruth').checked) visibleSeries.push(truth);
-  sampleSeries.forEach(s => visibleSeries.push(s.values));
-  const [yMin, yMax] = extent(visibleSeries);
-  const totalX = prompt.length + Math.max(truth.length, ...sampleSeries.map(s => s.values.length), 1);
-  const plotW = canvas.width - 70, plotH = canvas.height - 50;
-  const xScale = plotW / Math.max(totalX - 1, 1), yScale = plotH / (yMax - yMin);
-  const ctx = canvas.getContext('2d'); ctx.clearRect(0, 0, canvas.width, canvas.height);
-  ctx.strokeStyle = '#38404d'; ctx.lineWidth = 1;
-  for (let i = 0; i <= 5; i++) {{ const y = 18 + i * plotH / 5; ctx.beginPath(); ctx.moveTo(50, y); ctx.lineTo(50 + plotW, y); ctx.stroke(); }}
-  ctx.fillStyle = '#cfd6e4'; ctx.font = '12px ui-monospace, monospace'; ctx.fillText(yMax.toFixed(2), 6, 24); ctx.fillText(yMin.toFixed(2), 6, 18 + plotH);
-  const splitX = 50 + Math.max(prompt.length - 1, 0) * xScale; ctx.strokeStyle = '#666'; ctx.setLineDash([4,4]); ctx.beginPath(); ctx.moveTo(splitX, 18); ctx.lineTo(splitX, 18 + plotH); ctx.stroke(); ctx.setLineDash([]);
-  if (document.getElementById('showPrompt').checked) {{ drawLine(ctx, prompt, 0, xScale, yScale, yMax, '#8a96a8', 2); addLegend(legend, 'prompt tail', '#8a96a8'); }}
-  if (document.getElementById('showTruth').checked) {{ drawLine(ctx, truth, prompt.length, xScale, yScale, yMax, '#ffffff', 3); addLegend(legend, 'ground truth holdout', '#ffffff'); }}
-  sampleSeries.forEach(s => {{ const c = colors[s.idx % colors.length]; drawLine(ctx, s.values, prompt.length, xScale, yScale, yMax, c, 2, [6,3]); addLegend(legend, s.label, c); }});
+  const plot = document.createElement('div'); plot.className = 'plot'; plot.id = `plot_${{col}}`;
+  holder.append(title, plot); charts.append(holder);
+  const prompt = data.promptRows.slice(Math.max(0, data.promptRows.length - 128)).map(r => finiteOrNull(r[col]));
+  const truth = data.truthRows.map(r => finiteOrNull(r[col]));
+  const promptStart = 0;
+  const forecastStart = prompt.length;
+  const traces = [];
+  if (document.getElementById('showPrompt').checked) traces.push(trace('prompt tail', xRange(promptStart, prompt.length), prompt, '#8a96a8', 2));
+  if (document.getElementById('showTruth').checked) traces.push(trace('ground truth holdout', xRange(forecastStart, truth.length), truth, '#ffffff', 3));
+  enabledSamplesForColumn(col).forEach(s => traces.push(trace(s.label, xRange(forecastStart, s.values.length), s.values, colors[s.idx % colors.length], 2, 'dash')));
+  const splitX = Math.max(forecastStart - 0.5, 0);
+  const layout = {{
+    paper_bgcolor: '#08090b',
+    plot_bgcolor: '#08090b',
+    font: {{color: '#d6deeb'}},
+    margin: {{l: 58, r: 20, t: 12, b: 42}},
+    hovermode: 'x unified',
+    legend: {{orientation: 'h', x: 0, y: -0.22}},
+    xaxis: {{title: 'row index relative to prompt tail', gridcolor: '#27303b', zerolinecolor: '#3a4350'}},
+    yaxis: {{title: data.header[col], gridcolor: '#27303b', zerolinecolor: '#3a4350'}},
+    shapes: [{{type: 'line', x0: splitX, x1: splitX, y0: 0, y1: 1, yref: 'paper', line: {{color: '#777', dash: 'dot', width: 1}}}}]
+  }};
+  Plotly.newPlot(plot, traces, layout, {{responsive: true, displaylogo: false}});
 }}
 function render() {{
   const charts = document.getElementById('charts'); charts.innerHTML = '';
   data.header.forEach((_, col) => renderColumn(col, charts));
 }}
-render();
+if (!window.Plotly) {{
+  document.getElementById('charts').innerHTML = '<div class="panel">Plotly failed to load. Check network access to the Plotly CDN.</div>';
+}} else {{
+  render();
+}}
 </script>
 </body>
 </html>
 """,
         encoding="utf-8",
     )
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run seeded top-k samples and render prediction-vs-ground-truth time-series HTML.")

--- a/demos/dukascopy_fx_m1_csv_mc_int_demo.sh
+++ b/demos/dukascopy_fx_m1_csv_mc_int_demo.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Dukascopy FX M1 regular integer CSV multicontext demo:
+# 1) convert downloaded Dukascopy candle CSV(.gz) files into integer columns
+# 2) split those columns into per-column integer datasets via data/csv_mc_int
+# 3) train regular multicontext and sample timestamped CSV continuations
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+RAW_INPUT="${1:-data/dukascopy_fx_m1/raw/eurusd}"
+OUTPUT_ROOT="${DUKASCOPY_MC_OUTPUT_ROOT:-dukascopy_fx_m1}"
+CSV_INPUT="${DUKASCOPY_MC_INPUT_CSV:-data/dukascopy_fx_m1/input.csv}"
+OUT_DIR="${DUKASCOPY_MC_OUT_DIR:-out/dukascopy_fx_m1}"
+MAX_ITERS="${DUKASCOPY_MC_MAX_ITERS:-1000}"
+DEVICE="${DUKASCOPY_MC_DEVICE:-cuda:0}"
+DTYPE="${DUKASCOPY_MC_DTYPE:-bfloat16}"
+
+# Reuse the same dataset preparation path as csv_mc_int_demo.sh, with a
+# Dukascopy-specific float-to-integer conditioning step in front.
+data/dukascopy_fx_m1/get_dataset.sh "$RAW_INPUT"
+
+mapfile -t DATASETS < <(python3 - <<PY
+import json
+from pathlib import Path
+manifest = json.loads(Path('data/$OUTPUT_ROOT/manifest.json').read_text())
+for dataset in manifest['multicontext_datasets']:
+    print(dataset)
+PY
+)
+
+python3 train.py \
+  --training_mode multicontext \
+  --dataset "${DATASETS[0]}" \
+  --multicontext \
+  --multicontext_datasets "${DATASETS[@]}" \
+  --n_layer 6 \
+  --n_head 6 \
+  --attention_variant infinite \
+  --use_concat_heads \
+  --n_qk_head_dim 200 \
+  --n_v_head_dim 112 \
+  --n_embd 128 \
+  --block_size 100 \
+  --batch_size 2 \
+  --max_iters "$MAX_ITERS" \
+  --eval_interval 50 \
+  --eval_iters 10 \
+  --learning_rate 1e-3 \
+  --dropout 0.0 \
+  --device "$DEVICE" \
+  --dtype "$DTYPE" \
+  --optimizer muon \
+  --weight_decay 0.0 \
+  --softmax_variant_attn relu2max \
+  --use_qk_norm \
+  --use_qk_norm_scale \
+  --use_rotary_embeddings \
+  --no-use_abs_pos_embeddings \
+  --compile \
+  --out_dir "$OUT_DIR"
+
+python3 sample.py \
+  --out_dir "$OUT_DIR" \
+  --device "$DEVICE" \
+  --dtype "$DTYPE" \
+  --multicontext \
+  --multicontext_datasets "${DATASETS[@]}" \
+  --multicontext_csv_input "$CSV_INPUT" \
+  --multicontext_csv_output_dir "$OUT_DIR/csv_samples" \
+  --max_new_tokens 10000 \
+  --top_k 5 \
+  --compile \
+  --num_samples 1

--- a/demos/dukascopy_fx_m1_csv_mc_int_demo.sh
+++ b/demos/dukascopy_fx_m1_csv_mc_int_demo.sh
@@ -102,3 +102,19 @@ python3 sample.py \
   --top_k 5 \
   --compile \
   --num_samples 1
+
+read -r -a VIEWER_SEEDS <<<"${DUKASCOPY_VIEWER_SEEDS:-1337 1338 1339}"
+read -r -a VIEWER_TOP_K <<<"${DUKASCOPY_VIEWER_TOP_K:-1 5}"
+
+python3 data/timeseries_viewer/generate_timeseries_comparison.py \
+  --input_csv "$CSV_INPUT" \
+  --manifest "data/$OUTPUT_ROOT/manifest.json" \
+  --checkpoint_dir "$OUT_DIR" \
+  --work_dir "${DUKASCOPY_VIEWER_WORK_DIR:-$OUT_DIR/timeseries_viewer}" \
+  --holdout_rows "${DUKASCOPY_VIEWER_HOLDOUT_ROWS:-128}" \
+  --prompt_rows "${DUKASCOPY_VIEWER_PROMPT_ROWS:-512}" \
+  --seeds "${VIEWER_SEEDS[@]}" \
+  --top_k "${VIEWER_TOP_K[@]}" \
+  --device "$DEVICE" \
+  --dtype "$DTYPE" \
+  --compile

--- a/demos/dukascopy_fx_m1_csv_mc_int_demo.sh
+++ b/demos/dukascopy_fx_m1_csv_mc_int_demo.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Dukascopy FX M1 regular integer CSV multicontext demo:
-# 1) convert downloaded Dukascopy candle CSV(.gz) files into integer columns
-# 2) split those columns into per-column integer datasets via data/csv_mc_int
-# 3) train regular multicontext and sample timestamped CSV continuations
+# 1) download a tiny default Dukascopy candle slice when raw CSVs are missing
+# 2) convert downloaded Dukascopy candle CSV(.gz) files into integer columns
+# 3) split those columns into per-column integer datasets via data/csv_mc_int
+# 4) train regular multicontext and sample timestamped CSV continuations
 
 set -euo pipefail
 
@@ -16,6 +17,34 @@ OUT_DIR="${DUKASCOPY_MC_OUT_DIR:-out/dukascopy_fx_m1}"
 MAX_ITERS="${DUKASCOPY_MC_MAX_ITERS:-1000}"
 DEVICE="${DUKASCOPY_MC_DEVICE:-cuda:0}"
 DTYPE="${DUKASCOPY_MC_DTYPE:-bfloat16}"
+DOWNLOAD_START="${DUKASCOPY_DEMO_START:-2025-01-02}"
+DOWNLOAD_END="${DUKASCOPY_DEMO_END:-2025-01-03}"
+DOWNLOAD_SIDE="${DUKASCOPY_DEMO_SIDE:-BID}"
+DOWNLOAD_UNIVERSE="${DUKASCOPY_DEMO_UNIVERSE:-majors}"
+DOWNLOAD_OUT="${DUKASCOPY_DEMO_RAW_OUT:-data/dukascopy_fx_m1/raw}"
+
+has_candle_csvs() {
+  local path="$1"
+  if [[ -f "$path" ]]; then
+    return 0
+  fi
+  if [[ -d "$path" ]] && find "$path" -type f \( -name "*.csv" -o -name "*.csv.gz" \) -print -quit | grep -q .; then
+    return 0
+  fi
+  return 1
+}
+
+if ! has_candle_csvs "$RAW_INPUT"; then
+  echo "No Dukascopy candle CSVs found at $RAW_INPUT; downloading $DOWNLOAD_UNIVERSE $DOWNLOAD_SIDE data for [$DOWNLOAD_START, $DOWNLOAD_END)."
+  python3 data/dukascopy_fx_m1/download_dukascopy_fx_m1.py \
+    --start "$DOWNLOAD_START" \
+    --end "$DOWNLOAD_END" \
+    --universe "$DOWNLOAD_UNIVERSE" \
+    --out "$DOWNLOAD_OUT" \
+    --side "$DOWNLOAD_SIDE" \
+    --max-workers "${DUKASCOPY_DEMO_MAX_WORKERS:-4}" \
+    --rps "${DUKASCOPY_DEMO_RPS:-2}"
+fi
 
 # Reuse the same dataset preparation path as csv_mc_int_demo.sh, with a
 # Dukascopy-specific float-to-integer conditioning step in front.

--- a/demos/dukascopy_fx_m1_csv_mc_int_demo.sh
+++ b/demos/dukascopy_fx_m1_csv_mc_int_demo.sh
@@ -103,8 +103,8 @@ python3 sample.py \
   --compile \
   --num_samples 1
 
-read -r -a VIEWER_SEEDS <<<"${DUKASCOPY_VIEWER_SEEDS:-1337 1338 1339}"
-read -r -a VIEWER_TOP_K <<<"${DUKASCOPY_VIEWER_TOP_K:-1 5}"
+read -r -a VIEWER_SEEDS <<<"${DUKASCOPY_VIEWER_SEEDS:-1337 1338 1339 1340 1341}"
+read -r -a VIEWER_TOP_K <<<"${DUKASCOPY_VIEWER_TOP_K:-1 5 10}"
 
 python3 data/timeseries_viewer/generate_timeseries_comparison.py \
   --input_csv "$CSV_INPUT" \


### PR DESCRIPTION
### Motivation

- Provide an end-to-end path to use Dukascopy 1-minute FX candle data with the repo's existing integer multicontext CSV pipeline so FX minute candles can be trained/sampled like other CSV datasets. 
- Avoid brittle scraping for the common majors universe by shipping a downloader that uses a built-in majors list and a robust conversion/conditioning path to integer columns.

### Description

- Add a Dukascopy downloader `data/dukascopy_fx_m1/download_dukascopy_fx_m1.py` that decodes Dukascopy .bi5 minute-candle files and writes per-instrument/day gzipped CSVs with columns `timestamp_utc, open, high, low, close, volume`.
- Add a float-to-integer conditioning script `data/dukascopy_fx_m1/prepare_dukascopy_csv_for_mc_int.py` that converts candle CSV(.gz) files into an integer `input.csv` (minute_of_day, optional weekday, OHLC ticks, volume ticks) suitable for `data/csv_mc_int`.
- Add `data/dukascopy_fx_m1/get_dataset.sh` which runs the conditioning step then delegates to `data/csv_mc_int/get_dataset.sh` with appropriate per-column ranges and environment overrides.
- Add an end-to-end demo `demos/dukascopy_fx_m1_csv_mc_int_demo.sh` that mirrors `demos/csv_mc_int_demo.sh` to build datasets, train `--training_mode multicontext`, and sample CSV continuations, plus `data/dukascopy_fx_m1/README.md` documenting usage and overrides.
- Make the downloader resilient to environments missing `requests` by importing `requests` lazily inside the helper used for HTTP, allowing `--help` and static checks to run without network deps.

### Testing

- Ran `python3 data/dukascopy_fx_m1/prepare_dukascopy_csv_for_mc_int.py /tmp/dukafix/sample.csv --output_csv /tmp/dukafix/input.csv` and verified `/tmp/dukafix/input.csv` rows were written successfully.
- Ran the dataset wrapper with `DUKASCOPY_MC_OUTPUT_ROOT=dukascopy_fx_m1_test DUKASCOPY_MC_INPUT_CSV=/tmp/dukafix/input.csv data/dukascopy_fx_m1/get_dataset.sh /tmp/dukafix/sample.csv` and verified a `manifest.json` and per-column multicontext datasets were produced.
- Executed `python3 data/dukascopy_fx_m1/download_dukascopy_fx_m1.py --help` to verify the downloader help runs in the current environment (lazy `requests` import prevents hard failure).
- Performed syntax/static checks: `bash -n demos/dukascopy_fx_m1_csv_mc_int_demo.sh` and `python3 -m py_compile data/dukascopy_fx_m1/download_dukascopy_fx_m1.py data/dukascopy_fx_m1/prepare_dukascopy_csv_for_mc_int.py`, both completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbb2678f88326a3be778f5898fd45)