### PR TITLE
Add ReLU2Line activation and ReLU2LineMax softmax variant with config and CLI flags

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -200,6 +200,7 @@ class GPTConfig:
     activation_transition_start_iter: int = 0
     activation_transition_end_iter: int = None
     relu_power: float = 2.0
+    relu2line_transition_point: float | None = None
 
     # MLP Options
     use_parallel_mlp: bool = False
@@ -295,8 +296,11 @@ class GPTConfig:
     ## ReLUMax options
     relumax_divisor: float = 256.0
 
-    ## ReLUMax options
+    ## ReLU2Max options
     relu2max_divisor: float = 256.0
+
+    ## ReLU2LineMax options
+    relu2line_divisor: float = 256.0
 
     ## SigmoidMax options
     sigmoidmax_divisor: float = 256.0

--- a/train_args.py
+++ b/train_args.py
@@ -849,6 +849,7 @@ def parse_args():
             "prelu",
             "relu",
             "relu_power",
+            "relu2line",
             "relu6",
             "rrelu",
             "disco",
@@ -880,6 +881,9 @@ def parse_args():
 
     ## ReLUPower
     model_group.add_argument("--relu_power", type=float, default=2.0)
+
+    ## ReLU2Line
+    model_group.add_argument("--relu2line_transition_point", type=float, default=None)
 
     ## Shifted Gelu
     model_group.add_argument("--shifted_gelu_learnable_shift",  type=bool, default=True, action=argparse.BooleanOptionalAction)
@@ -1272,6 +1276,7 @@ def parse_args():
         "polymax",
         "relumax",
         "relu2max",
+        "relu2linemax",
         "sigmoidmax",
         "vpolymax",
         "exppolymax",
@@ -1321,6 +1326,9 @@ def parse_args():
 
     ### ReLU2Max Options
     model_group.add_argument("--relu2max_divisor", type=float, default=256.0)
+
+    ### ReLU2LineMax Options
+    model_group.add_argument("--relu2line_divisor", type=float, default=256.0)
 
     ### SimgoidMax Options
     model_group.add_argument("--sigmoidmax_divisor", type=float, default=256.0)

--- a/variations/activation_variations.py
+++ b/variations/activation_variations.py
@@ -18,12 +18,42 @@ class ReLUPower(nn.Module):
     def forward(self, x):
         return torch.pow(torch.relu(x), self.power)
 
+class ReLU2Line(nn.Module):
+    """Squared ReLU that can smoothly become linear after a configured point.
+
+    When ``relu2line_transition_point`` is ``None`` this is exactly ReLU^2 and
+    avoids the ``torch.where`` blend used by the piecewise linear tail. When a
+    positive transition point ``p`` is supplied, values above ``p`` use the
+    tangent line ``2px - p^2``, making the function C1-continuous at ``p``.
+    """
+    def __init__(self, config):
+        super().__init__()
+        transition_point = getattr(config, "relu2line_transition_point", None)
+        if transition_point is None:
+            self.forward = self._forward_relu2
+        elif transition_point <= 0:
+            raise ValueError("relu2line_transition_point must be positive or None")
+        else:
+            self.register_buffer("transition_point", torch.tensor(float(transition_point)))
+            self.forward = self._forward_relu2line
+
+    def _forward_relu2(self, x):
+        return torch.relu(x).square()
+
+    def _forward_relu2line(self, x):
+        relu_x = torch.relu(x)
+        squared = relu_x.square()
+        linear = (2 * self.transition_point * relu_x) - self.transition_point.square()
+        return torch.where(relu_x > self.transition_point, linear, squared)
+
+
 class Disco(nn.Module):
     def __init__(self, config):
         super().__init__()
 
     def forward(self, x):
         return x * torch.abs(x)
+
 class SquaredGELU(nn.Module):
     def __init__(self, config):
         super().__init__()
@@ -365,6 +395,7 @@ activation_dictionary = {
     "softsign": Softsign_Config,
     "softshrink": Softshrink_Config,
     "relu_power": ReLUPower,
+    "relu2line": ReLU2Line,
     "squared_relu": SquaredReLU,
     "squared_gelu": SquaredGELU,
     "tanh": Tanh_Config,

--- a/variations/softmax_variations.py
+++ b/variations/softmax_variations.py
@@ -577,6 +577,47 @@ class ReLU2Max(nn.Module):
         return result
 
 
+class ReLU2LineMax(nn.Module):
+    """ReLU^2 attention/output weighting with an optional smooth linear tail.
+
+    If ``relu2line_transition_point`` is unset, this runs the same numerator as
+    ReLU2Max without paying for a piecewise blend. With a positive point ``p``,
+    the numerator follows ReLU^2 up to ``p`` and the tangent line ``2px - p^2``
+    afterwards, preserving value and slope at the join.
+    """
+    def __init__(self, config, dim=-1):
+        super().__init__()
+        self.dim = dim
+        self.relu2line_divisor = config.relu2line_divisor
+        self.div_by_seq_len = config.div_by_seq_len
+        transition_point = getattr(config, "relu2line_transition_point", None)
+        if transition_point is None:
+            self.forward = self._forward_relu2
+        elif transition_point <= 0:
+            raise ValueError("relu2line_transition_point must be positive or None")
+        else:
+            self.register_buffer("transition_point", torch.tensor(float(transition_point)))
+            self.forward = self._forward_relu2line
+
+    def _finish(self, result, x):
+        result = result / self.relu2line_divisor
+
+        if self.div_by_seq_len:
+            seq_len = x.shape[self.dim]
+            result = result / seq_len
+
+        return result
+
+    def _forward_relu2(self, x):
+        return self._finish(torch.relu(x).square(), x)
+
+    def _forward_relu2line(self, x):
+        relu_x = torch.relu(x)
+        squared = relu_x.square()
+        linear = (2 * self.transition_point * relu_x) - self.transition_point.square()
+        return self._finish(torch.where(relu_x > self.transition_point, linear, squared), x)
+
+
 class Softplus2Max(nn.Module):
     """ Softmax variant based on arxiv 1805.10829 with added handles for base """
     def __init__(self, config, dim=-1):
@@ -870,6 +911,7 @@ softmax_dictionary = {
     "sigsoftmax": SigSoftmax,
     "relumax": ReLUMax,
     "relu2max": ReLU2Max,
+    "relu2linemax": ReLU2LineMax,
     "sigmoidmax": SigmoidMax,
     "softshrink": Softshrink,
     "gelumax": Gelumax,


### PR DESCRIPTION
### Motivation

- Provide a smooth, configurable activation that is ReLU^2 by default but can transition to a linear tail for better gradient/scale behavior, and expose the same behavior as a softmax numerator variant for attention/output weighting.

### Description

- Introduce `ReLU2Line` activation in `variations/activation_variations.py` that is ReLU^2 when `relu2line_transition_point` is `None` and switches to a C1-continuous linear tangent for inputs above a positive transition point; it raises for non-positive transition points and optimizes the default path by replacing `forward` directly.
- Add `ReLU2LineMax` in `variations/softmax_variations.py` implementing the matching numerator behavior for softmax variants, including optional sequence-length division and optimized no-transition path; register it under the key `relu2linemax` in `softmax_dictionary`.
- Add configuration fields to `GPTConfig` in `gpt_conf.py`: `relu2line_transition_point: float | None` and `relu2line_divisor: float`, and add corresponding CLI options in `train_args.py`: `--relu2line_transition_point` and `--relu2line_divisor`, plus include `"relu2line"` in the activation list and `"relu2linemax"` in the softmax variations list.
- Preserve existing ReLU^2 and ReLU2Max behavior when the transition point is unset to avoid extra runtime branching in the common case.

### Testing

- Ran the repository test suite with `pytest -q` and the linter via `flake8`, and the run completed without failures.
- Executed activation/softmax smoke instantiation checks by importing `ReLU2Line` and `ReLU2LineMax` and calling their forward paths for both `None` and positive transition-point configurations, which succeeded.
- Verified CLI parsing for the new flags via the existing argument parser to ensure no parsing regressions occurred, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b669a61dc8326a1f91501c04e5473)