### PR TITLE
Sequential training runner, stage placeholders, and recurrent latent-mixing features

### DIFF
--- a/demos/sequential_recurrent_latent_mix_inference_demo.sh
+++ b/demos/sequential_recurrent_latent_mix_inference_demo.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# End-to-end demo for the sequential latent-mix exploration:
+#   1. Ensure minipile and dialogsum have input.txt, train.bin, and val.bin.
+#   2. Run explorations/sequential_minipile_dialogsum_recurrent_latent_mix.yaml.
+#   3. Sample from the final recurrent checkpoint for each latent_mix_mode.
+#
+# Useful overrides:
+#   AUTO_PREPARE_DATA=0  # only check data and print instructions if files are missing
+#   RUN_TRAINING=0       # skip training and sample from existing checkpoints
+#   OUTPUT_DIR=out       # run_experiments output root
+#   DEVICE=cuda:0        # training/sampling device used by the YAML and sample.py
+#   MAX_NEW_TOKENS=200   # generated tokens per sample
+#   NUM_SAMPLES=1        # samples per checkpoint
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+CONFIG="${CONFIG:-explorations/sequential_minipile_dialogsum_recurrent_latent_mix.yaml}"
+OUTPUT_DIR="${OUTPUT_DIR:-out}"
+DEVICE="${DEVICE:-cuda:0}"
+AUTO_PREPARE_DATA="${AUTO_PREPARE_DATA:-1}"
+RUN_TRAINING="${RUN_TRAINING:-1}"
+MAX_NEW_TOKENS="${MAX_NEW_TOKENS:-200}"
+NUM_SAMPLES="${NUM_SAMPLES:-1}"
+START_TEXT="${START_TEXT:-#U: Please summarize the following:\nA researcher tested recurrent latent mixing after pretraining on a broad corpus and finetuning on summaries.\n#B:\n}"
+
+require_file_or_prepare() {
+  local dataset="$1"
+  local dataset_dir="data/${dataset}"
+  local input_path="${dataset_dir}/input.txt"
+  local train_path="${dataset_dir}/train.bin"
+  local val_path="${dataset_dir}/val.bin"
+
+  if [[ ! -d "${dataset_dir}" ]]; then
+    echo "[ERROR] Missing dataset directory: ${dataset_dir}" >&2
+    return 1
+  fi
+
+  if [[ ! -f "${input_path}" ]]; then
+    echo "[WARN] Missing ${input_path}."
+    if [[ "${AUTO_PREPARE_DATA}" != "1" ]]; then
+      cat <<MSG
+Set AUTO_PREPARE_DATA=1 or run manually:
+  (cd ${dataset_dir} && bash get_dataset.sh)
+  (cd ${dataset_dir} && python3 prepare.py -t input.txt --method tiktoken --train_output train.bin --val_output val.bin)
+MSG
+      return 1
+    fi
+    echo "[INFO] Downloading/building ${input_path} via ${dataset_dir}/get_dataset.sh ..."
+    (cd "${dataset_dir}" && bash get_dataset.sh)
+  fi
+
+  if [[ ! -f "${train_path}" || ! -f "${val_path}" ]]; then
+    echo "[WARN] Missing ${train_path} and/or ${val_path}."
+    if [[ "${AUTO_PREPARE_DATA}" != "1" ]]; then
+      cat <<MSG
+Set AUTO_PREPARE_DATA=1 or run manually:
+  (cd ${dataset_dir} && python3 prepare.py -t input.txt --method tiktoken --train_output train.bin --val_output val.bin)
+MSG
+      return 1
+    fi
+    echo "[INFO] Tokenizing ${dataset}/input.txt with tiktoken into train.bin and val.bin ..."
+    (cd "${dataset_dir}" && python3 prepare.py -t input.txt --method tiktoken --train_output train.bin --val_output val.bin)
+  fi
+
+  echo "[OK] ${dataset}: found input.txt, train.bin, and val.bin."
+}
+
+ensure_data() {
+  require_file_or_prepare "minipile"
+  require_file_or_prepare "dialogsum"
+}
+
+run_training_sequence() {
+  echo "[INFO] Running sequential exploration config: ${CONFIG}"
+  python3 optimization_and_search/run_experiments.py \
+    --config "${CONFIG}" \
+    --config_format yaml \
+    --output_dir "${OUTPUT_DIR}"
+}
+
+sample_variant() {
+  local variant="$1"
+  local run_name="seq_minipile_dialogsum_recurrent_${variant}"
+  local recurrent_stage="03_recurrent_dialogsum_${variant}"
+  local ckpt_dir="${OUTPUT_DIR}/${run_name}/${recurrent_stage}"
+  local ckpt_path="${ckpt_dir}/ckpt.pt"
+  local sample_dir="${OUTPUT_DIR}/${run_name}/samples"
+  local sample_file="${sample_dir}/${variant}_sample.txt"
+
+  if [[ ! -f "${ckpt_path}" ]]; then
+    echo "[ERROR] Expected final checkpoint not found: ${ckpt_path}" >&2
+    echo "        Run this script with RUN_TRAINING=1, or inspect ${OUTPUT_DIR}/${run_name}." >&2
+    return 1
+  fi
+
+  mkdir -p "${sample_dir}"
+  echo "[INFO] Sampling ${variant} recurrent checkpoint: ${ckpt_path}"
+  python3 sample.py \
+    --init_from resume \
+    --out_dir "${ckpt_dir}" \
+    --device "${DEVICE}" \
+    --dtype bfloat16 \
+    --start "${START_TEXT}" \
+    --num_samples "${NUM_SAMPLES}" \
+    --max_new_tokens "${MAX_NEW_TOKENS}" \
+    --top_k 200 \
+    --sample_file "${sample_file}" \
+    --no-print_model_info
+  echo "[OK] Wrote ${sample_file}"
+}
+
+main() {
+  ensure_data
+
+  if [[ "${RUN_TRAINING}" == "1" ]]; then
+    run_training_sequence
+  else
+    echo "[INFO] RUN_TRAINING=0; skipping sequential training and using existing checkpoints."
+  fi
+
+  sample_variant "direct"
+  sample_variant "slerp"
+  sample_variant "add_norm"
+
+  echo "[DONE] Sequential recurrent latent-mix demo completed."
+}
+
+main "$@"

--- a/explorations/recurrent_parallel_shakespeare_char.yaml
+++ b/explorations/recurrent_parallel_shakespeare_char.yaml
@@ -1,0 +1,80 @@
+# Compare recurrent latent mixing with genuinely parallel mini-batches.
+# The first stage creates a compatible character model; the second stage
+# sweeps batch size and latent mode while sampling at every evaluation.
+---
+named_static_groups:
+  - named_group: "small_char_model"
+    n_layer: [4]
+    n_head: [4]
+    n_embd: [128]
+    block_size: [64]
+    dropout: [0.0]
+
+named_group_static: ["small_char_model"]
+
+common_group:
+  dataset: ["shakespeare_char"]
+  device: ["cuda:0"]
+  dtype: ["bfloat16"]
+  learning_rate: [0.001]
+  gradient_accumulation_steps: [2]
+  eval_interval: [50]
+  eval_iters: [20]
+  log_interval: [10]
+  max_sample_tokens: [120]
+  sample_each_eval: [true]
+  sample_start_tokens: ["\n"]
+  sample_file: ["recurrent_samples.txt"]
+  always_save_checkpoint: [true]
+  compile: [true]
+
+parameter_groups:
+  - run_name_override: ["recurrent_char_direct_bs{batch_size}"]
+    batch_size: [8, 16, 32]
+    training_sequence:
+      - stage_name: "pretrain"
+        script: "train.py"
+        init_from: "scratch"
+        max_iters: 250
+      - stage_name: "recurrent_direct"
+        script: "train_recurrent.py"
+        max_iters: 200
+        latent_steps: 1
+        latent_mix_mode: "direct"
+        resume_from_previous: true
+        reset_optim: true
+        reset_best_val_loss_on_resume: true
+
+  - run_name_override: ["recurrent_char_slerp_bs{batch_size}"]
+    batch_size: [8, 16, 32]
+    training_sequence:
+      - stage_name: "pretrain"
+        script: "train.py"
+        init_from: "scratch"
+        max_iters: 250
+      - stage_name: "recurrent_slerp"
+        script: "train_recurrent.py"
+        max_iters: 200
+        latent_steps: 1
+        latent_mix_mode: "slerp"
+        latent_mix_alpha: 0.5
+        learn_latent_mix_alpha: true
+        resume_from_previous: true
+        reset_optim: true
+        reset_best_val_loss_on_resume: true
+
+  - run_name_override: ["recurrent_char_add_norm_bs{batch_size}"]
+    batch_size: [8, 16, 32]
+    training_sequence:
+      - stage_name: "pretrain"
+        script: "train.py"
+        init_from: "scratch"
+        max_iters: 250
+      - stage_name: "recurrent_add_norm"
+        script: "train_recurrent.py"
+        max_iters: 200
+        latent_steps: 1
+        latent_mix_mode: "add_norm"
+        resume_from_previous: true
+        reset_optim: true
+        reset_best_val_loss_on_resume: true

--- a/explorations/recurrent_scratch_shakespeare_char.yaml
+++ b/explorations/recurrent_scratch_shakespeare_char.yaml
@@ -1,8 +1,8 @@
 # Train latent-recurrent language models directly from random initialization.
 #
-# This compact 3 x 3 sweep compares all latent feedback modes at batch sizes
-# 8, 16, and 32. Gradient accumulation gives every optimizer step two
-# micro-batches, while the short context keeps recurrent training practical.
+# The baseline sweep compares direct/add-norm feedback at three batch sizes.
+# The slerp sweep additionally explores interpolation amount and whether that
+# amount remains fixed or is learned from its configured initial value.
 ---
 named_static_groups:
   - named_group: "fast_char_model"
@@ -31,7 +31,6 @@ common_group:
 
   # Recurrent objective settings.
   latent_steps: [1]
-  latent_mix_alpha: [0.5]
   skip_steps: [0]
   weight_start: [1.0]
   weight_end: [1.0]
@@ -47,7 +46,18 @@ common_group:
   sample_file: ["samples.txt"]
 
 parameter_groups:
+  # Alpha does not affect these modes, so avoid redundant combinations.
   - run_name_override:
       - "recurrent_scratch_{latent_mix_mode}_bs{batch_size}"
     batch_size: [8, 16, 32]
-    latent_mix_mode: ["direct", "slerp", "add_norm"]
+    latent_mix_mode: ["direct", "add_norm"]
+
+  # For fixed slerp, alpha is the interpolation fraction toward the correct
+  # token embedding. For learned slerp, it is the sigmoid-constrained scalar's
+  # initial value. The run name includes both fields to prevent collisions.
+  - run_name_override:
+      - "recurrent_scratch_slerp_bs{batch_size}_a{latent_mix_alpha}_learn{learn_latent_mix_alpha}"
+    batch_size: [8, 16, 32]
+    latent_mix_mode: ["slerp"]
+    latent_mix_alpha: [0.25, 0.5, 0.75]
+    learn_latent_mix_alpha: [false, true]

--- a/explorations/recurrent_scratch_shakespeare_char.yaml
+++ b/explorations/recurrent_scratch_shakespeare_char.yaml
@@ -1,0 +1,53 @@
+# Train latent-recurrent language models directly from random initialization.
+#
+# This compact 3 x 3 sweep compares all latent feedback modes at batch sizes
+# 8, 16, and 32. Gradient accumulation gives every optimizer step two
+# micro-batches, while the short context keeps recurrent training practical.
+---
+named_static_groups:
+  - named_group: "fast_char_model"
+    n_layer: [4]
+    n_head: [4]
+    n_embd: [128]
+    block_size: [64]
+    dropout: [0.0]
+    bias: [false]
+
+named_group_static: ["fast_char_model"]
+
+common_group:
+  train_script: ["recurrent"]
+  init_from: ["scratch"]
+  dataset: ["shakespeare_char"]
+  device: ["cuda:0"]
+  dtype: ["bfloat16"]
+  compile: [true]
+
+  # Throughput and optimization settings.
+  gradient_accumulation_steps: [2]
+  learning_rate: [0.001]
+  max_iters: [1000]
+  grad_clip: [1.0]
+
+  # Recurrent objective settings.
+  latent_steps: [1]
+  latent_mix_alpha: [0.5]
+  skip_steps: [0]
+  weight_start: [1.0]
+  weight_end: [1.0]
+
+  # Finite evaluation and qualitative samples keep the sweep comparable.
+  eval_interval: [100]
+  eval_iters: [20]
+  log_interval: [10]
+  always_save_checkpoint: [true]
+  max_sample_tokens: [200]
+  sample_each_eval: [true]
+  sample_start_tokens: ["\n"]
+  sample_file: ["samples.txt"]
+
+parameter_groups:
+  - run_name_override:
+      - "recurrent_scratch_{latent_mix_mode}_bs{batch_size}"
+    batch_size: [8, 16, 32]
+    latent_mix_mode: ["direct", "slerp", "add_norm"]

--- a/explorations/sequential_minipile_dialogsum_recurrent_latent_mix.yaml
+++ b/explorations/sequential_minipile_dialogsum_recurrent_latent_mix.yaml
@@ -1,0 +1,97 @@
+# Sequential train.py -> train.py -> train_recurrent.py sweep.
+# Each parameter_group is one full three-stage run. The architecture/model
+# settings live in the named static group plus common_group and are inherited
+# by all stages so resumed checkpoints keep compatible model_args.
+---
+named_static_groups:
+  - named_group: "tiny_rotary"
+    n_layer: [6]
+    n_head: [6]
+    n_embd: [384]
+    block_size: [256]
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+named_group_static: ["tiny_rotary"]
+
+common_group:
+  batch_size: [8]
+  gradient_accumulation_steps: [1]
+  learning_rate: [0.0006]
+  eval_interval: [500]
+  eval_iters: [100]
+  log_interval: [10]
+  always_save_checkpoint: [true]
+  compile: [false]
+  device: ["cuda"]
+  dtype: ["bfloat16"]
+
+parameter_groups:
+  - run_name_override: ["seq_minipile_dialogsum_recurrent_direct"]
+    training_sequence:
+      - stage_name: "pretrain_minipile"
+        script: "train.py"
+        dataset: "minipile"
+        init_from: "scratch"
+        max_iters: 10000
+      - stage_name: "finetune_dialogsum"
+        script: "train.py"
+        dataset: "dialogsum"
+        max_iters: 1000
+        resume_from_previous: true
+        reset_best_val_loss_on_resume: true
+      - stage_name: "recurrent_dialogsum_direct"
+        script: "train_recurrent.py"
+        dataset: "dialogsum"
+        max_iters: 1000
+        latent_steps: 1
+        latent_mix_mode: "direct"
+        reset_best_val_loss_on_resume: true
+        resume_from_previous: true
+        reset_optim: true
+  - run_name_override: ["seq_minipile_dialogsum_recurrent_slerp"]
+    training_sequence:
+      - stage_name: "pretrain_minipile"
+        script: "train.py"
+        dataset: "minipile"
+        init_from: "scratch"
+        max_iters: 10000
+      - stage_name: "finetune_dialogsum"
+        script: "train.py"
+        dataset: "dialogsum"
+        max_iters: 1000
+        resume_from_previous: true
+        reset_best_val_loss_on_resume: true
+      - stage_name: "recurrent_dialogsum_slerp"
+        script: "train_recurrent.py"
+        dataset: "dialogsum"
+        max_iters: 1000
+        latent_steps: 1
+        latent_mix_mode: "slerp"
+        latent_mix_alpha: 0.5
+        learn_latent_mix_alpha: true
+        reset_best_val_loss_on_resume: true
+        resume_from_previous: true
+        reset_optim: true
+  - run_name_override: ["seq_minipile_dialogsum_recurrent_add_norm"]
+    training_sequence:
+      - stage_name: "pretrain_minipile"
+        script: "train.py"
+        dataset: "minipile"
+        init_from: "scratch"
+        max_iters: 10000
+      - stage_name: "finetune_dialogsum"
+        script: "train.py"
+        dataset: "dialogsum"
+        max_iters: 1000
+        resume_from_previous: true
+        reset_best_val_loss_on_resume: true
+      - stage_name: "recurrent_dialogsum_add_norm"
+        script: "train_recurrent.py"
+        dataset: "dialogsum"
+        max_iters: 1000
+        latent_steps: 1
+        latent_mix_mode: "add_norm"
+        reset_best_val_loss_on_resume: true
+        resume_from_previous: true
+        reset_optim: true

--- a/explorations/sequential_minipile_dialogsum_recurrent_latent_mix.yaml
+++ b/explorations/sequential_minipile_dialogsum_recurrent_latent_mix.yaml
@@ -23,7 +23,7 @@ common_group:
   log_interval: [10]
   always_save_checkpoint: [true]
   compile: [false]
-  device: ["cuda"]
+  device: ["cuda:0"]
   dtype: ["bfloat16"]
 
 parameter_groups:

--- a/explorations/sequential_training_features_example.yaml
+++ b/explorations/sequential_training_features_example.yaml
@@ -1,0 +1,62 @@
+# Demonstrates the sequential runner features:
+# - script/train_script aliases for train.py, train_mezo.py, and train_recurrent.py
+# - per-stage out_dir creation under the parent run directory
+# - resume_from_previous checkpoint handoff
+# - reset_best_val_loss_on_resume between datasets/modes
+# - ${RUN_NAME}, ${STAGE_OUT_DIR}, ${PREV_OUT_DIR}, and ${PREV_CKPT} placeholders
+---
+named_static_groups:
+  - named_group: "smoke_arch"
+    n_layer: [2]
+    n_head: [2]
+    n_embd: [128]
+    block_size: [64]
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+named_group_static: ["smoke_arch"]
+
+common_group:
+  dataset: ["shakespeare_char"]
+  batch_size: [4]
+  gradient_accumulation_steps: [1]
+  learning_rate: [0.0003]
+  eval_interval: [50]
+  eval_iters: [10]
+  log_interval: [10]
+  always_save_checkpoint: [true]
+  compile: [false]
+  device: ["cuda"]
+  dtype: ["bfloat16"]
+
+parameter_groups:
+  - run_name_override: ["sequential_feature_demo"]
+    training_sequence:
+      - stage_name: "scratch_train"
+        train_script: "train"
+        init_from: "scratch"
+        max_iters: 100
+        sample_file: "${STAGE_OUT_DIR}/${RUN_NAME}_scratch_sample.txt"
+      - stage_name: "resume_train_new_budget"
+        train_script: "train.py"
+        max_iters: 150
+        resume_from_previous: true
+        reset_best_val_loss_on_resume: true
+        sample_file: "${STAGE_OUT_DIR}/${RUN_NAME}_resume_sample.txt"
+      - stage_name: "mezo_resume"
+        train_script: "mezo"
+        max_iters: 175
+        resume_from_previous: true
+        reset_best_val_loss_on_resume: true
+        mezo_epsilon: 0.001
+      - stage_name: "recurrent_from_mezo"
+        train_script: "recurrent"
+        max_iters: 200
+        resume_from_previous: true
+        reset_best_val_loss_on_resume: true
+        reset_optim: true
+        latent_steps: 1
+        latent_mix_mode: "slerp"
+        latent_mix_alpha: 0.25
+        learn_latent_mix_alpha: true
+        sample_file: "${STAGE_OUT_DIR}/${RUN_NAME}_from_${PREV_OUT_DIR}_sample.txt"

--- a/explorations/sequential_training_features_example.yaml
+++ b/explorations/sequential_training_features_example.yaml
@@ -26,7 +26,7 @@ common_group:
   log_interval: [10]
   always_save_checkpoint: [true]
   compile: [false]
-  device: ["cuda"]
+  device: ["cuda:0"]
   dtype: ["bfloat16"]
 
 parameter_groups:

--- a/optimization_and_search/run_experiments.py
+++ b/optimization_and_search/run_experiments.py
@@ -929,7 +929,11 @@ def run_experiment(
         expand_named_group_values=args.expand_named_groups_in_names,
     )
     if combo.get("run_name_override"):
-        run_name = f"{args.prefix}{combo['run_name_override']}"
+        try:
+            override = str(combo["run_name_override"]).format_map(combo)
+        except KeyError as exc:
+            raise ValueError(f"Unknown run_name_override placeholder: {exc.args[0]}") from exc
+        run_name = f"{args.prefix}{override}"
     log_file = LOG_DIR / f"{base}.yaml"
     if run_name in completed_runs(log_file):
         print(f"[yellow]Skipping already-run:[/] {run_name}")

--- a/optimization_and_search/run_experiments.py
+++ b/optimization_and_search/run_experiments.py
@@ -1,5 +1,6 @@
 import json
 import subprocess
+import shutil
 import time
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
@@ -125,10 +126,20 @@ def load_configurations(path: str, fmt: str) -> list[dict]:
 
 RUN_NAME_VAR = "${RUN_NAME}"
 DISTILLATION_SOURCE_VAR = "${DISTILLATION_SOURCE}"
+PREV_OUT_DIR_VAR = "${PREV_OUT_DIR}"
+PREV_CKPT_VAR = "${PREV_CKPT}"
+STAGE_OUT_DIR_VAR = "${STAGE_OUT_DIR}"
+SEQUENCE_CONFIG_KEYS = {"training_sequence"}
 RESERVED_CONFIG_KEYS = {
     "distillation_source_path",
     "distillation_source_run_name",
     "run_name_override",
+    "training_sequence",
+    "script",
+    "train_script",
+    "stage_name",
+    "resume_from_previous",
+    "checkpoint_name",
 }
 
 
@@ -145,21 +156,54 @@ def expand_range(val):
     return val
 
 
-def _substitute_config_vars(obj, run_name: str, distillation_source_path: str | None = None):
+def _substitute_config_vars(
+    obj,
+    run_name: str,
+    distillation_source_path: str | None = None,
+    previous_out_dir: str | None = None,
+    previous_ckpt: str | None = None,
+    stage_out_dir: str | None = None,
+):
     """Recursively substitute launcher-only placeholders inside ``obj``."""
+    replacements = {
+        RUN_NAME_VAR: run_name,
+        DISTILLATION_SOURCE_VAR: distillation_source_path,
+        PREV_OUT_DIR_VAR: previous_out_dir,
+        PREV_CKPT_VAR: previous_ckpt,
+        STAGE_OUT_DIR_VAR: stage_out_dir,
+    }
     if isinstance(obj, str):
-        substituted = obj.replace(RUN_NAME_VAR, run_name)
-        if DISTILLATION_SOURCE_VAR in substituted:
-            if distillation_source_path is None:
-                raise ValueError(
-                    f"{DISTILLATION_SOURCE_VAR} was used but distillation_source_path was not set."
-                )
-            substituted = substituted.replace(DISTILLATION_SOURCE_VAR, distillation_source_path)
+        substituted = obj
+        for token, value in replacements.items():
+            if token in substituted:
+                if value is None:
+                    raise ValueError(f"{token} was used but no value is available for this stage.")
+                substituted = substituted.replace(token, value)
         return substituted
     if isinstance(obj, list):
-        return [_substitute_config_vars(o, run_name, distillation_source_path) for o in obj]
+        return [
+            _substitute_config_vars(
+                o,
+                run_name,
+                distillation_source_path,
+                previous_out_dir,
+                previous_ckpt,
+                stage_out_dir,
+            )
+            for o in obj
+        ]
     if isinstance(obj, dict):
-        return {k: _substitute_config_vars(v, run_name, distillation_source_path) for k, v in obj.items()}
+        return {
+            k: _substitute_config_vars(
+                v,
+                run_name,
+                distillation_source_path,
+                previous_out_dir,
+                previous_ckpt,
+                stage_out_dir,
+            )
+            for k, v in obj.items()
+        }
     return obj
 
 
@@ -450,8 +494,12 @@ def generate_combinations(config: dict):
             if not (isinstance(v, dict) and 'conditions' in v)
                and k != 'parameter_groups'
         }
-        # Ensure each base value is iterable for cartesian product
-        base = {k: (v if isinstance(v, list) else [v]) for k, v in base.items()}
+        # Ensure each base value is iterable for cartesian product. Sequential
+        # stage lists are atomic configs, not a sweep axis.
+        base = {
+            k: ([v] if k in SEQUENCE_CONFIG_KEYS else (v if isinstance(v, list) else [v]))
+            for k, v in base.items()
+        }
 
         conditionals = {
             k: v for k, v in cfg.items()
@@ -709,11 +757,24 @@ def append_progress(log_file: Path, message: str) -> None:
         f.write(f"[{timestamp}] {message}\n")
 
 
+def _script_for_config(combo: dict) -> str:
+    script = combo.get("train_script", combo.get("script", "train.py"))
+    if script in {"train", "train.py"}:
+        return "train.py"
+    if script in {"train_recurrent", "train_recurrent.py", "recurrent"}:
+        return "train_recurrent.py"
+    if script in {"train_mezo", "train_mezo.py", "mezo"}:
+        return "train_mezo.py"
+    if not str(script).endswith(".py"):
+        raise ValueError(f"Unknown training script alias: {script}")
+    return str(script)
+
+
 def build_command(combo: dict) -> list[str]:
     """
-    Construct the command-line invocation for train.py.
+    Construct the command-line invocation for the selected training script.
     """
-    cmd = ['python3', 'train.py']
+    cmd = ['python3', _script_for_config(combo)]
     for k, v in combo.items():
         if k.startswith('_') or k in RESERVED_CONFIG_KEYS:
             continue
@@ -728,6 +789,122 @@ def build_command(combo: dict) -> list[str]:
         else:
             cmd += [f"--{k}", str(v)]
     return cmd
+
+
+def _stage_out_dir(parent_out_dir: str, index: int, stage: dict) -> str:
+    name = stage.get("stage_name", f"stage{index:02d}")
+    safe_name = str(name).replace(os.sep, "_")
+    return os.path.join(parent_out_dir, f"{index:02d}_{safe_name}")
+
+
+def _prepare_stage_config(
+    base_combo: dict,
+    stage: dict,
+    parent_out_dir: str,
+    run_name: str,
+    index: int,
+    previous_out_dir: str | None,
+    previous_ckpt: str | None,
+    distillation_source_path: str | None,
+) -> dict:
+    stage_out_dir = stage.get("out_dir", _stage_out_dir(parent_out_dir, index, stage))
+    merged = {
+        k: deepcopy(v)
+        for k, v in base_combo.items()
+        if k not in {"training_sequence", "out_dir", "tensorboard_run_name"}
+    }
+    merged.update(deepcopy(stage))
+    merged["out_dir"] = stage_out_dir
+    merged["tensorboard_run_name"] = f"{run_name}/{stage.get('stage_name', f'stage{index:02d}')}"
+
+    if merged.get("resume_from_previous"):
+        if previous_ckpt is None or previous_out_dir is None:
+            raise ValueError("resume_from_previous is set on the first stage or before a checkpoint exists")
+        script = _script_for_config(merged)
+        checkpoint_name = merged.get("checkpoint_name", "ckpt.pt")
+        if script in {"train.py", "train_mezo.py"}:
+            os.makedirs(stage_out_dir, exist_ok=True)
+            shutil.copy2(previous_ckpt, os.path.join(stage_out_dir, checkpoint_name))
+            merged.setdefault("init_from", "resume")
+            merged.setdefault("init_from_ckpt", checkpoint_name)
+        elif script == "train_recurrent.py":
+            merged.setdefault("resume_ckpt", previous_ckpt)
+        else:
+            merged.setdefault("prev_run_ckpt", previous_out_dir)
+            merged.setdefault("init_from", "prev_run")
+            merged.setdefault("init_from_ckpt", checkpoint_name)
+
+    return _substitute_config_vars(
+        merged,
+        run_name,
+        distillation_source_path=distillation_source_path,
+        previous_out_dir=previous_out_dir,
+        previous_ckpt=previous_ckpt,
+        stage_out_dir=stage_out_dir,
+    )
+
+
+def _print_parameters(combo: dict) -> None:
+    console = Console()
+    table = Table("Parameters", show_header=False)
+    for k, v in combo.items():
+        if k.startswith('_') or k in RESERVED_CONFIG_KEYS:
+            continue
+        table.add_row(k, str(v))
+    console.print(table)
+
+
+def _run_command(combo: dict, run_name: str) -> tuple[float, str]:
+    _print_parameters(combo)
+    cmd = build_command(combo)
+    print(f"Running: {' '.join(cmd)}")
+    run_started_at = time.perf_counter()
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError:
+        print(f"[red]Process exited with error for run:[/] {run_name}")
+    return time.perf_counter() - run_started_at, datetime.now(timezone.utc).isoformat()
+
+
+def _run_training_sequence(
+    combo: dict,
+    run_name: str,
+    distillation_source_path: str | None,
+) -> tuple[float, str, str]:
+    parent_out_dir = combo["out_dir"]
+    stages = combo.get("training_sequence")
+    if not isinstance(stages, list) or not stages:
+        raise ValueError("training_sequence must be a non-empty list of stage mappings")
+
+    previous_out_dir = None
+    previous_ckpt = None
+    total_time = 0.0
+    completed_at = datetime.now(timezone.utc).isoformat()
+    final_out_dir = parent_out_dir
+    for index, stage in enumerate(stages, 1):
+        if not isinstance(stage, dict):
+            raise TypeError("Each training_sequence entry must be a mapping")
+        stage_combo = _prepare_stage_config(
+            combo,
+            stage,
+            parent_out_dir,
+            run_name,
+            index,
+            previous_out_dir,
+            previous_ckpt,
+            distillation_source_path,
+        )
+        elapsed, completed_at = _run_command(stage_combo, f"{run_name}:{stage_combo.get('stage_name', index)}")
+        total_time += elapsed
+        final_out_dir = stage_combo["out_dir"]
+        checkpoint_name = stage_combo.get("checkpoint_name", "ckpt.pt")
+        previous_out_dir = final_out_dir
+        previous_ckpt = os.path.join(final_out_dir, checkpoint_name)
+        if _script_for_config(stage_combo) == "train_recurrent.py" and not os.path.exists(previous_ckpt):
+            recurrent_ckpt = os.path.join(final_out_dir, "ckpt_lat.pt")
+            if os.path.exists(recurrent_ckpt):
+                previous_ckpt = recurrent_ckpt
+    return total_time, completed_at, final_out_dir
 
 
 def run_experiment(
@@ -781,36 +958,35 @@ def run_experiment(
         )
         combo["distillation_source_path"] = distillation_source_path
 
-    # Substitute launcher-only tokens in string parameters
-    combo = _substitute_config_vars(
-        combo,
-        run_name,
-        distillation_source_path=distillation_source_path,
-    )
+    # Substitute launcher-only tokens in string parameters that are available
+    # before stage-specific values exist. For sequential runs, defer stage-local
+    # placeholders such as ${PREV_CKPT} until each stage is prepared.
+    if combo.get("training_sequence"):
+        combo = {
+            k: (v if k == "training_sequence" else _substitute_config_vars(
+                v,
+                run_name,
+                distillation_source_path=distillation_source_path,
+            ))
+            for k, v in combo.items()
+        }
+        run_total_time_s, run_completed_at, metrics_out_dir = _run_training_sequence(
+            combo,
+            run_name,
+            distillation_source_path,
+        )
+    else:
+        combo = _substitute_config_vars(
+            combo,
+            run_name,
+            distillation_source_path=distillation_source_path,
+        )
+        run_total_time_s, run_completed_at = _run_command(combo, run_name)
+        metrics_out_dir = combo['out_dir']
 
-    # Show parameters
-    console = Console()
-    table = Table("Parameters", show_header=False)
-    for k, v in combo.items():
-        if k.startswith('_') or k in RESERVED_CONFIG_KEYS:
-            continue
-        table.add_row(k, str(v))
-    console.print(table)
-
-    # Build and run
-    cmd = build_command(combo)
-    print(f"Running: {' '.join(cmd)}")
-    run_started_at = time.perf_counter()
-    try:
-        subprocess.run(cmd, check=True)
-    except subprocess.CalledProcessError:
-        print(f"[red]Process exited with error for run:[/] {run_name}")
-    run_total_time_s = time.perf_counter() - run_started_at
-    run_completed_at = datetime.now(timezone.utc).isoformat()
-    
     # Read metrics (use existing or nan on failure)
     try:
-        metrics = read_metrics(str(combo['out_dir']))
+        metrics = read_metrics(str(metrics_out_dir))
     except Exception:
         metrics = {k: float("nan") for k in METRIC_KEYS}
 

--- a/train_mezo.py
+++ b/train_mezo.py
@@ -232,6 +232,9 @@ def main() -> None:
             best_val_loss=checkpoint.get("best_val_loss", float("inf")),
             best_iter=checkpoint.get("best_iter", 0),
         )
+        if args.reset_best_val_loss_on_resume:
+            state.best_val_loss = float("inf")
+            state.best_iter = 0
     else:
         raise ValueError(f"Unsupported init_from value: {args.init_from}")
 

--- a/train_recurrent.py
+++ b/train_recurrent.py
@@ -14,6 +14,7 @@ import os
 import time
 import math
 import pickle
+from contextlib import nullcontext
 
 import numpy as np
 import torch
@@ -74,8 +75,12 @@ for k, v in vars(latent_args).items():
 # ----------------------------------------------------------------------
 # 2)  LOAD CHECKPOINT + MODEL
 # ----------------------------------------------------------------------
-device = "cuda" if torch.cuda.is_available() else "cpu"
-ckpt   = torch.load(args.resume_ckpt, map_location=device)
+device = args.device
+device_type = "cuda" if device.startswith("cuda") else "cpu"
+dtype_map = {"float32": torch.float32, "float16": torch.float16, "bfloat16": torch.bfloat16}
+ptdtype = dtype_map[args.dtype]
+ctx = nullcontext() if device_type == "cpu" else torch.amp.autocast(device_type=device_type, dtype=ptdtype)
+ckpt = torch.load(args.resume_ckpt, map_location=device)
 
 gpt_conf = GPTConfig(**ckpt["model_args"])
 model    = GPT(gpt_conf).to(device)
@@ -102,8 +107,14 @@ if missing:
 if unexpected:
     print(f"warning: {len(unexpected)} extra params ignored")
 
+if args.compile:
+    print("compiling the model (this may take a ~minute)...")
+    model = torch.compile(model)
+
+raw_model = model._orig_mod if hasattr(model, "_orig_mod") else model
+
 # helpers exposed in patched model.py
-embed_tokens     = model.embed_tokens
+embed_tokens = raw_model.embed_tokens
 forward_embedded = lambda x: model.forward_embedded(x, return_hidden=True)
 
 latent_mix_logit = None
@@ -247,104 +258,128 @@ def train_block(x_tokens, y_tokens):
     return total_loss / nz_sum
 
 # ----------------------------------------------------------------------
-# 6)  EPOCH LOOPS
+# 6)  PARALLEL MINI-BATCHES, EVALUATION, AND SAMPLING
 # ----------------------------------------------------------------------
-def run_epoch(split):
-    data   = train_bin if split == "train" else val_bin
-    losses = []
-    ptr    = 0
-    while ptr + block_size + 1 < len(data):
-        seq = torch.from_numpy(np.array(
-                  data[ptr:ptr + block_size + 1], dtype=np.int64)
-              ).to(device)
-        x, y = seq[:-1].unsqueeze(0), seq[1:].unsqueeze(0)  # (1,T)
-
-        if split == "train":
-            model.train()
-            optimizer.zero_grad()
-            loss = train_block(x, y)
-            loss.backward()
-            torch.nn.utils.clip_grad_norm_(model.parameters(), args.grad_clip)
-            optimizer.step()
-            global global_step
-            global_step += 1
-
-            if global_step % args.log_interval == 0:
-                print(f"iter {global_step:>7} | "
-                      f"loss {loss.item():.4f}")
-            # ─── validation & checkpoint ───────────────────────────────
-            if global_step % args.eval_interval == 0:
-                model.eval()
-                with torch.no_grad():
-                    val = run_epoch("val")          # one full pass
-
-                if tb:
-                    tb.add_scalar("loss/val", val, global_step)
-
-                if val < 5.00:
-                    print(val)
-                    best_val_loss = val
-                    torch.save(
-                        {"model": model.state_dict(),
-                         "model_args": ckpt["model_args"],
-                         "iter_num":   global_step,
-                         "best_val_loss": best_val_loss,
-                         "latent_mix_logit": None if latent_mix_logit is None else latent_mix_logit.detach().cpu()},
-                        best_ckpt_path)
-                    print(f"  ➜ new best @ step {global_step}; "
-                          f"checkpoint saved to {best_ckpt_path}")
+def get_batch(split):
+    """Draw a random mini-batch, matching train.py's default sampler."""
+    data = train_bin if split == "train" else val_bin
+    starts = torch.randint(len(data) - block_size - 1, (args.batch_size,))
+    x = torch.stack([
+        torch.from_numpy(np.asarray(data[i:i + block_size], dtype=np.int64))
+        for i in starts.tolist()
+    ])
+    y = torch.stack([
+        torch.from_numpy(np.asarray(data[i + 1:i + 1 + block_size], dtype=np.int64))
+        for i in starts.tolist()
+    ])
+    if device_type == "cuda":
+        return x.pin_memory().to(device, non_blocking=True), y.pin_memory().to(device, non_blocking=True)
+    return x.to(device), y.to(device)
 
 
-        else:
+@torch.no_grad()
+def estimate_val_loss():
+    model.eval()
+    losses = torch.zeros(args.eval_iters)
+    for k in range(args.eval_iters):
+        x, y = get_batch("val")
+        with ctx:
+            losses[k] = train_block(x, y).detach().cpu()
+    model.train()
+    return losses.mean().item()
 
-            model.eval()
-            with torch.no_grad():
-                loss = train_block(x, y)
 
-        losses.append(loss.item())
-        ptr += block_size
-    return sum(losses) / len(losses)
+def checkpoint_payload():
+    return {
+        "model": raw_model.state_dict(),
+        "optimizer": optimizer.state_dict(),
+        "model_args": ckpt["model_args"],
+        "iter_num": global_step,
+        "best_val_loss": best_val_loss,
+        "config": vars(args),
+        "latent_mix_logit": None if latent_mix_logit is None else latent_mix_logit.detach().cpu(),
+    }
+
+
+@torch.no_grad()
+def sample_and_print():
+    if not args.max_sample_tokens:
+        return
+    meta_path = os.path.join("data", args.dataset, "meta.pkl")
+    if not os.path.exists(meta_path):
+        print(f"warning: sampling skipped; {meta_path} was not found")
+        return
+    with open(meta_path, "rb") as f:
+        meta = pickle.load(f)
+    if "stoi" not in meta or "itos" not in meta:
+        print("warning: interval sampling currently requires a character-level meta.pkl")
+        return
+    encode = lambda text: [meta["stoi"][c] for c in text]
+    decode = lambda ids: "".join(meta["itos"][i] for i in ids)
+    start_ids = torch.tensor(encode(args.sample_start_tokens), dtype=torch.long, device=device)[None, ...]
+    top_k = max(args.top_k) if isinstance(args.top_k, list) else args.top_k
+    model.eval()
+    with ctx:
+        generated = raw_model.generate(start_ids, args.max_sample_tokens,
+                                       temperature=args.temperature, top_k=top_k)
+    text = decode(generated[0].tolist())
+    print(f"\n--- recurrent sample @ iter {global_step} ---\n{text}\n--- end sample ---\n")
+    if args.sample_file:
+        sample_path = args.sample_file
+        if not os.path.isabs(sample_path):
+            sample_path = os.path.join(args.out_dir, sample_path)
+        os.makedirs(os.path.dirname(sample_path) or ".", exist_ok=True)
+        with open(sample_path, "a", encoding="utf-8") as f:
+            f.write(f"\n--- iter {global_step} ---\n{text}\n")
+    model.train()
+
 
 # ----------------------------------------------------------------------
-# 7)  TRAINING DRIVER
+# 7)  ITERATION-BASED TRAINING DRIVER
 # ----------------------------------------------------------------------
 tb = SummaryWriter() if getattr(args, "tensorboard_log", False) else None
 os.makedirs(args.out_dir, exist_ok=True)
 best_ckpt_path = os.path.join(args.out_dir, "ckpt.pt")
 
-val_loss = 999.9
+model.train()
+optimizer.zero_grad(set_to_none=True)
 while global_step < args.max_iters:
     t0 = time.time()
-    train_loss = run_epoch("train")
+    accumulated_loss = 0.0
+    for _ in range(args.gradient_accumulation_steps):
+        x, y = get_batch("train")
+        with ctx:
+            loss = train_block(x, y) / args.gradient_accumulation_steps
+        loss.backward()
+        accumulated_loss += loss.detach().item()
 
-    # ── run validation/checkpoint every N iterations ────────────────
-    if global_step % args.eval_interval == 0:
-        val_loss = run_epoch("val")
+    if args.grad_clip:
+        torch.nn.utils.clip_grad_norm_(model.parameters(), args.grad_clip)
+    optimizer.step()
+    optimizer.zero_grad(set_to_none=True)
+    global_step += 1
 
+    if global_step % args.log_interval == 0:
+        dt = time.time() - t0
+        tokens = args.batch_size * block_size * args.gradient_accumulation_steps
+        print(f"iter {global_step:>7} | loss {accumulated_loss:.4f} | "
+              f"{dt * 1000:.1f} ms | {tokens / max(dt, 1e-9):.0f} tok/s")
+        if tb:
+            tb.add_scalar("loss/train", accumulated_loss, global_step)
+
+    if global_step % args.eval_interval == 0 or global_step == args.max_iters:
+        val_loss = estimate_val_loss()
+        improved = val_loss < best_val_loss
+        if improved:
+            best_val_loss = val_loss
+        print(f"eval iter {global_step}: val loss {val_loss:.4f}")
         if tb:
             tb.add_scalar("loss/val", val_loss, global_step)
-
-        if val_loss < best_val_loss:
-            best_val_loss = val_loss
-            torch.save(
-                {"model": model.state_dict(),
-                 "model_args": ckpt["model_args"],
-                 "iter_num":   global_step,
-                 "best_val_loss": best_val_loss,
-                 "latent_mix_logit": None if latent_mix_logit is None else latent_mix_logit.detach().cpu()},
-                best_ckpt_path)
-            print(f"  ➜ new best @ step {global_step}; "
-                  f"checkpoint saved to {best_ckpt_path}")
-
-    # (tensorboard train-loss stays per-epoch to avoid spam)
-
-    if tb:
-        tb.add_scalar("loss/train", train_loss, global_step)
-
-    print(f"iter {global_step:03d} | "
-          f"train {train_loss:.4f} | val {val_loss:.4f} | "
-          f"{(time.time()-t0):.1f}s")
-
+        if improved or args.always_save_checkpoint:
+            torch.save(checkpoint_payload(), best_ckpt_path)
+            print(f"checkpoint saved to {best_ckpt_path}")
+        if improved or args.sample_each_eval:
+            sample_and_print()
 
 if tb:
     tb.flush()

--- a/train_recurrent.py
+++ b/train_recurrent.py
@@ -52,7 +52,8 @@ recur_parser.add_argument("--latent_mix_mode", choices=("direct", "slerp", "add_
                           help="How to turn a recurrent latent into the next input: reuse it directly, slerp toward the correct token embedding, or add then L2-normalize")
 recur_parser.add_argument("--latent_mix_alpha", type=float, default=0.5,
                           help="Blend amount for --latent_mix_mode=slerp; ignored by direct/add_norm unless --learn_latent_mix_alpha is set for checkpointing consistency")
-recur_parser.add_argument("--learn_latent_mix_alpha", action="store_true",
+recur_parser.add_argument("--learn_latent_mix_alpha", default=False,
+                          action=argparse.BooleanOptionalAction,
                           help="Learn the slerp blend amount as a sigmoid-constrained scalar")
 
 # -- split cmdline -----------------------------------------------------

--- a/train_recurrent.py
+++ b/train_recurrent.py
@@ -2,8 +2,8 @@
 # train_recurrent.py  –  latent-chaining fine-tuning
 # ======================================================================
 #  * trains from scratch or resumes from an existing train.py checkpoint
-#  * feeds the HIDDEN state (after ln_f / scale_down) back as the next
-#    “token”, skipping de-embedding, for the first `--latent_steps`
+#  * teacher-forces the first `--latent_steps` positions, then feeds each
+#    HIDDEN state (after ln_f / scale_down) back as the next “token”
 #  * keeps cross-entropy vs. ground-truth, with optional per-position
 #    linear weighting and an initial “skip” window
 # ----------------------------------------------------------------------
@@ -40,7 +40,7 @@ recur_parser = argparse.ArgumentParser(add_help=False)
 recur_parser.add_argument("--resume_ckpt", default=None,
                           help="Optional checkpoint produced by train.py; omit with --init_from=scratch")
 recur_parser.add_argument("--latent_steps",  type=int, default=0,
-                          help="Chain this many hidden states before teacher-forcing")
+                          help="Teacher-force this many initial positions before recurrent latent feedback")
 recur_parser.add_argument("--skip_steps",    type=int, default=0,
                           help="Mask loss for the first K positions in every block")
 recur_parser.add_argument("--weight_start",  type=float, default=1.0)

--- a/train_recurrent.py
+++ b/train_recurrent.py
@@ -45,6 +45,14 @@ recur_parser.add_argument("--skip_steps",    type=int, default=0,
 recur_parser.add_argument("--weight_start",  type=float, default=1.0)
 recur_parser.add_argument("--weight_end",    type=float, default=1.0)
 recur_parser.add_argument("--reset_optim", action="store_true", help="Ignore optimiser state in the checkpoint")
+recur_parser.add_argument("--reset_best_val_loss_on_resume", default=False, action=argparse.BooleanOptionalAction,
+                          help="Reset best_val_loss instead of inheriting it from --resume_ckpt")
+recur_parser.add_argument("--latent_mix_mode", choices=("direct", "slerp", "add_norm"), default="direct",
+                          help="How to turn a recurrent latent into the next input: reuse it directly, slerp toward the correct token embedding, or add then L2-normalize")
+recur_parser.add_argument("--latent_mix_alpha", type=float, default=0.5,
+                          help="Blend amount for --latent_mix_mode=slerp; ignored by direct/add_norm unless --learn_latent_mix_alpha is set for checkpointing consistency")
+recur_parser.add_argument("--learn_latent_mix_alpha", action="store_true",
+                          help="Learn the slerp blend amount as a sigmoid-constrained scalar")
 
 # -- split cmdline -----------------------------------------------------
 latent_args, remaining = recur_parser.parse_known_args()
@@ -98,9 +106,20 @@ if unexpected:
 embed_tokens     = model.embed_tokens
 forward_embedded = lambda x: model.forward_embedded(x, return_hidden=True)
 
+latent_mix_logit = None
+if args.learn_latent_mix_alpha:
+    initial_alpha = min(max(args.latent_mix_alpha, 1e-6), 1.0 - 1e-6)
+    latent_mix_logit = torch.nn.Parameter(
+        torch.logit(torch.tensor(initial_alpha, device=device))
+    )
+    if ckpt.get("latent_mix_logit") is not None:
+        latent_mix_logit.data.copy_(ckpt["latent_mix_logit"].to(device))
+
 decay, no_decay = [], []
 for n, p in model.named_parameters():
     (decay if p.dim() >= 2 else no_decay).append(p)
+if latent_mix_logit is not None:
+    no_decay.append(latent_mix_logit)
 
 param_groups = [
     {"params": decay,     "weight_decay": args.opt_weight_decay},
@@ -110,12 +129,17 @@ param_groups = [
 optimizer = optimizer_dictionary[args.optimizer](param_groups, args)
 
 if ckpt.get("optimizer") and not getattr(args, "reset_optim", False):
-    optimizer.load_state_dict(ckpt["optimizer"])
+    try:
+        optimizer.load_state_dict(ckpt["optimizer"])
+    except ValueError as exc:
+        print(f"warning: optimizer state not loaded ({exc})")
 
 
-best_val_loss = ckpt["best_val_loss"].item()
+best_val_loss_raw = ckpt.get("best_val_loss", float("inf"))
+best_val_loss = best_val_loss_raw.item() if hasattr(best_val_loss_raw, "item") else float(best_val_loss_raw)
+if args.reset_best_val_loss_on_resume:
+    best_val_loss = float("inf")
 print("best_val_loss", best_val_loss)
-best_val_loss=5.00 # TODO: set a flag so that we can choose to definitely start saving checkpoints in recurrent mode
 iter_num      = ckpt["iter_num"]          # not used, but preserved
 
 block_size = gpt_conf.block_size
@@ -140,8 +164,46 @@ def make_loss_weights(bsz: int, T: int, device):
     return w
 
 # ----------------------------------------------------------------------
-# 5)  ONE BLOCK (B,T)  →  scalar loss
+# 5)  LATENT MIXING + ONE BLOCK (B,T)  →  scalar loss
 # ----------------------------------------------------------------------
+def current_latent_mix_alpha():
+    if latent_mix_logit is not None:
+        return torch.sigmoid(latent_mix_logit)
+    return torch.tensor(args.latent_mix_alpha, device=device)
+
+
+def slerp_latent(latent, target, amount, eps=1e-8):
+    """
+    Spherical interpolation from `latent` toward the correct-token embedding.
+    Norms are interpolated linearly so the result keeps a sensible magnitude
+    even when the two input vectors have different lengths.
+    """
+    latent_norm = latent.norm(dim=-1, keepdim=True).clamp_min(eps)
+    target_norm = target.norm(dim=-1, keepdim=True).clamp_min(eps)
+    latent_unit = latent / latent_norm
+    target_unit = target / target_norm
+    dot = (latent_unit * target_unit).sum(dim=-1, keepdim=True).clamp(-1.0 + eps, 1.0 - eps)
+    omega = torch.acos(dot)
+    sin_omega = torch.sin(omega).clamp_min(eps)
+    mixed_unit = (
+        torch.sin((1.0 - amount) * omega) / sin_omega * latent_unit
+        + torch.sin(amount * omega) / sin_omega * target_unit
+    )
+    mixed_norm = (1.0 - amount) * latent_norm + amount * target_norm
+    return mixed_unit * mixed_norm
+
+
+def mix_recurrent_latent(latent, correct_token_emb):
+    if args.latent_mix_mode == "direct":
+        return latent
+    if args.latent_mix_mode == "slerp":
+        return slerp_latent(latent, correct_token_emb, current_latent_mix_alpha())
+    if args.latent_mix_mode == "add_norm":
+        mixed = latent + correct_token_emb
+        return F.normalize(mixed, p=2, dim=-1) * math.sqrt(gpt_conf.n_embd)
+    raise ValueError(f"unknown latent_mix_mode: {args.latent_mix_mode}")
+
+
 def train_block(x_tokens, y_tokens):
     """
     One recurrent block that **preserves full self-attention context**.
@@ -161,11 +223,13 @@ def train_block(x_tokens, y_tokens):
 
     for t in range(T):
         # ---- decide what to append ---------------------------------
-        # ↳ Teacher-force **until** we reach latent_steps
-        if t < args.latent_steps:
-            new_piece = embed_tokens(x_tokens[:, t:t+1])  # GT token
+        correct_piece = embed_tokens(x_tokens[:, t:t+1])  # GT token embedding
+        # ↳ Seed with GT embeddings, then feed back the previous latent.
+        #    Optional modes can bias that latent back toward the correct token.
+        if t < args.latent_steps or hidden_prev is None:
+            new_piece = correct_piece
         else:
-            new_piece = hidden_prev                       # latent
+            new_piece = mix_recurrent_latent(hidden_prev, correct_piece)
 
         # ---- grow the buffer ---------------------------------------
         hidden_buf = new_piece if hidden_buf is None else \
@@ -224,7 +288,8 @@ def run_epoch(split):
                         {"model": model.state_dict(),
                          "model_args": ckpt["model_args"],
                          "iter_num":   global_step,
-                         "best_val_loss": best_val_loss},
+                         "best_val_loss": best_val_loss,
+                         "latent_mix_logit": None if latent_mix_logit is None else latent_mix_logit.detach().cpu()},
                         best_ckpt_path)
                     print(f"  ➜ new best @ step {global_step}; "
                           f"checkpoint saved to {best_ckpt_path}")
@@ -244,7 +309,8 @@ def run_epoch(split):
 # 7)  TRAINING DRIVER
 # ----------------------------------------------------------------------
 tb = SummaryWriter() if getattr(args, "tensorboard_log", False) else None
-best_ckpt_path = os.path.join(os.path.dirname(args.resume_ckpt), "ckpt_lat.pt")
+os.makedirs(args.out_dir, exist_ok=True)
+best_ckpt_path = os.path.join(args.out_dir, "ckpt.pt")
 
 val_loss = 999.9
 while global_step < args.max_iters:
@@ -264,7 +330,8 @@ while global_step < args.max_iters:
                 {"model": model.state_dict(),
                  "model_args": ckpt["model_args"],
                  "iter_num":   global_step,
-                 "best_val_loss": best_val_loss},
+                 "best_val_loss": best_val_loss,
+                 "latent_mix_logit": None if latent_mix_logit is None else latent_mix_logit.detach().cpu()},
                 best_ckpt_path)
             print(f"  ➜ new best @ step {global_step}; "
                   f"checkpoint saved to {best_ckpt_path}")

--- a/train_recurrent.py
+++ b/train_recurrent.py
@@ -1,7 +1,7 @@
 # ======================================================================
 # train_recurrent.py  –  latent-chaining fine-tuning
 # ======================================================================
-#  * resumes from an existing checkpoint (no scratch / no GPT-2 import)
+#  * trains from scratch or resumes from an existing train.py checkpoint
 #  * feeds the HIDDEN state (after ln_f / scale_down) back as the next
 #    “token”, skipping de-embedding, for the first `--latent_steps`
 #  * keeps cross-entropy vs. ground-truth, with optional per-position
@@ -37,8 +37,8 @@ global_step = 0          # counts *training* iterations
 # 1-bis)  add the *extra* flags that are unique to latent-chaining
 # ----------------------------------------------------------------------
 recur_parser = argparse.ArgumentParser(add_help=False)
-recur_parser.add_argument("--resume_ckpt",   required=True,
-                          help="Path to .pt checkpoint produced by train.py")
+recur_parser.add_argument("--resume_ckpt", default=None,
+                          help="Optional checkpoint produced by train.py; omit with --init_from=scratch")
 recur_parser.add_argument("--latent_steps",  type=int, default=0,
                           help="Chain this many hidden states before teacher-forcing")
 recur_parser.add_argument("--skip_steps",    type=int, default=0,
@@ -62,7 +62,7 @@ latent_args, remaining = recur_parser.parse_known_args()
 # 1-b)  now run the gigantic parser **only on the leftovers**
 # ----------------------------------------------------------------------
 sys.argv = [sys.argv[0]] + remaining          # fake argv for train_args
-generic_args, *_ = parse_generic_args()
+generic_args, model_group, _, _ = parse_generic_args()
 
 # ----------------------------------------------------------------------
 # 1-c)  merge both Namespaces into one `args`
@@ -80,10 +80,24 @@ device_type = "cuda" if device.startswith("cuda") else "cpu"
 dtype_map = {"float32": torch.float32, "float16": torch.float16, "bfloat16": torch.bfloat16}
 ptdtype = dtype_map[args.dtype]
 ctx = nullcontext() if device_type == "cpu" else torch.amp.autocast(device_type=device_type, dtype=ptdtype)
-ckpt = torch.load(args.resume_ckpt, map_location=device)
+if args.resume_ckpt:
+    ckpt = torch.load(args.resume_ckpt, map_location=device)
+    model_args = ckpt["model_args"]
+else:
+    if args.init_from != "scratch":
+        raise ValueError("train_recurrent.py requires --resume_ckpt unless --init_from=scratch")
+    meta_path = os.path.join("data", args.dataset, "meta.pkl")
+    if not os.path.exists(meta_path):
+        raise FileNotFoundError(f"scratch training requires tokenizer metadata at {meta_path}")
+    with open(meta_path, "rb") as f:
+        meta = pickle.load(f)
+    model_args = {action.dest: getattr(args, action.dest) for action in model_group._group_actions}
+    model_args["vocab_size"] = meta["vocab_size"]
+    model_args["eval_interval"] = args.eval_interval
+    ckpt = {"model_args": model_args, "iter_num": 0, "best_val_loss": float("inf")}
 
-gpt_conf = GPTConfig(**ckpt["model_args"])
-model    = GPT(gpt_conf).to(device)
+gpt_conf = GPTConfig(**model_args)
+model = GPT(gpt_conf).to(device)
 
 def unwrap_state_dict(wrapped_sd):
     """
@@ -99,10 +113,10 @@ def unwrap_state_dict(wrapped_sd):
         clean[k] = v
     return clean
 
-state_dict = unwrap_state_dict(ckpt["model"])
+state_dict = unwrap_state_dict(ckpt.get("model", {}))
 missing, unexpected = model.load_state_dict(state_dict, strict=False)
 
-if missing:
+if missing and args.resume_ckpt:
     print(f"warning: {len(missing)} missing params (OK if all zero-grad)")
 if unexpected:
     print(f"warning: {len(unexpected)} extra params ignored")
@@ -151,7 +165,7 @@ best_val_loss = best_val_loss_raw.item() if hasattr(best_val_loss_raw, "item") e
 if args.reset_best_val_loss_on_resume:
     best_val_loss = float("inf")
 print("best_val_loss", best_val_loss)
-iter_num      = ckpt["iter_num"]          # not used, but preserved
+iter_num = ckpt["iter_num"]          # not used, but preserved
 
 block_size = gpt_conf.block_size
 
@@ -387,4 +401,3 @@ if tb:
 
 print("done.")
 # ======================================================================
-


### PR DESCRIPTION
### Motivation
- Add first-class support for multi-stage sequential experiment runs with per-stage out dirs and checkpoint handoff to enable multi-stage pretraining→finetune→recurrent workflows.
- Enable flexible recurrent latent-chaining experiments with multiple mixing modes and an optional learnable mix parameter to explore alternatives to direct latent feedback.

### Description
- Add two example configs under `explorations/` (`sequential_minipile_dialogsum_recurrent_lat_mix.yaml` and `sequential_training_features_example.yaml`) demonstrating sequential runs, stage-level out dirs, `train_script` aliases, and placeholder usage.
- Extend `optimization_and_search/run_experiments.py` to support `${PREV_OUT_DIR}`, `${PREV_CKPT}`, and `${STAGE_OUT_DIR}` placeholders, `training_sequence` stage lists, `train_script` aliases, per-stage config preparation (`_prepare_stage_config`), per-stage out dir naming, checkpoint copying when `resume_from_previous` is set, stage command building, and sequential execution logic (`_run_training_sequence`).
- Make `run_experiments.py` safer: defer stage-local substitutions until stage prep, gracefully report optimizer load failures, and centralize parameter printing with `_print_parameters`.
- Add resume/metric behavior and latent-mixing support in training scripts: `train_mezo.py` will reset `best_val_loss` when `--reset_best_val_loss_on_resume` is set, and `train_recurrent.py` gains CLI flags `--latent_mix_mode`, `--latent_mix_alpha`, `--learn_latent_mix_alpha`, and `--reset_best_val_loss_on_resume`, implements `slerp` and `add_norm` mixing, optional learnable `latent_mix_logit` checkpointing, uses mixed latents in the recurrent loop, and standardizes `out_dir`/checkpoint save paths.

### Testing
- Performed a smoke invocation of `optimization_and_search/run_experiments.py` using `explorations/sequential_training_features_example.yaml` to verify per-stage command generation and placeholder substitution, which produced the expected stage commands and out_dir layout.
- Ran basic sanity checks of `train_recurrent.py` and `train_mezo.py` argument parsing and resume/checkpoint handling paths to confirm no parse/load errors; these checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5930e65bec83268ad2ada58ffa5433)