### PR TITLE
Add Cayley orthogonal layers and exploration sweep

### DIFF
--- a/explorations/cayley_ns_orthogonal_layers.yaml
+++ b/explorations/cayley_ns_orthogonal_layers.yaml
@@ -1,0 +1,77 @@
+# cayley_ns_orthogonal_layers.yaml
+---
+# Compare matmul-only Newton-Schulz Cayley layers against conventional nanoGPT
+# runs at a similar non-embedding parameter scale. Use compute_model_stats to
+# verify exact counts for your vocab/dataset before launching a long sweep.
+
+named_static_groups:
+  - named_group: "conventional_nanogpt"
+    attention_variant: ["causal"]
+    mlp_variant: ["mlp"]
+    n_embd: [32]
+    n_head: [1]
+    mlp_size: [128]
+
+  - named_group: "inf_cayley_wv_identity_wo"
+    attention_variant: ["infinite"]
+    infinite_cayley_value: [true]
+    cayley_mode: ["ns"]
+    cayley_ns_steps: [8, 12]
+    cayley_max_skew_norm: [2.0]
+    use_concat_heads: [false]
+    n_embd: [32]
+    n_head: [1]
+    n_kv_group: [1]
+    n_qk_head_dim: [32]
+    n_v_head_dim: [32]
+    n_cproj: [1]
+    mlp_variant: ["mlp"]
+    # Smaller MLP keeps total non-embedding params close to the conventional
+    # baseline after Wv/Wo are replaced by one n_embd x n_embd Cayley parameter.
+    mlp_size: [96]
+
+  - named_group: "single_cayley_mlp"
+    attention_variant: ["causal"]
+    mlp_variant: ["cayley"]
+    cayley_mode: ["ns"]
+    cayley_ns_steps: [8, 12]
+    cayley_max_skew_norm: [2.0]
+    n_embd: [32]
+    n_head: [1]
+
+  - named_group: "mixture_cayley_mlp"
+    attention_variant: ["causal"]
+    mlp_variant: ["cayley_mixture"]
+    cayley_mode: ["ns"]
+    cayley_ns_steps: [8, 12]
+    cayley_max_skew_norm: [2.0]
+    cayley_mixture_size: [2, 4]
+    n_embd: [32]
+    n_head: [1]
+
+common_group:
+  dataset: ["shakespeare_char"]
+  device: ["cuda"]
+  dtype: ["bfloat16"]
+  compile: [true]
+  max_iters: [3000]
+  eval_interval: [250]
+  eval_iters: [200]
+  batch_size: [64]
+  block_size: [256]
+  n_layer: [1]
+  use_rotary_embeddings: [true]
+  use_abs_pos_embeddings: [false]
+  bias: [false]
+  dropout: [0.0]
+  never_save_checkpoint: [true]
+  compute_model_stats: [true]
+  log_btc_per_param: [true]
+
+print_model_stats_table: ["print_stats/${RUN_NAME}.csv"]
+
+parameter_groups:
+  - named_group_static: ["conventional_nanogpt"]
+  - named_group_static: ["inf_cayley_wv_identity_wo"]
+  - named_group_static: ["single_cayley_mlp"]
+  - named_group_static: ["mixture_cayley_mlp"]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -203,6 +203,12 @@ class GPTConfig:
 
     # MLP Options
     use_parallel_mlp: bool = False
+    cayley_mode: str = "exact"
+    cayley_ns_steps: int = 8
+    cayley_init_scale: float = 1e-3
+    cayley_max_skew_norm: float | None = None
+    cayley_mixture_size: int = 4
+    infinite_cayley_value: bool = False
     mlp_variant: str = "mlp"
     mlp_expansion_factor: int = 4
     mlp_size: int = None

--- a/train_args.py
+++ b/train_args.py
@@ -684,6 +684,8 @@ def parse_args():
             "swiglu",
             "dual_path",
             "dual_path_swiglu",
+            "cayley",
+            "cayley_mixture",
             "identity",
             ]
 
@@ -693,6 +695,11 @@ def parse_args():
     model_group.add_argument("--mlp_size", type=int, default=None, help="If not None, is used instead of mlp_expansion_factor")
     model_group.add_argument('--mlp_cproj_scale', default=1.0, type=float, help="Divide MLP down projection outputs by this value")
     model_group.add_argument('--mlp_post_act_l2_norm', default=False, action=argparse.BooleanOptionalAction, help="L2 normalize MLP activation vectors before down projection")
+    model_group.add_argument('--cayley_mode', type=str, default="exact", choices=["exact", "ns"], help="Cayley map backend for Cayley attention/MLP variants")
+    model_group.add_argument('--cayley_ns_steps', type=int, default=8, help="Newton-Schulz steps for cayley_mode=ns")
+    model_group.add_argument('--cayley_init_scale', type=float, default=1e-3, help="Initialization scale for Cayley skew parameters")
+    model_group.add_argument('--cayley_max_skew_norm', type=float, default=None, help="Optional smooth norm cap for Cayley skew parameters")
+    model_group.add_argument('--cayley_mixture_size', type=int, default=4, help="Number of learned rotations in cayley_mixture MLP")
 
     ## KAN Options
     model_group.add_argument("--kan_poly_order", type=int, default=3, help="Order of KAN non-linearity")
@@ -978,6 +985,7 @@ def parse_args():
     model_group.add_argument('--attn_post_act_l2_norm', default=False, action=argparse.BooleanOptionalAction,
                              help="L2 normalize attention outputs before c_proj (Infinite Attention)")
     model_group.add_argument("--use_concat_heads",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="concat heads instead of adding in infinite attention")
+    model_group.add_argument('--infinite_cayley_value', default=False, action=argparse.BooleanOptionalAction, help='Use CayleyLinear for Infinite Attention Wv and make Wo/c_proj an identity; requires n_v_head_dim == n_embd and no head concatenation.')
 
     ## qk_norm variations
     model_group.add_argument("--use_qk_norm",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="applies the norm to q and k before attn")

--- a/variations/attention_variations.py
+++ b/variations/attention_variations.py
@@ -12,6 +12,7 @@ from variations.linear_variations import linear_dictionary, wrap_with_flashnorm
 from variations.position_encoding_variations import (
     FIRE, RotaryEmbedding, SymmetricalOverlapAngularPositions)
 from variations.softmax_variations import softmax_dictionary
+from variations.cayley_variations import CayleyLinear
 from variations.triadic_modulation_variations import mod_fn_dict
 
 
@@ -1029,6 +1030,9 @@ class InfiniteHeadAttention(nn.Module):
         self.use_qk_norm        = config.use_qk_norm
         self.use_qk_norm_scale  = config.use_qk_norm_scale
         self.use_v_norm         = config.use_v_norm
+        self.infinite_cayley_value = getattr(config, "infinite_cayley_value", False)
+        if self.infinite_cayley_value and (self.use_concat_heads or self.n_v_head_dim != self.n_embd):
+            raise ValueError("infinite_cayley_value requires use_concat_heads=False and n_v_head_dim == n_embd so Wo can be identity")
 
         # Flash Lobo
         self.use_flash_lobo          = config.use_flash_lobo
@@ -1068,7 +1072,20 @@ class InfiniteHeadAttention(nn.Module):
         # TODO: no reason for qk and v to have same dimension
         self.c_attn_q = self.linear_variant_q(self.n_embd, self.n_head * self.n_qk_head_dim, config, bias=config.bias)
         self.c_attn_k = self.linear_variant_k(self.n_embd, self.n_kv_group * self.n_qk_head_dim, config, bias=config.bias)
-        self.c_attn_v = self.linear_variant_v(self.n_embd, self.n_kv_group * self.n_v_head_dim, config, bias=config.bias)
+        if self.infinite_cayley_value:
+            if self.n_kv_group != 1:
+                raise ValueError("infinite_cayley_value currently requires n_kv_group == 1 so one Cayley Wv feeds all heads")
+            self.c_attn_v = CayleyLinear(
+                self.n_embd,
+                self.n_v_head_dim,
+                bias=config.bias,
+                mode=config.cayley_mode,
+                ns_steps=config.cayley_ns_steps,
+                init_scale=config.cayley_init_scale,
+                max_skew_norm=config.cayley_max_skew_norm,
+            )
+        else:
+            self.c_attn_v = self.linear_variant_v(self.n_embd, self.n_kv_group * self.n_v_head_dim, config, bias=config.bias)
 
         self.q_norm_dim = 1 if self.l2_norm_attn_q_dim == "embed" else 0
         self.k_norm_dim = 1 if self.l2_norm_attn_k_dim == "embed" else 0
@@ -1081,6 +1098,9 @@ class InfiniteHeadAttention(nn.Module):
             self.c_proj = self.linear_variant_attn_proj(
                 self.n_head * self.n_v_head_dim, self.n_embd, config, bias=config.bias
             )
+        elif self.infinite_cayley_value:
+            print("use Cayley Wv with identity c_proj")
+            self.c_proj = nn.Identity()
         elif self.n_cproj==1:
             print("use n_cproj 1", self.n_v_head_dim, self.n_embd)
             self.c_proj = self.linear_variant_attn_proj(self.n_v_head_dim, self.n_embd, config, bias=config.bias)
@@ -1282,7 +1302,9 @@ class InfiniteHeadAttention(nn.Module):
             # (B, nh, T, v_dim) → (B, T, nh*v_dim); avoid extra .contiguous()
             # flatten heads → (B, T, n_head * n_v_head_dim)
             y = y.transpose(1, 2).contiguous().view(B, T, self.n_head * self.n_v_head_dim)
-            if self.l2_norm_attn_cproj:
+            if self.infinite_cayley_value:
+                y = self.c_proj(y)
+            elif self.l2_norm_attn_cproj:
                 cproj_weight = F.normalize(self.c_proj.weight, p=2, dim=self.cproj_norm_dim)
                 y = F.linear(y, cproj_weight, self.c_proj.bias)
             else:
@@ -1290,7 +1312,9 @@ class InfiniteHeadAttention(nn.Module):
         elif self.n_cproj == 1:
             # Sum heads first: (B, nh, T, v_dim) → (B, T, v_dim)
             y = y.sum(dim=1)
-            if self.l2_norm_attn_cproj:
+            if self.infinite_cayley_value:
+                y = self.c_proj(y)
+            elif self.l2_norm_attn_cproj:
                 cproj_weight = F.normalize(self.c_proj.weight, p=2, dim=self.cproj_norm_dim)
                 y = F.linear(y, cproj_weight, self.c_proj.bias)
             else:

--- a/variations/cayley_variations.py
+++ b/variations/cayley_variations.py
@@ -1,0 +1,100 @@
+"""Cayley-map orthogonal and semi-orthogonal layers."""
+
+import torch
+import torch.nn as nn
+from torch.nn import functional as F
+
+
+class CayleyLinear(nn.Module):
+    """
+    Orthogonal / semi-orthogonal Linear layer via a differentiable Cayley map.
+
+    out_features <= in_features: W W.T ~= I  (orthonormal rows)
+    out_features >= in_features: W.T W ~= I  (orthonormal columns)
+    mode="exact": exact Cayley using torch.linalg.solve.
+    mode="ns":    Newton-Schulz approximation to the Cayley inverse.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int | None = None,
+        bias: bool = True,
+        mode: str = "exact",
+        ns_steps: int = 8,
+        init_scale: float = 1e-3,
+        max_skew_norm: float | None = None,
+        device=None,
+        dtype=None,
+    ):
+        super().__init__()
+        if out_features is None:
+            out_features = in_features
+        if mode not in {"exact", "ns"}:
+            raise ValueError('mode must be "exact" or "ns"')
+        factory_kwargs = {"device": device, "dtype": dtype}
+        self.in_features = int(in_features)
+        self.out_features = int(out_features)
+        self.n = max(self.in_features, self.out_features)
+        self.mode = mode
+        self.ns_steps = int(ns_steps)
+        self.max_skew_norm = max_skew_norm
+        self.raw = nn.Parameter(init_scale * torch.randn(self.n, self.n, **factory_kwargs))
+        self.bias = (
+            nn.Parameter(torch.zeros(self.out_features, **factory_kwargs))
+            if bias
+            else None
+        )
+        self.register_buffer("_I", torch.eye(self.n, **factory_kwargs), persistent=False)
+
+    @property
+    def weight(self) -> torch.Tensor:
+        return self.cayley_matrix()[: self.out_features, : self.in_features]
+
+    def _skew(self) -> torch.Tensor:
+        A = self.raw - self.raw.mT
+        if self.max_skew_norm is not None:
+            eps = torch.finfo(A.dtype).eps
+            norm = torch.linalg.vector_norm(A).clamp_min(eps)
+            cap = torch.as_tensor(self.max_skew_norm, dtype=A.dtype, device=A.device)
+            A = A * (torch.tanh(norm / cap) * cap / norm)
+        return A
+
+    def _identity(self, A: torch.Tensor) -> torch.Tensor:
+        return self._I.to(dtype=A.dtype, device=A.device)
+
+    def _cayley_exact(self, A: torch.Tensor) -> torch.Tensor:
+        I = self._identity(A)
+        M = I - 0.5 * A
+        N = I + 0.5 * A
+        return torch.linalg.solve(M.mT, N.mT).mT
+
+    def _cayley_ns_inverse(self, A: torch.Tensor) -> torch.Tensor:
+        I = self._identity(A)
+        M = I - 0.5 * A
+        N = I + 0.5 * A
+        eps = torch.finfo(A.dtype).eps
+        alpha = 1.0 + 0.25 * torch.linalg.vector_norm(A).square()
+        X = N / alpha.clamp_min(eps)
+        for _ in range(self.ns_steps):
+            X = X @ (2.0 * I - M @ X)
+        return N @ X
+
+    def cayley_matrix(self) -> torch.Tensor:
+        A = self._skew()
+        if self.mode == "exact":
+            return self._cayley_exact(A)
+        return self._cayley_ns_inverse(A)
+
+    def orthogonality_error(self) -> torch.Tensor:
+        W = self.weight
+        if self.out_features <= self.in_features:
+            G = W @ W.mT
+            I = torch.eye(self.out_features, dtype=W.dtype, device=W.device)
+        else:
+            G = W.mT @ W
+            I = torch.eye(self.in_features, dtype=W.dtype, device=W.device)
+        return torch.linalg.matrix_norm(G - I)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return F.linear(x, self.weight, self.bias)

--- a/variations/mlp_variations.py
+++ b/variations/mlp_variations.py
@@ -6,6 +6,7 @@ from torch.nn import functional as F
 
 from variations.activation_variations import activation_dictionary
 from variations.linear_variations import linear_dictionary, wrap_with_flashnorm
+from variations.cayley_variations import CayleyLinear
 from quantization.quantize import fake_quantize_act
 from quantization.quant_utils import set_variant, create_activation_buffers
 
@@ -874,6 +875,61 @@ class KanMLP(nn.Module):
 
         return x
 
+class CayleyMLP(nn.Module):
+    """A residual MLP slot replaced by one learned Cayley rotation."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.cayley = CayleyLinear(
+            config.n_embd,
+            config.n_embd,
+            bias=config.bias,
+            mode=config.cayley_mode,
+            ns_steps=config.cayley_ns_steps,
+            init_scale=config.cayley_init_scale,
+            max_skew_norm=config.cayley_max_skew_norm,
+        )
+        self.dropout = nn.Dropout(config.dropout)
+
+    def forward(self, x, iter_num=None):
+        return self.dropout(self.cayley(x))
+
+
+class CayleyMixtureMLP(nn.Module):
+    """Input-conditioned mixture of learned Cayley rotations."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.num_rotations = int(config.cayley_mixture_size)
+        if self.num_rotations <= 0:
+            raise ValueError("cayley_mixture_size must be positive")
+        self.rotations = nn.ModuleList(
+            [
+                CayleyLinear(
+                    config.n_embd,
+                    config.n_embd,
+                    bias=False,
+                    mode=config.cayley_mode,
+                    ns_steps=config.cayley_ns_steps,
+                    init_scale=config.cayley_init_scale,
+                    max_skew_norm=config.cayley_max_skew_norm,
+                )
+                for _ in range(self.num_rotations)
+            ]
+        )
+        self.router = nn.Linear(config.n_embd, self.num_rotations, bias=config.bias)
+        self.bias = nn.Parameter(torch.zeros(config.n_embd)) if config.bias else None
+        self.dropout = nn.Dropout(config.dropout)
+
+    def forward(self, x, iter_num=None):
+        gates = F.softmax(self.router(x), dim=-1)
+        rotated = torch.stack([rotation(x) for rotation in self.rotations], dim=-2)
+        x = (gates.unsqueeze(-1) * rotated).sum(dim=-2)
+        if self.bias is not None:
+            x = x + self.bias
+        return self.dropout(x)
+
+
 class MLP_Identity(nn.Module):
     def __init__(self, config):
         super().__init__()
@@ -890,7 +946,9 @@ mlp_dictionary = {
     "identity": MLP_Identity,
     "kan": KanMLP,
     "dual_path": DualPathMLP,
-    "dual_path_swiglu": DualPathSwiglu
+    "dual_path_swiglu": DualPathSwiglu,
+    "cayley": CayleyMLP,
+    "cayley_mixture": CayleyMixtureMLP,
     }
 
 def get_mlp_instance(config):


### PR DESCRIPTION
### Motivation
- Provide a differentiable Cayley-map parameterization as an orthogonal / semi-orthogonal alternative to standard linear projections for attention value (`Wv`) and MLP slots. 
- Offer a matmul-only Newton–Schulz (`ns`) approximation path for GPU-friendly experiments and a numerically-robust exact path using `torch.linalg.solve`.
- Enable direct comparison of Cayley-based components vs conventional NanoGPT layers in the repo's exploration tooling.

### Description
- Add `variations/cayley_variations.py` implementing `CayleyLinear` with exact (`torch.linalg.solve`) and Newton–Schulz inverse iteration modes and helper utilities like `orthogonality_error` and `weight`/`forward` access. 
- Integrate Cayley support into infinite attention by adding an `infinite_cayley_value` option that replaces `Wv` with `CayleyLinear` and uses an identity `c_proj`/`Wo` when dimensions allow. 
- Add two MLP alternatives in `variations/mlp_variations.py`: `cayley` (single learned Cayley rotation) and `cayley_mixture` (input-conditioned mixture of learned Cayley rotations routed by a small `router`).
- Expose runtime/config knobs in `gpt_conf.py` and `train_args.py` for `cayley_mode`, `cayley_ns_steps`, `cayley_init_scale`, `cayley_max_skew_norm`, `cayley_mixture_size`, and `infinite_cayley_value` so experiments and CLI runs can toggle behaviors. 
- Add an exploration sweep `explorations/cayley_ns_orthogonal_layers.yaml` that compares `ns` Cayley variants (attention and MLP) against a conventional NanoGPT baseline while keeping comparable non-embedding parameter counts.

### Testing
- Ran `python -m py_compile variations/cayley_variations.py variations/mlp_variations.py variations/attention_variations.py gpt_conf.py train_args.py` to verify syntax and the new modules compile successfully. 
- Parsed and validated the new exploration file with `yaml.safe_load` and an assertion that `parameter_groups` contains the expected entries. 
- Attempted a lightweight model-instantiation smoke test, but the execution environment lacked a usable `torch` installation so a full forward/backward smoke test could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bc2d901e08326b79d937bd2a0ded1)