### PR TITLE
feat(attention): add Orbital Attention (A/B/P three-head rotation primitive)

### DIFF
--- a/explorations/orbital_modular_arithmetic.yaml
+++ b/explorations/orbital_modular_arithmetic.yaml
@@ -1,0 +1,63 @@
+# Compare Orbital Attention against conventional causal attention on the
+# modular_arithmetic grokking dataset. Prepare data first with:
+#   python data/modular_arithmetic/prepare.py --modulus 97 --train_fraction 0.3
+---
+
+named_static_groups:
+  - named_group: "causal_attention"
+    attention_variant: ["causal"]
+
+  - named_group: "orbital_attention"
+    attention_variant: ["orbital"]
+    use_concat_heads: [true]
+    orbital_theta_max_deg: [45.0]
+    orbital_displacement_only: [true]
+    orbital_signed_gate: [false]
+
+  - named_group: "rotary"
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  - named_group: "rmsnorm"
+    norm_variant_attn: ["rmsnorm"]
+    norm_variant_output: ["rmsnorm"]
+
+common_group:
+  dataset: ["modular_arithmetic"]
+  out_dir: ["out/orbital_modular_arithmetic"]
+  tensorboard_run_name: ["orbital_modular_arithmetic"]
+  eval_interval: [100]
+  log_interval: [10]
+  max_iters: [5000]
+  batch_size: [64]
+  block_size: [32]
+  n_layer: [2]
+  n_head: [4]
+  n_embd: [128]
+  n_qk_head_dim: [32]
+  n_v_head_dim: [32]
+  dropout: [0.0]
+  weight_decay: [1.0]
+  learning_rate: [0.001]
+  decay_lr: [false]
+  compile: [true]
+  never_save_checkpoint: [true]
+  log_rankme: [true]
+  log_areq: [true]
+
+parameter_groups:
+  - named_group_static:
+      - "causal_attention"
+      - "rotary"
+      - "qk_norm"
+      - "rmsnorm"
+
+  - named_group_static:
+      - "orbital_attention"
+      - "rotary"
+      - "qk_norm"
+      - "rmsnorm"

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -84,6 +84,10 @@ class GPTConfig:
     mla_latent_dim: int | None = None   # d_c  (proj dimension of the shared latent)
     mla_rotary_dim: int       = 32      # d_r  (# rotary channels per head)
 
+    orbital_theta_max_deg: float = 45.0
+    orbital_displacement_only: bool = False
+    orbital_signed_gate: bool = False
+
     use_mla_lobo: bool = False          # turns the feature on/off
     mla_lobo_init: float = 0.0          # log-space initial value (like flash_lobo_log_const)
 

--- a/train_args.py
+++ b/train_args.py
@@ -911,6 +911,7 @@ def parse_args():
                           "ssm",
                           "identity",
                           "infinite",
+                          "orbital",
                           "mla",
                           "co4",
                           ]
@@ -978,6 +979,9 @@ def parse_args():
     model_group.add_argument('--attn_post_act_l2_norm', default=False, action=argparse.BooleanOptionalAction,
                              help="L2 normalize attention outputs before c_proj (Infinite Attention)")
     model_group.add_argument("--use_concat_heads",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="concat heads instead of adding in infinite attention")
+    model_group.add_argument("--orbital_theta_max_deg", default=45.0, type=float, help="Maximum signed rotation angle in degrees for Orbital Attention")
+    model_group.add_argument("--orbital_displacement_only", type=bool, default=False, action=argparse.BooleanOptionalAction, help="Use W_O(A'-A) instead of W_OA' for Orbital Attention")
+    model_group.add_argument("--orbital_signed_gate", type=bool, default=False, action=argparse.BooleanOptionalAction, help="Use tanh signed gate instead of sigmoid gate for Orbital Attention")
 
     ## qk_norm variations
     model_group.add_argument("--use_qk_norm",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="applies the norm to q and k before attn")

--- a/variations/attention_variations.py
+++ b/variations/attention_variations.py
@@ -1314,6 +1314,134 @@ class InfiniteHeadAttention(nn.Module):
 
         return y
 
+
+def orbital_rotate(A: torch.Tensor, B_axis: torch.Tensor, P: torch.Tensor, theta: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+    """Rotate A around B_axis in the plane selected by P.
+
+    A, B_axis, P are (..., d_rot); theta is (..., 1).  The operation preserves
+    ||A|| and the angle between A and B_axis, falling back to A when the orbit
+    plane is numerically degenerate.
+    """
+    original_dtype = A.dtype
+    A32 = A.float()
+    B32 = B_axis.float()
+    P32 = P.float()
+    theta32 = theta.float()
+
+    radius = A32.norm(dim=-1, keepdim=True)
+    a = A32 / radius.clamp_min(eps)
+    b = F.normalize(B32, dim=-1, eps=eps)
+
+    cos_alpha = (a * b).sum(dim=-1, keepdim=True).clamp(-1.0, 1.0)
+    a_tangent = a - cos_alpha * b
+    sin_alpha = a_tangent.norm(dim=-1, keepdim=True)
+    u = a_tangent / sin_alpha.clamp_min(eps)
+
+    p_tangent = P32 - (P32 * b).sum(dim=-1, keepdim=True) * b - (P32 * u).sum(dim=-1, keepdim=True) * u
+    p_tangent_norm = p_tangent.norm(dim=-1, keepdim=True)
+    v = p_tangent / p_tangent_norm.clamp_min(eps)
+
+    rotated_u = torch.cos(theta32) * u + torch.sin(theta32) * v
+    rotated_a = cos_alpha * b + sin_alpha * rotated_u
+    rotated_A = radius * rotated_a
+
+    valid = (radius > eps) & (sin_alpha > eps) & (p_tangent_norm > eps)
+    return torch.where(valid, rotated_A, A32).to(original_dtype)
+
+
+class OrbitalAttention(InfiniteHeadAttention):
+    """Three-head data-dependent geometric attention.
+
+    Each orbital triplet computes independent A/B/P attention outputs in a common
+    rotation space. A is rotated around the semantic axis B, with P selecting the
+    tangent direction and signed angle, then projected like an Infinite Attention
+    head.
+    """
+
+    def __init__(self, config, fire_pos_enc=None):
+        super().__init__(config, fire_pos_enc=fire_pos_enc)
+        self.theta_max = math.radians(getattr(config, "orbital_theta_max_deg", 45.0))
+        self.displacement_only = getattr(config, "orbital_displacement_only", False)
+        self.signed_gate = getattr(config, "orbital_signed_gate", False)
+
+        # Replace Infinite Attention's single Q/K/V stream with three ordinary
+        # attention streams: A (content), B (axis), and P (plane/angle).
+        self.c_attn_q = nn.ModuleList([
+            self.linear_variant_q(self.n_embd, self.n_head * self.n_qk_head_dim, config, bias=config.bias)
+            for _ in range(3)
+        ])
+        self.c_attn_k = nn.ModuleList([
+            self.linear_variant_k(self.n_embd, self.n_kv_group * self.n_qk_head_dim, config, bias=config.bias)
+            for _ in range(3)
+        ])
+        self.c_attn_v = nn.ModuleList([
+            self.linear_variant_v(self.n_embd, self.n_kv_group * self.n_v_head_dim, config, bias=config.bias)
+            for _ in range(3)
+        ])
+        self.angle = nn.Linear(self.n_v_head_dim, 1)
+        self.gate = nn.Linear(self.n_v_head_dim, 1)
+        nn.init.zeros_(self.angle.weight)
+        nn.init.zeros_(self.angle.bias)
+        nn.init.zeros_(self.gate.weight)
+        nn.init.zeros_(self.gate.bias)
+
+    def _project_stream(self, x, stream_idx, B, T):
+        q = self.c_attn_q[stream_idx](x).view(B, T, self.n_head, self.n_qk_head_dim).transpose(1, 2)
+        k = self.c_attn_k[stream_idx](x).view(B, T, self.n_kv_group, self.n_qk_head_dim).transpose(1, 2)
+        v = self.c_attn_v[stream_idx](x).view(B, T, self.n_kv_group, self.n_v_head_dim).transpose(1, 2)
+        if (self.rotary_emb_q is not None) and (self.rotary_emb_k is not None):
+            q = self.rotary_emb_q(q)
+            k = self.rotary_emb_k(k)
+        if self.use_qk_norm:
+            q = q / (q.norm(dim=-1, keepdim=True) + 1e-6)
+            k = k / (k.norm(dim=-1, keepdim=True) + 1e-6)
+        if self.use_v_norm:
+            v = v / (v.norm(dim=-1, keepdim=True) + 1e-6)
+        return q, k, v
+
+    def _attend_stream(self, q, k, v, x, T):
+        k_attn = self._expand_kv(k)
+        v_attn = self._expand_kv(v)
+        if not self.disable_flash_attention and self.softmax_variant_attn == "softmax":
+            if self.use_qk_norm_scale:
+                q = q * (self.qk_norm_factor * math.sqrt(k_attn.size(-1)))
+            return F.scaled_dot_product_attention(q, k_attn, v_attn, dropout_p=self.dropout if self.training else 0, is_causal=True)
+        att = q @ k_attn.transpose(-2, -1)
+        att = att * self.qk_norm_factor if self.use_qk_norm_scale else att / math.sqrt(k_attn.size(-1))
+        att = att.masked_fill(self.bias[:, :, :T, :T].to(x.device) == 0, float("-inf"))
+        att = self.softmax_layer_attn(att) if self.softmax_variant_attn != "softmax" else F.softmax(att, dim=-1)
+        return self.attn_dropout(att) @ v_attn
+
+    def forward(self, x, iter_num):
+        B, T, C = x.size()
+        streams = []
+        for idx in range(3):
+            q, k, v = self._project_stream(x, idx, B, T)
+            streams.append(self._attend_stream(q, k, v, x, T))
+        A, B_axis, P = streams
+        theta = self.theta_max * torch.tanh(self.angle(P))
+        gate_logits = self.gate(P)
+        gate = torch.tanh(gate_logits) if self.signed_gate else torch.sigmoid(gate_logits)
+        y = orbital_rotate(A, B_axis, P, theta)
+        if self.displacement_only:
+            y = y - A
+        y = gate * y
+
+        if self.post_act_l2_norm:
+            y = y / y.norm(dim=-1, keepdim=True).clamp_min(1e-6)
+        if self.cproj_scale is not None and self.cproj_scale != 1.0:
+            y = y / self.cproj_scale
+
+        if self.use_concat_heads:
+            y = y.transpose(1, 2).contiguous().view(B, T, self.n_head * self.n_v_head_dim)
+            y = self.c_proj(y)
+        elif self.n_cproj == 1:
+            y = self.c_proj(y.sum(dim=1))
+        else:
+            y_sum = y.sum(dim=1)
+            y = torch.stack([proj(y_sum) for proj in self.c_proj_list], dim=0).sum(dim=0)
+        return self.resid_dropout(y)
+
 ##############################################################################
 #  Multi-head Latent Attention (MLA) – DeepSeek-V2 implementation
 #  - low-rank joint compression of K & V (latent_kv_dim)
@@ -1541,6 +1669,7 @@ attention_dictionary = {
     # "ssm": MambaBlock,
     "identity": AttnIdentity,
     "infinite": InfiniteHeadAttention,
+    "orbital": OrbitalAttention,
     "mla": MultiHeadLatentAttention,
     "co4": Co4Attention,
 }


### PR DESCRIPTION
### Motivation

- Provide a data-dependent geometric attention primitive that rotates a content vector around a semantic axis using a third head to select the tangent/angle, enabling non-linear contextual transforms beyond fixed `W_V W_O` projections.  
- Make this available as a sister variant to the existing `infinite` attention so it can be evaluated with the existing exploration tooling.  
- Compare the new operator on a canonical modular-arithmetic grokking task to evaluate its effect on algorithmic learning.

### Description

- Added the hyperspherical rotation primitive `orbital_rotate` that preserves `||A||` and the angular relation to `B` and falls back to `A` for degenerate planes (file: `variations/attention_variations.py`).  
- Implemented `OrbitalAttention` (subclassing `InfiniteHeadAttention`) which computes three attention streams `A/B/P`, derives a signed angle from `P`, performs the orbital rotation, supports `displacement_only` and signed- or sigmoid- gating, and projects outputs using the existing Infinite-style c_proj behavior.  
- Registered the new variant in `attention_dictionary` and added CLI flags `--orbital_theta_max_deg`, `--orbital_displacement_only`, and `--orbital_signed_gate` plus `orbital` choice in the attention variants (files: `variations/attention_variations.py`, `train_args.py`).  
- Added default config fields to `GPTConfig` and created `explorations/orbital_modular_arithmetic.yaml` to compare `orbital` vs `causal` attention on the `modular_arithmetic` dataset (files: `gpt_conf.py`, `explorations/orbital_modular_arithmetic.yaml`).

### Testing

- Ran `python -m py_compile variations/attention_variations.py train_args.py gpt_conf.py` to verify the modified Python files compile successfully (succeeded).  
- Loaded the new exploration YAML via `yaml.safe_load(...)` to verify parsing of `explorations/orbital_modular_arithmetic.yaml` (succeeded).  
- Performed a local smoke test plan that attempted to instantiate `OrbitalAttention` and call `orbital_rotate`, but the runtime smoke invocation failed with `ModuleNotFoundError: No module named 'torch'` in this environment, so runtime PyTorch-based verification could not be completed here (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a520734d5188326b5ea10636b7da891)