### PR TITLE
Add ReLU2Line activation and ReLU2LineMax softmax (config, CLI, and sweep)

### DIFF
--- a/explorations/relu2line_activation_softmax.yaml
+++ b/explorations/relu2line_activation_softmax.yaml
@@ -1,0 +1,160 @@
+# explorations/relu2line_activation_softmax.yaml
+#
+# Default-infinite-attention style sweep for the ReLU2Line activation and
+# ReLU2LineMax attention numerator. Baseline groups keep conventional GELU +
+# softmax and the existing ReLU^2 + ReLU2Max settings for comparison. ReLU2Line
+# groups sweep only positive transition points; the no-transition fast path is
+# represented by the squared_relu / relu2max baseline because it is numerically
+# equivalent to ReLU^2 without the linear tail.
+---
+
+named_static_groups:
+  # QK Norm
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  # Norm Type
+  - named_group: "peri_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [true]
+    use_post_ln: [false]
+
+  # Position Embeddings
+  - named_group: "rotary"
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+  # Embedding Norm
+  - named_group: "rmsnorm_wte"
+    norm_variant_wte: ["rmsnorm"]
+
+  # Infinite Attention
+  - named_group: "infinite"
+    attention_variant: ["infinite"]
+    use_concat_heads: [true]
+
+  # MQA
+  - named_group: "mqa"
+    n_kv_group: [1]
+
+  # Head Dimension
+  - named_group: "hd_100"
+    n_qk_head_dim: [100]
+    n_v_head_dim: [100]
+
+  - named_group: "hd_150"
+    n_qk_head_dim: [150]
+    n_v_head_dim: [150]
+
+  - named_group: "hd_200"
+    n_qk_head_dim: [200]
+    n_v_head_dim: [200]
+
+  # Conventional baselines
+  - named_group: "gelu_softmax"
+    activation_variant: ["gelu"]
+    softmax_variant_attn: ["softmax"]
+
+  - named_group: "relu2_relu2max"
+    activation_variant: ["squared_relu"]
+    softmax_variant_attn: ["relu2max"]
+    relu2max_divisor: [256.0]
+
+  # New variant placements
+  - named_group: "relu2line_activation_only"
+    activation_variant: ["relu2line"]
+    softmax_variant_attn: ["softmax"]
+
+  - named_group: "relu2line_softmax_only"
+    activation_variant: ["squared_relu"]
+    softmax_variant_attn: ["relu2linemax"]
+
+  - named_group: "relu2line_activation_and_softmax"
+    activation_variant: ["relu2line"]
+    softmax_variant_attn: ["relu2linemax"]
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [2500]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+  compile: [true]
+  log_rankme: [true]
+  log_areq: [true]
+  tensorboard_run_name: ["relu2line_activation_softmax"]
+
+parameter_groups:
+  # Conventional GELU + softmax frontier under the default_inf organization.
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "rmsnorm_wte"
+      - "infinite"
+      - "mqa"
+      - "gelu_softmax"
+    n_head:
+      range:
+        start: 1
+        end: 12
+        step: 1
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]
+
+  # Existing ReLU^2 + ReLU2Max baseline, including the no-transition equivalent
+  # for the new ReLU2Line shape.
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "rmsnorm_wte"
+      - "infinite"
+      - "mqa"
+      - "relu2_relu2max"
+    n_head:
+      range:
+        start: 1
+        end: 12
+        step: 1
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]
+
+  # Isolate the MLP activation effect while attention remains conventional.
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "rmsnorm_wte"
+      - "infinite"
+      - "mqa"
+      - "relu2line_activation_only"
+    relu2line_transition_point: [1.0, 2.0, 4.0, 8.0]
+    n_head: [2, 4, 8]
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]
+
+  # Isolate the attention numerator effect against the existing squared-ReLU MLP.
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "rmsnorm_wte"
+      - "infinite"
+      - "mqa"
+      - "relu2line_softmax_only"
+    relu2line_transition_point: [1.0, 2.0, 4.0, 8.0]
+    relu2line_divisor: [64.0, 256.0, 1024.0]
+    n_head: [2, 4, 8]
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]
+
+  # Joint sweep for the paired activation + attention variant.
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "rmsnorm_wte"
+      - "infinite"
+      - "mqa"
+      - "relu2line_activation_and_softmax"
+    relu2line_transition_point: [1.0, 2.0, 4.0, 8.0]
+    relu2line_divisor: [64.0, 256.0, 1024.0]
+    n_head: [2, 4, 8]
+    named_group_alternates: ["hd_100", "hd_150", "hd_200"]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -200,6 +200,7 @@ class GPTConfig:
     activation_transition_start_iter: int = 0
     activation_transition_end_iter: int = None
     relu_power: float = 2.0
+    relu2line_transition_point: float | None = None
 
     # MLP Options
     use_parallel_mlp: bool = False
@@ -295,8 +296,11 @@ class GPTConfig:
     ## ReLUMax options
     relumax_divisor: float = 256.0
 
-    ## ReLUMax options
+    ## ReLU2Max options
     relu2max_divisor: float = 256.0
+
+    ## ReLU2LineMax options
+    relu2line_divisor: float = 256.0
 
     ## SigmoidMax options
     sigmoidmax_divisor: float = 256.0

--- a/train_args.py
+++ b/train_args.py
@@ -849,6 +849,7 @@ def parse_args():
             "prelu",
             "relu",
             "relu_power",
+            "relu2line",
             "relu6",
             "rrelu",
             "disco",
@@ -1272,6 +1273,7 @@ def parse_args():
         "polymax",
         "relumax",
         "relu2max",
+        "relu2linemax",
         "sigmoidmax",
         "vpolymax",
         "exppolymax",
@@ -1321,6 +1323,10 @@ def parse_args():
 
     ### ReLU2Max Options
     model_group.add_argument("--relu2max_divisor", type=float, default=256.0)
+
+    ### ReLU2Line Options
+    model_group.add_argument("--relu2line_transition_point", type=float, default=None)
+    model_group.add_argument("--relu2line_divisor", type=float, default=256.0)
 
     ### SimgoidMax Options
     model_group.add_argument("--sigmoidmax_divisor", type=float, default=256.0)

--- a/variations/activation_variations.py
+++ b/variations/activation_variations.py
@@ -18,12 +18,42 @@ class ReLUPower(nn.Module):
     def forward(self, x):
         return torch.pow(torch.relu(x), self.power)
 
+class ReLU2Line(nn.Module):
+    """Squared ReLU that can smoothly become linear after a configured point.
+
+    When ``relu2line_transition_point`` is ``None`` this is exactly ReLU^2 and
+    avoids the ``torch.where`` blend used by the piecewise linear tail. When a
+    positive transition point ``p`` is supplied, values above ``p`` use the
+    tangent line ``2px - p^2``, making the function C1-continuous at ``p``.
+    """
+    def __init__(self, config):
+        super().__init__()
+        transition_point = getattr(config, "relu2line_transition_point", None)
+        if transition_point is None:
+            self.forward = self._forward_relu2
+        elif transition_point <= 0:
+            raise ValueError("relu2line_transition_point must be positive or None")
+        else:
+            self.register_buffer("transition_point", torch.tensor(float(transition_point)))
+            self.forward = self._forward_relu2line
+
+    def _forward_relu2(self, x):
+        return torch.relu(x).square()
+
+    def _forward_relu2line(self, x):
+        relu_x = torch.relu(x)
+        squared = relu_x.square()
+        linear = (2 * self.transition_point * relu_x) - self.transition_point.square()
+        return torch.where(relu_x > self.transition_point, linear, squared)
+
+
 class Disco(nn.Module):
     def __init__(self, config):
         super().__init__()
 
     def forward(self, x):
         return x * torch.abs(x)
+
 class SquaredGELU(nn.Module):
     def __init__(self, config):
         super().__init__()
@@ -365,6 +395,7 @@ activation_dictionary = {
     "softsign": Softsign_Config,
     "softshrink": Softshrink_Config,
     "relu_power": ReLUPower,
+    "relu2line": ReLU2Line,
     "squared_relu": SquaredReLU,
     "squared_gelu": SquaredGELU,
     "tanh": Tanh_Config,

--- a/variations/softmax_variations.py
+++ b/variations/softmax_variations.py
@@ -577,6 +577,47 @@ class ReLU2Max(nn.Module):
         return result
 
 
+class ReLU2LineMax(nn.Module):
+    """ReLU^2 attention/output weighting with an optional smooth linear tail.
+
+    If ``relu2line_transition_point`` is unset, this runs the same numerator as
+    ReLU2Max without paying for a piecewise blend. With a positive point ``p``,
+    the numerator follows ReLU^2 up to ``p`` and the tangent line ``2px - p^2``
+    afterwards, preserving value and slope at the join.
+    """
+    def __init__(self, config, dim=-1):
+        super().__init__()
+        self.dim = dim
+        self.relu2line_divisor = config.relu2line_divisor
+        self.div_by_seq_len = config.div_by_seq_len
+        transition_point = getattr(config, "relu2line_transition_point", None)
+        if transition_point is None:
+            self.forward = self._forward_relu2
+        elif transition_point <= 0:
+            raise ValueError("relu2line_transition_point must be positive or None")
+        else:
+            self.register_buffer("transition_point", torch.tensor(float(transition_point)))
+            self.forward = self._forward_relu2line
+
+    def _finish(self, result, x):
+        result = result / self.relu2line_divisor
+
+        if self.div_by_seq_len:
+            seq_len = x.shape[self.dim]
+            result = result / seq_len
+
+        return result
+
+    def _forward_relu2(self, x):
+        return self._finish(torch.relu(x).square(), x)
+
+    def _forward_relu2line(self, x):
+        relu_x = torch.relu(x)
+        squared = relu_x.square()
+        linear = (2 * self.transition_point * relu_x) - self.transition_point.square()
+        return self._finish(torch.where(relu_x > self.transition_point, linear, squared), x)
+
+
 class Softplus2Max(nn.Module):
     """ Softmax variant based on arxiv 1805.10829 with added handles for base """
     def __init__(self, config, dim=-1):
@@ -870,6 +911,7 @@ softmax_dictionary = {
     "sigsoftmax": SigSoftmax,
     "relumax": ReLUMax,
     "relu2max": ReLU2Max,
+    "relu2linemax": ReLU2LineMax,
     "sigmoidmax": SigmoidMax,
     "softshrink": Softshrink,
     "gelumax": Gelumax,


### PR DESCRIPTION
### Motivation
- Introduce a ReLU^2 variant that can smoothly transition to a linear tail to study performance/stability tradeoffs versus existing `squared_relu` and `relu2max` behaviors.
- Provide a matched attention/output numerator variant to evaluate interactions between MLP activation shape and attention numerator scaling.

### Description
- Add `ReLU2Line` activation implementation in `variations/activation_variations.py` with an efficient no-transition fast path and a C1-continuous piecewise linear tail controlled by `relu2line_transition_point`.
- Add `ReLU2LineMax` softmax/numerator implementation in `variations/softmax_variations.py` with matching piecewise behavior and divisor handling via `relu2line_divisor` and existing `div_by_seq_len` logic.
- Expose new configuration fields in `gpt_conf.py`: `relu2line_transition_point` and `relu2line_divisor`, and keep them `None`/default-compatible to avoid changing behavior unless enabled.
- Add CLI arguments in `train_args.py`: `--relu2line_transition_point` and `--relu2line_divisor`, and register `relu2line` and `relu2linemax` in the activation and softmax choice lists respectively.
- Add an exploration sweep file `explorations/relu2line_activation_softmax.yaml` that compares `relu2line` activation and `relu2linemax` numerator against `gelu+softmax` and `squared_relu+relu2max` baselines across head dimensions, transition points, and divisors.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b669a61dc8326a1f91501c04e5473)