### PR TITLE
feat(sample): add dynamic temperature sampling scaled by logit flatness

### DIFF
--- a/demos/conala_dynamic_sampling_demo.sh
+++ b/demos/conala_dynamic_sampling_demo.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
-# Demo: train a small CoNaLa instruction-to-code model and sample with
-# entropy/flatness-scaled dynamic temperature.
+# Demo: train a small CoNaLa instruction-to-code model, then compare baseline
+# confidence heatmaps against dynamic-temperature effective colorization.
 set -euo pipefail
+
+OUT_DIR=${OUT_DIR:-./out_conala_dynamic_sampling}
+PROMPT=${PROMPT:-$'#U:\nwrite python code to flatten a list of lists\n#B:\n'}
+SEED=${SEED:-1337}
+MAX_NEW_TOKENS=${MAX_NEW_TOKENS:-160}
+TOP_K=${TOP_K:-50}
+TEMPERATURE=${TEMPERATURE:-0.8}
 
 if [ ! -f data/conala/input.txt ]; then
   echo "Preparing CoNaLa input.txt..."
@@ -10,20 +17,40 @@ fi
 
 python3 train.py \
   --dataset data/conala \
-  --out_dir ./out_conala_dynamic_sampling \
+  --out_dir "$OUT_DIR" \
   --max_iters 2000 \
   --eval_interval 500 \
   --log_interval 10 \
   --compile
 
+# Baseline: same seed/settings, no dynamic temperature. This emits the original
+# per-token confidence colorization and heatmap images under OUT_DIR for comparison.
 python3 sample.py \
-  --out_dir ./out_conala_dynamic_sampling \
-  --start $'#U:\nwrite python code to flatten a list of lists\n#B:\n' \
-  --max_new_tokens 160 \
-  --num_samples 3 \
-  --top_k 50 \
-  --temperature 0.8 \
+  --out_dir "$OUT_DIR" \
+  --start "$PROMPT" \
+  --max_new_tokens "$MAX_NEW_TOKENS" \
+  --num_samples 1 \
+  --top_k "$TOP_K" \
+  --temperature "$TEMPERATURE" \
+  --seed "$SEED" \
+  --colorize_output \
+  --colorize_mode softmax \
+  --show_heatmaps \
+  --sample_file "$OUT_DIR/conala_baseline_confidence.txt"
+
+# Dynamic: same seed/settings plus dynamic temperature. The color map visualizes
+# effective per-token temperature: green is lower/sharper, red is higher/flatter.
+python3 sample.py \
+  --out_dir "$OUT_DIR" \
+  --start "$PROMPT" \
+  --max_new_tokens "$MAX_NEW_TOKENS" \
+  --num_samples 1 \
+  --top_k "$TOP_K" \
+  --temperature "$TEMPERATURE" \
+  --seed "$SEED" \
   --dynamic_temperature \
   --dynamic_temperature_min 0.35 \
   --dynamic_temperature_max 1.75 \
-  --sample_file ./out_conala_dynamic_sampling/conala_dynamic_samples.txt
+  --colorize_output \
+  --colorize_mode dynamic_temperature \
+  --sample_file "$OUT_DIR/conala_dynamic_temperature_map.txt"

--- a/demos/conala_dynamic_sampling_demo.sh
+++ b/demos/conala_dynamic_sampling_demo.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Demo: train a small CoNaLa instruction-to-code model and sample with
+# entropy/flatness-scaled dynamic temperature.
+set -euo pipefail
+
+if [ ! -f data/conala/input.txt ]; then
+  echo "Preparing CoNaLa input.txt..."
+  (cd data/conala && bash get_dataset.sh)
+fi
+
+python3 train.py \
+  --dataset data/conala \
+  --out_dir ./out_conala_dynamic_sampling \
+  --max_iters 2000 \
+  --eval_interval 500 \
+  --log_interval 10 \
+  --compile
+
+python3 sample.py \
+  --out_dir ./out_conala_dynamic_sampling \
+  --start $'#U:\nwrite python code to flatten a list of lists\n#B:\n' \
+  --max_new_tokens 160 \
+  --num_samples 3 \
+  --top_k 50 \
+  --temperature 0.8 \
+  --dynamic_temperature \
+  --dynamic_temperature_min 0.35 \
+  --dynamic_temperature_max 1.75 \
+  --sample_file ./out_conala_dynamic_sampling/conala_dynamic_samples.txt

--- a/sample.py
+++ b/sample.py
@@ -77,9 +77,9 @@ def parse_args():
 
     # Output Confidence
     parser.add_argument('--colorize_mode', type=str, default='minmax',
-                        choices=['minmax', 'softmax', 'softmax_top_k', 'rank', 'dot_product', 'topk', 'all'],
+                        choices=['minmax', 'softmax', 'softmax_top_k', 'rank', 'dot_product', 'dynamic_temperature', 'topk', 'all'],
                         help="Mode to colorize text: 'minmax' (default), 'softmax', 'softmax_top_k' for softmax over top-k values,"
-                             " 'rank', 'dot_product', or 'topk' to display a prediction table. "
+                             " 'rank', 'dot_product', 'dynamic_temperature', or 'topk' to display a prediction table. "
                              "Requires --colorize_output (enabled by default).")
     parser.add_argument('--colorize_topk', type=int, default=10,
                         help="Number of top predictions to display when colorize_mode='topk'")
@@ -254,6 +254,9 @@ def colorize_text(tokens, data_for_color, decode, colorize_mode='minmax'):
       - 'softmax': data_for_color is a 2D list/array (T, vocab_size) containing
                    the *full* distribution at each step. We extract the chosen
                    token's probability for each step, then min-max normalize.
+      - 'dynamic_temperature': data_for_color is a 1D list/array of effective
+                   per-token temperatures. Lower temperatures render greener
+                   (more confident/sharp), higher temperatures render redder.
     """
     text = Text()
 
@@ -282,6 +285,11 @@ def colorize_text(tokens, data_for_color, decode, colorize_mode='minmax'):
 
         # Normalize the chosen values (probabilities or logits) to [0..1]
         norm_values = (values - values.min()) / (values.max() - values.min() + 1e-6)
+
+    if colorize_mode == 'dynamic_temperature':
+        values = torch.tensor(data_for_color, dtype=torch.float32)
+        normalized_temps = (values - values.min()) / (values.max() - values.min() + 1e-6)
+        norm_values = 1.0 - normalized_temps
 
     segments = _token_segments(tokens, decode)
     for i, token_str in enumerate(segments):
@@ -608,7 +616,7 @@ def sample_with_existing_model(
     console = Console()
     model.eval()
 
-    valid_modes = ["minmax", "softmax", "softmax_top_k", "dot_product", "rank", "topk"]
+    valid_modes = ["minmax", "softmax", "softmax_top_k", "dot_product", "dynamic_temperature", "rank", "topk"]
     modes_to_apply = valid_modes if colorize_mode == "all" else [colorize_mode]
 
 
@@ -625,6 +633,7 @@ def sample_with_existing_model(
             kl_divergences = [] # To store the impact of the cosine penalty
             dynamic_temperatures = []
             dynamic_flatness_values = []
+            dynamic_temperatures_for_color: List[float] = []
 
             if args is not None:
                 # This block handles LSV for standalone sampling. When called from train.py,
@@ -754,6 +763,11 @@ def sample_with_existing_model(
 
                     if colorize_output:
                         chosen = idx_next.item()
+                        if args is not None and args.dynamic_temperature:
+                            if isinstance(step_temperature, torch.Tensor):
+                                dynamic_temperatures_for_color.append(float(step_temperature.flatten()[0].detach().cpu()))
+                            else:
+                                dynamic_temperatures_for_color.append(float(step_temperature))
                         # rank: 1 = best
                         rank = (full_row > full_row[chosen]).sum().item() + 1
 
@@ -842,6 +856,8 @@ def sample_with_existing_model(
                         data_for_color = topk_rows
                     elif cm == "dot_product":
                         data_for_color = dot_product_values
+                    elif cm == "dynamic_temperature" and dynamic_temperatures_for_color:
+                        data_for_color = dynamic_temperatures_for_color
 
                     if data_for_color is not None:
                         coloured = colorize_text(              # type: ignore

--- a/sample.py
+++ b/sample.py
@@ -45,6 +45,9 @@ def parse_args():
     parser.add_argument("--num_samples", type=int, default=3, help="Number of inference streams to draw")
     parser.add_argument("--max_new_tokens", type=int, default=500, help="Number of tokens to generate in each sample")
     parser.add_argument("--temperature", type=float, default=0.8, help="Temperature for predictions (1.0 = no change, < 1.0 = less random, > 1.0 = more random)")
+    parser.add_argument("--dynamic_temperature", default=False, action=argparse.BooleanOptionalAction, help="Scale sampling temperature by the flatness of the next-token logit distribution.")
+    parser.add_argument("--dynamic_temperature_min", type=float, default=0.25, help="Lower multiplier for --dynamic_temperature when the distribution is sharp.")
+    parser.add_argument("--dynamic_temperature_max", type=float, default=2.0, help="Upper multiplier for --dynamic_temperature when the distribution is flat.")
     parser.add_argument("--top_k", type=int, nargs='+', default=[1, 200], help="Retain only the top_k most likely tokens")
     parser.add_argument("--seed", type=int, default=1337, help="Seed for pseudorandom number generator")
     parser.add_argument("--dtype", type=str, default="bfloat16", choices=["bfloat16", "float16", "float32"], help="Torch data type for inference")
@@ -174,6 +177,35 @@ def parse_args():
     return parser.parse_args()
 
 
+
+
+def dynamic_temperature_from_logits(
+    logits: torch.Tensor,
+    base_temperature: float,
+    min_multiplier: float = 0.25,
+    max_multiplier: float = 2.0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return per-row temperatures proportional to logit-distribution flatness.
+
+    Flatness is measured as normalized entropy of the softmax distribution
+    computed at temperature 1.0. A one-hot/sharp distribution approaches 0,
+    a uniform/flat distribution approaches 1, and the returned temperature is
+    linearly interpolated between ``base * min_multiplier`` and
+    ``base * max_multiplier``.
+    """
+    if base_temperature <= 0:
+        raise ValueError("base_temperature must be positive")
+    if min_multiplier <= 0 or max_multiplier <= 0:
+        raise ValueError("dynamic temperature multipliers must be positive")
+    if min_multiplier > max_multiplier:
+        raise ValueError("dynamic_temperature_min must be <= dynamic_temperature_max")
+
+    finite_counts = torch.isfinite(logits).sum(dim=-1).clamp_min(2).to(logits.dtype)
+    probs = F.softmax(logits, dim=-1)
+    entropy = -(probs * torch.log(probs.clamp_min(torch.finfo(probs.dtype).tiny))).sum(dim=-1)
+    flatness = (entropy / torch.log(finite_counts)).clamp(0.0, 1.0)
+    multiplier = min_multiplier + flatness * (max_multiplier - min_multiplier)
+    return base_temperature * multiplier, flatness
 
 def convert_rich_renderable_to_ansi(renderable) -> str:
     """Convert any Rich renderable (Text, Table, etc.) into an ANSI string."""
@@ -591,6 +623,8 @@ def sample_with_existing_model(
         for sample_idx in range(num_samples):
             # ------------- LSV per-sample section -------------------
             kl_divergences = [] # To store the impact of the cosine penalty
+            dynamic_temperatures = []
+            dynamic_flatness_values = []
 
             if args is not None:
                 # This block handles LSV for standalone sampling. When called from train.py,
@@ -666,7 +700,19 @@ def sample_with_existing_model(
                             kl_divergences.append(kl_div.item())
 
 
-                    logits = raw_logits_row / temperature        # Scaled logits for sampling
+                    step_temperature = temperature
+                    if args is not None and args.dynamic_temperature:
+                        step_temperature_tensor, flatness_tensor = dynamic_temperature_from_logits(
+                            raw_logits_row,
+                            temperature,
+                            args.dynamic_temperature_min,
+                            args.dynamic_temperature_max,
+                        )
+                        step_temperature = step_temperature_tensor.unsqueeze(-1)
+                        dynamic_temperatures.append(step_temperature_tensor.detach().cpu())
+                        dynamic_flatness_values.append(flatness_tensor.detach().cpu())
+
+                    logits = raw_logits_row / step_temperature        # Scaled logits for sampling
                     full_row = logits[0].clone()               # pre-mask
 
 
@@ -739,6 +785,15 @@ def sample_with_existing_model(
             if kl_divergences:
                 avg_kl = np.mean(kl_divergences)
                 console.print(f"\n[bold yellow]Cosine Penalty Impact (Avg KL Divergence):[/bold yellow] [bold cyan]{avg_kl:.4f}[/bold cyan]")
+
+            if dynamic_temperatures:
+                temp_values = torch.cat([t.flatten() for t in dynamic_temperatures]).numpy()
+                flat_values = torch.cat([f.flatten() for f in dynamic_flatness_values]).numpy()
+                console.print(
+                    "\n[bold yellow]Dynamic Temperature:[/bold yellow] "
+                    f"avg={temp_values.mean():.3f}, min={temp_values.min():.3f}, max={temp_values.max():.3f}, "
+                    f"avg_flatness={flat_values.mean():.3f}"
+                )
 
             # ---------- save minmax chart if requested ----------------------
             if args.show_minmax_chart and pre_temp_scalar_rows:
@@ -1835,7 +1890,17 @@ def main():
 
                             idx_next = rounded.to(torch.long).unsqueeze(-1)
                         else:
-                            cur_logits = logits_list[i][:, -1, :] / args.temperature
+                            raw_cur_logits = logits_list[i][:, -1, :]
+                            cur_temperature = args.temperature
+                            if args is not None and args.dynamic_temperature:
+                                cur_temperature, _ = dynamic_temperature_from_logits(
+                                    raw_cur_logits,
+                                    args.temperature,
+                                    args.dynamic_temperature_min,
+                                    args.dynamic_temperature_max,
+                                )
+                                cur_temperature = cur_temperature.unsqueeze(-1)
+                            cur_logits = raw_cur_logits / cur_temperature
                             if args.top_k is not None:
                                 top_k_val = (
                                     args.top_k[0]


### PR DESCRIPTION
### Motivation
- Provide a way to adapt sampling temperature at each step based on how "flat" or uncertain the next-token logit distribution is, so sampling is more conservative on sharp distributions and more exploratory on flat ones.
- Make this behavior configurable via CLI so it can be toggled and tuned for both single-context and multicontext sampling.
- Add a runnable demo using the CoNaLa dataset to illustrate the new behavior end-to-end.

### Description
- Added CLI flags `--dynamic_temperature`, `--dynamic_temperature_min`, and `--dynamic_temperature_max` to `sample.py` to enable and configure flatness-scaled temperature. 
- Implemented `dynamic_temperature_from_logits(logits, base_temperature, min_multiplier, max_multiplier)` which measures distribution flatness via normalized entropy and linearly interpolates a temperature multiplier; returns per-row temperature and flatness. 
- Integrated dynamic temperature into the standard sampling loop and the multicontext sampling path so raw logits are scaled by the per-step temperature before masking/softmax/sampling, and collected per-step temps/flatness for summary logging. 
- Added `demos/conala_dynamic_sampling_demo.sh`, a demo script that prepares the CoNaLa dataset, trains a small model, and samples with `--dynamic_temperature` enabled.

### Testing
- `python3 -m py_compile sample.py` succeeded (syntax/type sanity check).
- `bash -n demos/conala_dynamic_sampling_demo.sh` succeeded (demo script syntax check).
- `git diff --check` returned clean (no whitespace/fixme issues) in automated checks run here.
- `python3 sample.py --help` could not be executed in this environment due to a missing `matplotlib` dependency, which is unrelated to the new flags themselves.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56f07c4d4c8326811f6f52fb8d03cc)