### PR TITLE
Add ReLU2Line activation and matching ReLU2LineMax softmax variant

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -200,6 +200,7 @@ class GPTConfig:
     activation_transition_start_iter: int = 0
     activation_transition_end_iter: int = None
     relu_power: float = 2.0
+    relu2line_transition_point: float | None = None
 
     # MLP Options
     use_parallel_mlp: bool = False
@@ -295,8 +296,11 @@ class GPTConfig:
     ## ReLUMax options
     relumax_divisor: float = 256.0
 
-    ## ReLUMax options
+    ## ReLU2Max options
     relu2max_divisor: float = 256.0
+
+    ## ReLU2LineMax options
+    relu2line_divisor: float = 256.0
 
     ## SigmoidMax options
     sigmoidmax_divisor: float = 256.0

--- a/train_args.py
+++ b/train_args.py
@@ -849,6 +849,7 @@ def parse_args():
             "prelu",
             "relu",
             "relu_power",
+            "relu2line",
             "relu6",
             "rrelu",
             "disco",
@@ -1272,6 +1273,7 @@ def parse_args():
         "polymax",
         "relumax",
         "relu2max",
+        "relu2linemax",
         "sigmoidmax",
         "vpolymax",
         "exppolymax",
@@ -1321,6 +1323,10 @@ def parse_args():
 
     ### ReLU2Max Options
     model_group.add_argument("--relu2max_divisor", type=float, default=256.0)
+
+    ### ReLU2Line Options
+    model_group.add_argument("--relu2line_transition_point", type=float, default=None)
+    model_group.add_argument("--relu2line_divisor", type=float, default=256.0)
 
     ### SimgoidMax Options
     model_group.add_argument("--sigmoidmax_divisor", type=float, default=256.0)

--- a/variations/activation_variations.py
+++ b/variations/activation_variations.py
@@ -18,12 +18,42 @@ class ReLUPower(nn.Module):
     def forward(self, x):
         return torch.pow(torch.relu(x), self.power)
 
+class ReLU2Line(nn.Module):
+    """Squared ReLU that can smoothly become linear after a configured point.
+
+    When ``relu2line_transition_point`` is ``None`` this is exactly ReLU^2 and
+    avoids the ``torch.where`` blend used by the piecewise linear tail. When a
+    positive transition point ``p`` is supplied, values above ``p`` use the
+    tangent line ``2px - p^2``, making the function C1-continuous at ``p``.
+    """
+    def __init__(self, config):
+        super().__init__()
+        transition_point = getattr(config, "relu2line_transition_point", None)
+        if transition_point is None:
+            self.forward = self._forward_relu2
+        elif transition_point <= 0:
+            raise ValueError("relu2line_transition_point must be positive or None")
+        else:
+            self.register_buffer("transition_point", torch.tensor(float(transition_point)))
+            self.forward = self._forward_relu2line
+
+    def _forward_relu2(self, x):
+        return torch.relu(x).square()
+
+    def _forward_relu2line(self, x):
+        relu_x = torch.relu(x)
+        squared = relu_x.square()
+        linear = (2 * self.transition_point * relu_x) - self.transition_point.square()
+        return torch.where(relu_x > self.transition_point, linear, squared)
+
+
 class Disco(nn.Module):
     def __init__(self, config):
         super().__init__()
 
     def forward(self, x):
         return x * torch.abs(x)
+
 class SquaredGELU(nn.Module):
     def __init__(self, config):
         super().__init__()
@@ -365,6 +395,7 @@ activation_dictionary = {
     "softsign": Softsign_Config,
     "softshrink": Softshrink_Config,
     "relu_power": ReLUPower,
+    "relu2line": ReLU2Line,
     "squared_relu": SquaredReLU,
     "squared_gelu": SquaredGELU,
     "tanh": Tanh_Config,

--- a/variations/softmax_variations.py
+++ b/variations/softmax_variations.py
@@ -577,6 +577,47 @@ class ReLU2Max(nn.Module):
         return result
 
 
+class ReLU2LineMax(nn.Module):
+    """ReLU^2 attention/output weighting with an optional smooth linear tail.
+
+    If ``relu2line_transition_point`` is unset, this runs the same numerator as
+    ReLU2Max without paying for a piecewise blend. With a positive point ``p``,
+    the numerator follows ReLU^2 up to ``p`` and the tangent line ``2px - p^2``
+    afterwards, preserving value and slope at the join.
+    """
+    def __init__(self, config, dim=-1):
+        super().__init__()
+        self.dim = dim
+        self.relu2line_divisor = config.relu2line_divisor
+        self.div_by_seq_len = config.div_by_seq_len
+        transition_point = getattr(config, "relu2line_transition_point", None)
+        if transition_point is None:
+            self.forward = self._forward_relu2
+        elif transition_point <= 0:
+            raise ValueError("relu2line_transition_point must be positive or None")
+        else:
+            self.register_buffer("transition_point", torch.tensor(float(transition_point)))
+            self.forward = self._forward_relu2line
+
+    def _finish(self, result, x):
+        result = result / self.relu2line_divisor
+
+        if self.div_by_seq_len:
+            seq_len = x.shape[self.dim]
+            result = result / seq_len
+
+        return result
+
+    def _forward_relu2(self, x):
+        return self._finish(torch.relu(x).square(), x)
+
+    def _forward_relu2line(self, x):
+        relu_x = torch.relu(x)
+        squared = relu_x.square()
+        linear = (2 * self.transition_point * relu_x) - self.transition_point.square()
+        return self._finish(torch.where(relu_x > self.transition_point, linear, squared), x)
+
+
 class Softplus2Max(nn.Module):
     """ Softmax variant based on arxiv 1805.10829 with added handles for base """
     def __init__(self, config, dim=-1):
@@ -870,6 +911,7 @@ softmax_dictionary = {
     "sigsoftmax": SigSoftmax,
     "relumax": ReLUMax,
     "relu2max": ReLU2Max,
+    "relu2linemax": ReLU2LineMax,
     "sigmoidmax": SigmoidMax,
     "softshrink": Softshrink,
     "gelumax": Gelumax,


### PR DESCRIPTION
### Motivation
- Provide a ReLU^2 activation variant that can smoothly transition into a linear tail so activations can be C1‑continuous at a configurable point. 
- Offer an attention/output weighting variant that mirrors the activation behaviour so attention numerators can share the same shape and training properties. 
- Minimize runtime branching overhead when no transition is requested by binding the chosen forward path at initialization for optimal PyTorch training performance.

### Description
- Added `ReLU2Line` in `variations/activation_variations.py`, which is exact ReLU^2 when `relu2line_transition_point` is `None` and switches to a C1‑continuous tangent line `2px - p^2` above the transition point, with the forward implementation bound at init to avoid per-call branching. 
- Added `ReLU2LineMax` in `variations/softmax_variations.py`, a matching softmax/attention numerator that applies the same ReLU^2→linear behaviour and preserves divisor and `div_by_seq_len` handling. 
- Registered the new variants in `activation_dictionary` and `softmax_dictionary` and added configuration entries `relu2line_transition_point` and `relu2line_divisor` to `gpt_conf.py`.

### Testing
- Ran static checks by compiling the modified modules with `python -m py_compile variations/activation_variations.py variations/softmax_variations.py gpt_conf.py`, which completed successfully. 
- Attempted a small runtime behaviour/gradient check script, but it could not run because the execution environment is missing `torch` (`ModuleNotFoundError: No module named 'torch'`), so dynamic assertions were not executed. 
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b669a61dc8326a1f91501c04e5473)