### PR TITLE
feat(audio): add mel CSV multicontext demo and Plotly audio viewer

### DIFF
--- a/data/audio_mel_csv/README.md
+++ b/data/audio_mel_csv/README.md
@@ -2,7 +2,7 @@
 
 This directory extends the existing Whisper-style mel CSV direction into an end-to-end workflow similar to the Dukascopy multicontext demo:
 
-1. Decompose an audio file (`wav`, `mp3`, or `flac`) into Whisper-style normalized mel spectrogram frames.
+1. Decompose one audio file or a folder of audio files (`wav`, `mp3`, `flac`, `ogg`, or `m4a`) into Whisper-style normalized mel spectrogram frames.
 2. Quantize each mel channel to integer CSV columns so `data/csv_mc_int` can create one regular multicontext dataset per channel.
 3. Train with `train.py --training_mode multicontext` exactly like the Dukascopy flow.
 4. Sample mel continuations, reconstruct approximate WAV files, and render a Plotly HTML page with playable audio.
@@ -16,6 +16,8 @@ python3 data/audio_mel_csv/prepare_audio_mel_csv.py sample.wav \
   --output_root audio_mel_csv \
   --work_dir data/audio_mel_csv/work
 ```
+
+You can also pass a folder; supported audio files are processed in sorted order and concatenated at the mel-frame level.
 
 Outputs:
 
@@ -46,3 +48,14 @@ python3 data/audio_mel_csv/generate_audio_mel_comparison.py \
 ```
 
 Open `out/audio_mel_csv/audio_viewer/audio_prediction_vs_truth.html` to play sample and ground-truth audio and inspect Plotly heatmaps.
+
+## End-to-end demo with generated audio
+
+The demo accepts either an audio file or a folder of audio files. If no argument
+is provided, or if the target folder does not contain supported audio files, the
+script uses `sox` to synthesize a small folder of demo WAV files before running
+the same prepare → train → sample → viewer pipeline.
+
+```bash
+bash demos/audio_mel_csv_mc_int_demo.sh [optional-audio-file-or-folder]
+```

--- a/data/audio_mel_csv/README.md
+++ b/data/audio_mel_csv/README.md
@@ -1,0 +1,48 @@
+# Audio mel CSV multicontext extension
+
+This directory extends the existing Whisper-style mel CSV direction into an end-to-end workflow similar to the Dukascopy multicontext demo:
+
+1. Decompose an audio file (`wav`, `mp3`, or `flac`) into Whisper-style normalized mel spectrogram frames.
+2. Quantize each mel channel to integer CSV columns so `data/csv_mc_int` can create one regular multicontext dataset per channel.
+3. Train with `train.py --training_mode multicontext` exactly like the Dukascopy flow.
+4. Sample mel continuations, reconstruct approximate WAV files, and render a Plotly HTML page with playable audio.
+
+The generated viewer intentionally reconstructs and embeds audio for **prompt/start tokens + continuation** for both model samples and ground truth.
+
+## Prepare a dataset
+
+```bash
+python3 data/audio_mel_csv/prepare_audio_mel_csv.py sample.wav \
+  --output_root audio_mel_csv \
+  --work_dir data/audio_mel_csv/work
+```
+
+Outputs:
+
+- `data/audio_mel_csv/work/mel_float.csv`: normalized mel frames.
+- `data/audio_mel_csv/work/mel_int.csv`: integer CSV with headers `mel_000` ... `mel_079`.
+- `data/audio_mel_csv/manifest.json`: multicontext dataset manifest and mel/quantization metadata.
+- `data/audio_mel_csv/mel_*/train.bin`, `val.bin`, and `meta.pkl`: one context per mel channel.
+
+## Recompose a quantized mel CSV into audio
+
+```bash
+python3 data/audio_mel_csv/mel_int_csv_to_wav.py \
+  data/audio_mel_csv/work/mel_int.csv \
+  --output reconstructed.wav
+```
+
+This is an approximate inverse using `data/template/mel_csv_to_wav.py` and Griffin-Lim.
+
+## Generate the audio viewer
+
+After training a checkpoint, run:
+
+```bash
+python3 data/audio_mel_csv/generate_audio_mel_comparison.py \
+  --input_csv data/audio_mel_csv/work/mel_int.csv \
+  --manifest data/audio_mel_csv/manifest.json \
+  --checkpoint_dir out/audio_mel_csv
+```
+
+Open `out/audio_mel_csv/audio_viewer/audio_prediction_vs_truth.html` to play sample and ground-truth audio and inspect Plotly heatmaps.

--- a/data/audio_mel_csv/generate_audio_mel_comparison.py
+++ b/data/audio_mel_csv/generate_audio_mel_comparison.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Sample mel multicontext continuations, reconstruct audio, and write Plotly HTML."""
+from __future__ import annotations
+import argparse, base64, csv, html, json, subprocess, sys
+from dataclasses import dataclass
+from pathlib import Path
+
+@dataclass
+class Run: label:str; csv_path:Path; wav_path:Path; top_k:int; seed:int
+
+def read_rows(path):
+    with Path(path).open(newline='', encoding='utf-8') as f:
+        r=csv.reader(f); header=next(r); rows=[[int(float(x)) for x in row] for row in r if row]
+    return header, rows
+
+def write_csv(path, header, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open('w', newline='', encoding='utf-8') as f:
+        w=csv.writer(f); w.writerow(header); w.writerows(rows)
+
+def b64(path): return base64.b64encode(Path(path).read_bytes()).decode('ascii')
+
+def wav(repo, csv_path, out, scale, iters):
+    subprocess.run([sys.executable, str(repo/'data/audio_mel_csv/mel_int_csv_to_wav.py'), str(csv_path), '--output', str(out), '--scale', str(scale), '--griffin_lim_iters', str(iters)], check=True, cwd=repo)
+
+def sample(repo, ckpt, prompt_csv, output_csv, datasets, holdout, top_k, seed, device, dtype, compile_model):
+    cmd=[sys.executable,'sample.py','--out_dir',str(ckpt),'--device',device,'--dtype',dtype,'--multicontext','--multicontext_datasets',*datasets,'--multicontext_csv_input',str(prompt_csv),'--multicontext_csv_output_file',str(output_csv),'--max_new_tokens',str(holdout),'--top_k',str(top_k),'--seed',str(seed),'--num_samples','1','--no-print_model_info']
+    cmd.append('--compile' if compile_model else '--no-compile')
+    subprocess.run(cmd, check=True, cwd=repo)
+
+def html_page(path, payload):
+    js=json.dumps(payload).replace('</','<\\/')
+    path.write_text(f'''<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>{html.escape(payload['title'])}</title><script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script><style>body{{margin:0;padding:20px;background:#101114;color:#eee;font-family:system-ui,sans-serif}}.panel{{background:#191b20;border:1px solid #333842;border-radius:10px;padding:14px;margin:14px 0}}audio{{width:100%;max-width:720px}}.plot{{height:520px;border:1px solid #343a46;border-radius:8px}}label{{margin-right:14px;color:#cdd1d7}}</style></head><body><h1>{html.escape(payload['title'])}</h1><div class="panel"><p>Audio includes the start/prompt tokens. Ground truth is prompt + held-out continuation; samples are prompt + model continuation.</p><div id="audios"></div></div><div class="panel"><label><input id="truth" type="checkbox" checked> ground truth</label><span id="toggles"></span><div id="heat" class="plot"></div></div><script id="payload" type="application/json">{js}</script><script>
+const data=JSON.parse(document.getElementById('payload').textContent); const colors=['Viridis','Magma','Cividis','Turbo'];
+const audios=document.getElementById('audios');
+function addAudio(name,wav){{const d=document.createElement('div');d.innerHTML=`<h3>${{name}}</h3><audio controls src="data:audio/wav;base64,${{wav}}"></audio>`;audios.appendChild(d)}}
+addAudio('ground truth (prompt + holdout)', data.truth.wav); data.samples.forEach(s=>addAudio(s.label, s.wav));
+const toggles=document.getElementById('toggles'); data.samples.forEach((s,i)=>{{const l=document.createElement('label');l.innerHTML=`<input type="checkbox" class="s" data-i="${{i}}" checked> ${{s.label}}`;toggles.appendChild(l)}});
+document.getElementById('truth').onchange=render; toggles.onchange=render;
+function heat(name,z,colorscale,opacity=1){{return {{type:'heatmap',name,z:z[0].map((_,c)=>z.map(r=>r[c])), colorscale, opacity, showscale:false, hovertemplate:'mel=%{{y}}<br>frame=%{{x}}<br>value=%{{z}}<extra>'+name+'</extra>'}}}}
+function render(){{const traces=[]; if(document.getElementById('truth').checked) traces.push(heat('ground truth',data.truth.rows,'Viridis',1)); document.querySelectorAll('.s').forEach(cb=>{{if(cb.checked){{const i=+cb.dataset.i; traces.push(heat(data.samples[i].label,data.samples[i].rows,colors[(i+1)%colors.length],0.55));}}}}); Plotly.newPlot('heat',traces,{{paper_bgcolor:'#08090b',plot_bgcolor:'#08090b',font:{{color:'#d6deeb'}},xaxis:{{title:'frame (includes prompt/start tokens)'}},yaxis:{{title:'mel channel'}},margin:{{l:60,r:20,t:20,b:50}}}},{{responsive:true,displaylogo:false}})}}
+render();</script></body></html>''', encoding='utf-8')
+
+def main():
+    p=argparse.ArgumentParser(description=__doc__); p.add_argument('--input_csv', default='data/audio_mel_csv/work/mel_int.csv'); p.add_argument('--manifest', default='data/audio_mel_csv/manifest.json'); p.add_argument('--checkpoint_dir', default='out/audio_mel_csv'); p.add_argument('--work_dir', default='out/audio_mel_csv/audio_viewer'); p.add_argument('--holdout_rows', type=int, default=128); p.add_argument('--prompt_rows', type=int, default=512); p.add_argument('--seeds', nargs='+', type=int, default=[1337]); p.add_argument('--top_k', nargs='+', type=int, default=[5]); p.add_argument('--device', default='cuda:0'); p.add_argument('--dtype', default='bfloat16'); p.add_argument('--compile', dest='compile_model', action=argparse.BooleanOptionalAction, default=True); p.add_argument('--skip_sampling', action='store_true'); p.add_argument('--griffin_lim_iters', type=int, default=32)
+    a=p.parse_args(); repo=Path(__file__).resolve().parents[2]; work=Path(a.work_dir); work=work if work.is_absolute() else repo/work; work.mkdir(parents=True,exist_ok=True)
+    manifest=json.loads((repo/a.manifest if not Path(a.manifest).is_absolute() else Path(a.manifest)).read_text()); scale=manifest.get('quantization',{}).get('scale',32767); datasets=manifest['multicontext_datasets']
+    header, rows=read_rows(repo/a.input_csv if not Path(a.input_csv).is_absolute() else Path(a.input_csv)); prompt=rows[:-a.holdout_rows][-a.prompt_rows:]; truth=rows[-a.holdout_rows:]; prompt_csv=work/'prompt.csv'; truth_csv=work/'ground_truth_with_prompt.csv'; write_csv(prompt_csv,header,prompt); write_csv(truth_csv,header,prompt+truth); truth_wav=work/'ground_truth_with_prompt.wav'; wav(repo, truth_csv, truth_wav, scale, a.griffin_lim_iters)
+    runs=[]; samples_dir=work/'samples';
+    for top_k in a.top_k:
+      for seed in a.seeds:
+        out=samples_dir/f'sample_topk{top_k}_seed{seed}_with_prompt.csv'; ww=out.with_suffix('.wav')
+        if not a.skip_sampling: sample(repo, Path(a.checkpoint_dir), prompt_csv, out, datasets, a.holdout_rows, top_k, seed, a.device, a.dtype, a.compile_model)
+        if out.exists(): wav(repo,out,ww,scale,a.griffin_lim_iters); runs.append(Run(f'top_k={top_k} seed={seed}',out,ww,top_k,seed))
+    payload={'title':'Mel audio prediction vs ground truth','truth':{'rows':prompt+truth,'wav':b64(truth_wav)},'samples':[{'label':r.label,'rows':read_rows(r.csv_path)[1],'wav':b64(r.wav_path)} for r in runs]}
+    out_html=work/'audio_prediction_vs_truth.html'; html_page(out_html,payload); print(f'Viewer HTML: {out_html}')
+if __name__=='__main__': main()

--- a/data/audio_mel_csv/mel_int_csv_to_wav.py
+++ b/data/audio_mel_csv/mel_int_csv_to_wav.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Convert quantized mel integer CSV back to WAV via existing mel_csv_to_wav.py."""
+from __future__ import annotations
+import argparse, csv, subprocess, sys, tempfile
+from pathlib import Path
+
+def load_numeric(path):
+    import numpy as np
+    with Path(path).open(newline='', encoding='utf-8') as f:
+        rows=list(csv.reader(f))
+    if not rows: raise ValueError('empty CSV')
+    start=0
+    try: [float(x) for x in rows[0]]
+    except ValueError: start=1
+    return np.array([[float(x) for x in r] for r in rows[start:] if r], dtype=np.float32)
+
+def main():
+    p=argparse.ArgumentParser(description=__doc__)
+    p.add_argument('csv_path'); p.add_argument('--output', default='reconstructed.wav'); p.add_argument('--scale', type=float, default=32767.0)
+    p.add_argument('--keep_float_csv', default=None)
+    p.add_argument('--griffin_lim_iters', type=int, default=32)
+    args=p.parse_args(); repo=Path(__file__).resolve().parents[2]
+    import numpy as np
+    data=load_numeric(args.csv_path)/args.scale
+    tmp_path=Path(args.keep_float_csv) if args.keep_float_csv else Path(tempfile.mkstemp(suffix='.csv')[1])
+    np.savetxt(tmp_path, data, delimiter=',', fmt='%.6f')
+    try:
+        subprocess.run([sys.executable, str(repo/'data/template/mel_csv_to_wav.py'), str(tmp_path), '--output', args.output, '--griffin_lim_iters', str(args.griffin_lim_iters)], check=True, cwd=repo)
+    finally:
+        if not args.keep_float_csv: tmp_path.unlink(missing_ok=True)
+if __name__=='__main__': main()

--- a/data/audio_mel_csv/prepare_audio_mel_csv.py
+++ b/data/audio_mel_csv/prepare_audio_mel_csv.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Decompose audio into quantized Whisper-style mel CSV for multicontext training."""
+from __future__ import annotations
+import argparse, csv, json, pickle, subprocess, sys
+from pathlib import Path
+
+def main():
+    p=argparse.ArgumentParser(description=__doc__)
+    p.add_argument('audio', help='Input wav/mp3/flac audio')
+    p.add_argument('--output_root', default='audio_mel_csv', help='Folder under data/ for datasets and manifest')
+    p.add_argument('--work_dir', default='data/audio_mel_csv/work')
+    p.add_argument('--quantized_csv', default=None)
+    p.add_argument('--scale', type=int, default=32767, help='Scale normalized mel floats to integer range')
+    p.add_argument('--train_ratio', type=float, default=0.9)
+    p.add_argument('--keep_float_csv', action='store_true')
+    args=p.parse_args()
+    import numpy as np
+    repo=Path(__file__).resolve().parents[2]
+    work=Path(args.work_dir); work = work if work.is_absolute() else repo/work; work.mkdir(parents=True, exist_ok=True)
+    float_csv=work/'mel_float.csv'
+    q_csv=Path(args.quantized_csv) if args.quantized_csv else work/'mel_int.csv'
+    if not q_csv.is_absolute(): q_csv=repo/q_csv
+    prep=repo/'data/template/prepare.py'
+    subprocess.run([sys.executable, str(prep), '--method','whisper_mel_csv','--train_input',args.audio,'--train_output',str(float_csv),'--percentage_train','1.0'], check=True, cwd=repo)
+    mel=np.loadtxt(float_csv, delimiter=',', dtype=np.float32)
+    if mel.ndim==1: mel=mel[np.newaxis,:]
+    q=np.rint(np.clip(mel,0.0,1.0)*args.scale).astype(np.int32)
+    q_csv.parent.mkdir(parents=True, exist_ok=True)
+    header=[f'mel_{i:03d}' for i in range(q.shape[1])]
+    with q_csv.open('w', newline='', encoding='utf-8') as f:
+        w=csv.writer(f); w.writerow(header); w.writerows(q.tolist())
+    out_root=args.output_root
+    subprocess.run([sys.executable, str(repo/'data/csv_mc_int/prepare_csv_integer_multicontext.py'), '--input_csv', str(q_csv), '--output_root', out_root, '--train_ratio', str(args.train_ratio), '--default_range', f'0:{args.scale}', '--allow_out_of_range'], check=True, cwd=repo)
+    manifest=repo/'data'/out_root/'manifest.json'
+    meta={}
+    with (repo/'meta.pkl').open('rb') as f: meta=pickle.load(f)
+    m=json.loads(manifest.read_text())
+    m.update({'audio_source': str(Path(args.audio).resolve()), 'float_mel_csv': str(float_csv), 'quantized_mel_csv': str(q_csv), 'quantization': {'scale': args.scale, 'inverse': 'float = integer / scale'}, 'mel_meta': meta})
+    manifest.write_text(json.dumps(m, indent=2), encoding='utf-8')
+    if not args.keep_float_csv and float_csv.exists():
+        pass
+    print(f'Quantized mel CSV: {q_csv}')
+    print(f'Manifest: {manifest}')
+if __name__=='__main__': main()

--- a/data/audio_mel_csv/prepare_audio_mel_csv.py
+++ b/data/audio_mel_csv/prepare_audio_mel_csv.py
@@ -1,44 +1,135 @@
 #!/usr/bin/env python3
-"""Decompose audio into quantized Whisper-style mel CSV for multicontext training."""
+"""Decompose one audio file or a folder of audio files into quantized mel CSV."""
+
 from __future__ import annotations
-import argparse, csv, json, pickle, subprocess, sys
+
+import argparse
+import csv
+import json
+import pickle
+import subprocess
+import sys
 from pathlib import Path
 
-def main():
-    p=argparse.ArgumentParser(description=__doc__)
-    p.add_argument('audio', help='Input wav/mp3/flac audio')
-    p.add_argument('--output_root', default='audio_mel_csv', help='Folder under data/ for datasets and manifest')
-    p.add_argument('--work_dir', default='data/audio_mel_csv/work')
-    p.add_argument('--quantized_csv', default=None)
-    p.add_argument('--scale', type=int, default=32767, help='Scale normalized mel floats to integer range')
-    p.add_argument('--train_ratio', type=float, default=0.9)
-    p.add_argument('--keep_float_csv', action='store_true')
-    args=p.parse_args()
+AUDIO_EXTENSIONS = {".wav", ".wave", ".mp3", ".flac", ".ogg", ".m4a"}
+
+
+def resolve_audio_inputs(path: Path) -> list[Path]:
+    if path.is_dir():
+        return sorted(p for p in path.rglob("*") if p.is_file() and p.suffix.lower() in AUDIO_EXTENSIONS)
+    return [path]
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("audio", help="Input audio file or folder containing wav/mp3/flac/ogg/m4a files.")
+    p.add_argument("--output_root", default="audio_mel_csv", help="Folder under data/ for datasets and manifest.")
+    p.add_argument("--work_dir", default="data/audio_mel_csv/work")
+    p.add_argument("--quantized_csv", default=None)
+    p.add_argument("--scale", type=int, default=32767, help="Scale normalized mel floats to integer range.")
+    p.add_argument("--train_ratio", type=float, default=0.9)
+    p.add_argument("--keep_per_file_float_csv", action="store_true", help="Keep intermediate per-audio mel CSV files.")
+    args = p.parse_args()
+
     import numpy as np
-    repo=Path(__file__).resolve().parents[2]
-    work=Path(args.work_dir); work = work if work.is_absolute() else repo/work; work.mkdir(parents=True, exist_ok=True)
-    float_csv=work/'mel_float.csv'
-    q_csv=Path(args.quantized_csv) if args.quantized_csv else work/'mel_int.csv'
-    if not q_csv.is_absolute(): q_csv=repo/q_csv
-    prep=repo/'data/template/prepare.py'
-    subprocess.run([sys.executable, str(prep), '--method','whisper_mel_csv','--train_input',args.audio,'--train_output',str(float_csv),'--percentage_train','1.0'], check=True, cwd=repo)
-    mel=np.loadtxt(float_csv, delimiter=',', dtype=np.float32)
-    if mel.ndim==1: mel=mel[np.newaxis,:]
-    q=np.rint(np.clip(mel,0.0,1.0)*args.scale).astype(np.int32)
+
+    repo = Path(__file__).resolve().parents[2]
+    source = Path(args.audio)
+    if not source.is_absolute():
+        source = repo / source
+    audio_files = resolve_audio_inputs(source)
+    if not audio_files:
+        raise FileNotFoundError(f"No supported audio files found at {source}")
+
+    work = Path(args.work_dir)
+    work = work if work.is_absolute() else repo / work
+    work.mkdir(parents=True, exist_ok=True)
+    per_file_dir = work / "per_file_float_mels"
+    per_file_dir.mkdir(parents=True, exist_ok=True)
+    float_csv = work / "mel_float.csv"
+    q_csv = Path(args.quantized_csv) if args.quantized_csv else work / "mel_int.csv"
+    if not q_csv.is_absolute():
+        q_csv = repo / q_csv
+
+    prep = repo / "data/template/prepare.py"
+    frames = []
+    segments = []
+    cursor = 0
+    for idx, audio_file in enumerate(audio_files):
+        part_csv = per_file_dir / f"{idx:04d}_{audio_file.stem}.csv"
+        subprocess.run(
+            [
+                sys.executable,
+                str(prep),
+                "--method",
+                "whisper_mel_csv",
+                "--train_input",
+                str(audio_file),
+                "--train_output",
+                str(part_csv),
+                "--percentage_train",
+                "1.0",
+            ],
+            check=True,
+            cwd=repo,
+        )
+        mel_part = np.loadtxt(part_csv, delimiter=",", dtype=np.float32)
+        if mel_part.ndim == 1:
+            mel_part = mel_part[np.newaxis, :]
+        frames.append(mel_part)
+        segments.append({"path": str(audio_file), "start_frame": cursor, "frames": int(mel_part.shape[0])})
+        cursor += int(mel_part.shape[0])
+        if not args.keep_per_file_float_csv:
+            part_csv.unlink(missing_ok=True)
+
+    mel = np.vstack(frames)
+    np.savetxt(float_csv, mel, delimiter=",", fmt="%.6f")
+    q = np.rint(np.clip(mel, 0.0, 1.0) * args.scale).astype(np.int32)
     q_csv.parent.mkdir(parents=True, exist_ok=True)
-    header=[f'mel_{i:03d}' for i in range(q.shape[1])]
-    with q_csv.open('w', newline='', encoding='utf-8') as f:
-        w=csv.writer(f); w.writerow(header); w.writerows(q.tolist())
-    out_root=args.output_root
-    subprocess.run([sys.executable, str(repo/'data/csv_mc_int/prepare_csv_integer_multicontext.py'), '--input_csv', str(q_csv), '--output_root', out_root, '--train_ratio', str(args.train_ratio), '--default_range', f'0:{args.scale}', '--allow_out_of_range'], check=True, cwd=repo)
-    manifest=repo/'data'/out_root/'manifest.json'
-    meta={}
-    with (repo/'meta.pkl').open('rb') as f: meta=pickle.load(f)
-    m=json.loads(manifest.read_text())
-    m.update({'audio_source': str(Path(args.audio).resolve()), 'float_mel_csv': str(float_csv), 'quantized_mel_csv': str(q_csv), 'quantization': {'scale': args.scale, 'inverse': 'float = integer / scale'}, 'mel_meta': meta})
-    manifest.write_text(json.dumps(m, indent=2), encoding='utf-8')
-    if not args.keep_float_csv and float_csv.exists():
-        pass
-    print(f'Quantized mel CSV: {q_csv}')
-    print(f'Manifest: {manifest}')
-if __name__=='__main__': main()
+    header = [f"mel_{i:03d}" for i in range(q.shape[1])]
+    with q_csv.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(header)
+        w.writerows(q.tolist())
+
+    out_root = args.output_root
+    subprocess.run(
+        [
+            sys.executable,
+            str(repo / "data/csv_mc_int/prepare_csv_integer_multicontext.py"),
+            "--input_csv",
+            str(q_csv),
+            "--output_root",
+            out_root,
+            "--train_ratio",
+            str(args.train_ratio),
+            "--default_range",
+            f"0:{args.scale}",
+            "--allow_out_of_range",
+        ],
+        check=True,
+        cwd=repo,
+    )
+    manifest = repo / "data" / out_root / "manifest.json"
+    with (repo / "meta.pkl").open("rb") as f:
+        meta = pickle.load(f)
+    m = json.loads(manifest.read_text(encoding="utf-8"))
+    m.update(
+        {
+            "audio_source": str(source),
+            "audio_files": [str(p) for p in audio_files],
+            "audio_segments": segments,
+            "float_mel_csv": str(float_csv),
+            "quantized_mel_csv": str(q_csv),
+            "quantization": {"scale": args.scale, "inverse": "float = integer / scale"},
+            "mel_meta": meta,
+        }
+    )
+    manifest.write_text(json.dumps(m, indent=2), encoding="utf-8")
+    print(f"Audio files: {len(audio_files)}")
+    print(f"Quantized mel CSV: {q_csv}")
+    print(f"Manifest: {manifest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/audio_mel_csv_mc_int_demo.sh
+++ b/demos/audio_mel_csv_mc_int_demo.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Audio mel regular integer CSV multicontext demo:
+# 1) convert audio to quantized Whisper mel CSV columns
+# 2) split columns into per-channel integer datasets via data/csv_mc_int
+# 3) train regular multicontext
+# 4) sample, reconstruct WAVs including prompt/start tokens, and write Plotly HTML
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+AUDIO_INPUT="${1:?Usage: $0 input.wav|input.mp3|input.flac}"
+OUTPUT_ROOT="${AUDIO_MEL_OUTPUT_ROOT:-audio_mel_csv}"
+WORK_DIR="${AUDIO_MEL_WORK_DIR:-data/audio_mel_csv/work}"
+OUT_DIR="${AUDIO_MEL_OUT_DIR:-out/audio_mel_csv}"
+MAX_ITERS="${AUDIO_MEL_MAX_ITERS:-1000}"
+DEVICE="${AUDIO_MEL_DEVICE:-cuda:0}"
+DTYPE="${AUDIO_MEL_DTYPE:-bfloat16}"
+
+python3 data/audio_mel_csv/prepare_audio_mel_csv.py "$AUDIO_INPUT" \
+  --output_root "$OUTPUT_ROOT" \
+  --work_dir "$WORK_DIR" \
+  --train_ratio "${AUDIO_MEL_TRAIN_RATIO:-0.9}"
+
+mapfile -t DATASETS < <(python3 - <<PY
+import json
+from pathlib import Path
+manifest = json.loads(Path('data/$OUTPUT_ROOT/manifest.json').read_text())
+for dataset in manifest['multicontext_datasets']:
+    print(dataset)
+PY
+)
+
+python3 train.py \
+  --training_mode multicontext \
+  --dataset "${DATASETS[0]}" \
+  --multicontext \
+  --multicontext_datasets "${DATASETS[@]}" \
+  --n_layer 6 \
+  --n_head 6 \
+  --attention_variant infinite \
+  --use_concat_heads \
+  --n_qk_head_dim 200 \
+  --n_v_head_dim 112 \
+  --n_embd 128 \
+  --block_size 100 \
+  --batch_size 2 \
+  --max_iters "$MAX_ITERS" \
+  --eval_interval 50 \
+  --eval_iters 10 \
+  --learning_rate 1e-3 \
+  --dropout 0.0 \
+  --device "$DEVICE" \
+  --dtype "$DTYPE" \
+  --optimizer muon \
+  --weight_decay 0.0 \
+  --softmax_variant_attn relu2max \
+  --use_qk_norm \
+  --use_qk_norm_scale \
+  --use_rotary_embeddings \
+  --no-use_abs_pos_embeddings \
+  --compile \
+  --out_dir "$OUT_DIR"
+
+read -r -a VIEWER_SEEDS <<<"${AUDIO_MEL_VIEWER_SEEDS:-1337 1338 1339}"
+read -r -a VIEWER_TOP_K <<<"${AUDIO_MEL_VIEWER_TOP_K:-1 5}"
+python3 data/audio_mel_csv/generate_audio_mel_comparison.py \
+  --input_csv "$WORK_DIR/mel_int.csv" \
+  --manifest "data/$OUTPUT_ROOT/manifest.json" \
+  --checkpoint_dir "$OUT_DIR" \
+  --work_dir "${AUDIO_MEL_VIEWER_WORK_DIR:-$OUT_DIR/audio_viewer}" \
+  --holdout_rows "${AUDIO_MEL_VIEWER_HOLDOUT_ROWS:-128}" \
+  --prompt_rows "${AUDIO_MEL_VIEWER_PROMPT_ROWS:-512}" \
+  --seeds "${VIEWER_SEEDS[@]}" \
+  --top_k "${VIEWER_TOP_K[@]}" \
+  --device "$DEVICE" \
+  --dtype "$DTYPE" \
+  --compile

--- a/demos/audio_mel_csv_mc_int_demo.sh
+++ b/demos/audio_mel_csv_mc_int_demo.sh
@@ -7,13 +7,43 @@
 set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
-AUDIO_INPUT="${1:?Usage: $0 input.wav|input.mp3|input.flac}"
+AUDIO_INPUT="${1:-data/audio_mel_csv/demo_audio}"
 OUTPUT_ROOT="${AUDIO_MEL_OUTPUT_ROOT:-audio_mel_csv}"
 WORK_DIR="${AUDIO_MEL_WORK_DIR:-data/audio_mel_csv/work}"
 OUT_DIR="${AUDIO_MEL_OUT_DIR:-out/audio_mel_csv}"
 MAX_ITERS="${AUDIO_MEL_MAX_ITERS:-1000}"
 DEVICE="${AUDIO_MEL_DEVICE:-cuda:0}"
 DTYPE="${AUDIO_MEL_DTYPE:-bfloat16}"
+
+find_audio_files() {
+  local path="$1"
+  if [[ -f "$path" ]]; then
+    printf '%s\n' "$path"
+  elif [[ -d "$path" ]]; then
+    find "$path" -type f \( -iname "*.wav" -o -iname "*.wave" -o -iname "*.mp3" -o -iname "*.flac" -o -iname "*.ogg" -o -iname "*.m4a" \) -print
+  fi
+}
+
+create_demo_audio_folder() {
+  local folder="$1"
+  if ! command -v sox >/dev/null 2>&1; then
+    echo "No audio files found at '$folder' and sox is not installed. Install sox or pass an audio file/folder." >&2
+    exit 1
+  fi
+  mkdir -p "$folder"
+  echo "No audio files found at '$folder'; generating demo WAV files with sox."
+  sox -n -r 16000 -c 1 "$folder/000_sine_220hz.wav" synth 1.5 sine 220 fade 0.02 1.5 0.02 gain -6
+  sox -n -r 16000 -c 1 "$folder/001_sine_330hz.wav" synth 1.5 sine 330 fade 0.02 1.5 0.02 gain -6
+  sox -n -r 16000 -c 1 "$folder/002_chord.wav" synth 1.5 sine 261.63 sine 329.63 sine 392.00 fade 0.02 1.5 0.02 gain -10
+}
+
+if [[ -z "$(find_audio_files "$AUDIO_INPUT" | head -n 1)" ]]; then
+  if [[ -f "$AUDIO_INPUT" ]]; then
+    echo "'$AUDIO_INPUT' exists but is not a supported audio file (.wav/.wave/.mp3/.flac/.ogg/.m4a)." >&2
+    exit 1
+  fi
+  create_demo_audio_folder "$AUDIO_INPUT"
+fi
 
 python3 data/audio_mel_csv/prepare_audio_mel_csv.py "$AUDIO_INPUT" \
   --output_root "$OUTPUT_ROOT" \


### PR DESCRIPTION
### Motivation
- Reuse the Dukascopy multicontext demo direction for audio by converting Whisper-style mel spectrograms into integer multicontext datasets so the existing training/sampling pipeline can be applied to audio. 
- Provide end-to-end tooling to decompose audio to mel CSV, train with the multicontext flow, reconstruct audio (including prompt/start tokens), and visualize/play model samples vs ground truth in a browser.

### Description
- Add `data/audio_mel_csv/prepare_audio_mel_csv.py` to export normalized Whisper mel frames, quantize them to integer CSV columns, and invoke `data/csv_mc_int/prepare_csv_integer_multicontext.py` to build per-channel multicontext datasets and a manifest. 
- Add `data/audio_mel_csv/mel_int_csv_to_wav.py` to convert quantized integer mel CSV back to normalized floats and call the existing `data/template/mel_csv_to_wav.py` for approximate WAV reconstruction (Griffin-Lim). 
- Add `data/audio_mel_csv/generate_audio_mel_comparison.py` to run seeded/top-k multicontext sampling, reconstruct WAVs for prompt+continuation (including start tokens), and write a Plotly-based HTML viewer that embeds playable audio and heatmap graphs of mel frames for ground truth and samples. 
- Add `demos/audio_mel_csv_mc_int_demo.sh` to provide an end-to-end demo modeled on the Dukascopy flow (prepare → train → sample → viewer) and `data/audio_mel_csv/README.md` documenting usage and outputs.

### Testing
- Ran `python3 -m py_compile data/audio_mel_csv/*.py` which succeeded. 
- Inspected CLI help for new tools using `--help` invocations (`prepare_audio_mel_csv.py`, `generate_audio_mel_comparison.py`, `mel_int_csv_to_wav.py`) which printed usage and returned successfully. 
- Performed repository checks with `git diff --cached --check` and committed the new files without issues. 
- No runtime training/sampling was executed in CI; the changes are exercised via the prepared scripts and help/compile checks above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55feb32c1883269862f1432cc6ff7b)