### PR TITLE
Allow SLERP extrapolation and add model-backed `norm(...)` / `wov(...)` arithmetic functions

### DIFF
--- a/report/threejs/hf-vocab-sphere/app/main.py
+++ b/report/threejs/hf-vocab-sphere/app/main.py
@@ -6,7 +6,6 @@ from html import escape as html_escape
 from pathlib import Path
 
 import numpy as np
-
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
@@ -19,12 +18,13 @@ from .model_store import (
     list_local_models,
     load_model,
     model_status,
+    model_vector_function,
     nearest_neighbors,
     search_tokens,
-    tokenize_text,
     selected_token_rows,
     selected_vectors,
     token_record,
+    tokenize_text,
     unload_model,
 )
 from .projections import nearest_neighbor_edges, project_vectors, projection_catalog
@@ -237,7 +237,11 @@ def _prepare_projection_selection(
         requested_ids.insert(0, anchor_id)
     ids, base_vectors = selected_vectors(assets, requested_ids)
     anchor_index = ids.index(anchor_id) if anchor_id is not None else None
-    resultants = evaluate_vector_expressions(base_vectors, arithmetic_expressions or [])
+    resultants = evaluate_vector_expressions(
+        base_vectors,
+        arithmetic_expressions or [],
+        model_function=lambda name, args: model_vector_function(assets, name, args),
+    )
     if resultants:
         vectors = np.vstack([base_vectors, *(item.vector[None, :] for item in resultants)])
     else:

--- a/report/threejs/hf-vocab-sphere/app/model_store.py
+++ b/report/threejs/hf-vocab-sphere/app/model_store.py
@@ -6,9 +6,10 @@ import math
 import os
 import re
 import threading
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 import numpy as np
 import torch
@@ -102,7 +103,10 @@ class ModelAssets:
 
     @property
     def memory_bytes(self) -> int:
-        return int(self.weight.nelement() * self.weight.element_size() + self.magnitudes.nelement() * self.magnitudes.element_size())
+        return int(
+            self.weight.nelement() * self.weight.element_size()
+            + self.magnitudes.nelement() * self.magnitudes.element_size()
+        )
 
     def token(self, token_id: int) -> TokenInfo:
         if token_id < 0 or token_id >= self.vocab_size:
@@ -346,7 +350,9 @@ def _load_full_model(
         try:
             model = model_class.from_pretrained(model_name, **kwargs)
             output = model.get_output_embeddings() if callable(getattr(model, "get_output_embeddings", None)) else None
-            input_embedding = model.get_input_embeddings() if callable(getattr(model, "get_input_embeddings", None)) else None
+            input_embedding = (
+                model.get_input_embeddings() if callable(getattr(model, "get_input_embeddings", None)) else None
+            )
             if requested_source == "output":
                 chosen, source = output, "output"
             elif requested_source == "input":
@@ -354,7 +360,9 @@ def _load_full_model(
             else:
                 chosen, source = (output, "output") if output is not None else (input_embedding, "input")
             if chosen is None or getattr(chosen, "weight", None) is None:
-                raise ValueError(f"{model_class.__name__} does not expose a usable {requested_source} vocabulary matrix.")
+                raise ValueError(
+                    f"{model_class.__name__} does not expose a usable {requested_source} vocabulary matrix."
+                )
             tensor = chosen.weight.detach().cpu().contiguous()
             name = "get_output_embeddings().weight" if source == "output" else "get_input_embeddings().weight"
             return tensor, name, source
@@ -975,3 +983,148 @@ def list_local_models() -> list[LocalModelInfo]:
                 modified = None
             records[name] = LocalModelInfo(name, str(path), None, modified)
     return sorted(records.values(), key=lambda item: item.model_name.casefold())
+
+
+_AUX_TENSOR_CACHE: dict[tuple[str, str, bool], dict[str, torch.Tensor]] = {}
+
+
+def _all_safetensor_tensors(model_name: str, *, revision: str, allow_download: bool = True) -> dict[str, torch.Tensor]:
+    cache_key = (model_name, revision, allow_download)
+    cached = _AUX_TENSOR_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+    tensors: dict[str, torch.Tensor] = {}
+    index_path = _try_repo_file(
+        model_name, "model.safetensors.index.json", revision=revision, allow_download=allow_download
+    )
+    if index_path is not None:
+        with index_path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        weight_map = data.get("weight_map") or {}
+        files = sorted(set(str(value) for value in weight_map.values() if isinstance(value, str)))
+    else:
+        files = _list_safetensors_files(model_name, revision=revision, allow_download=allow_download)
+    for filename in files:
+        path = _try_repo_file(model_name, filename, revision=revision, allow_download=allow_download)
+        if path is None:
+            continue
+        with safe_open(str(path), framework="pt", device="cpu") as handle:
+            for name in handle.keys():
+                lname = str(name).casefold()
+                if (
+                    lname.endswith(("norm.weight", "norm.bias", "layernorm.weight", "layernorm.bias"))
+                    or ".v_proj.weight" in lname
+                    or ".value.weight" in lname
+                    or ".o_proj.weight" in lname
+                    or ".out_proj.weight" in lname
+                ):
+                    tensors[str(name)] = (
+                        handle.get_tensor(str(name)).detach().cpu().to(dtype=torch.float32).contiguous()
+                    )
+    _AUX_TENSOR_CACHE[cache_key] = tensors
+    return tensors
+
+
+def _layer_prefix(tensor_name: str, layer: int) -> str:
+    markers = (f"layers.{layer}.", f"h.{layer}.", f"blocks.{layer}.", f"layer.{layer}.")
+    for marker in markers:
+        if marker in tensor_name:
+            return tensor_name.split(marker, 1)[0] + marker
+    return ""
+
+
+def _find_tensor(
+    tensors: dict[str, torch.Tensor], needles: Iterable[str], *, layer: int | None = None, ndim: int | None = None
+) -> tuple[str, torch.Tensor]:
+    names = list(tensors)
+    if layer is not None:
+        names = [name for name in names if _layer_prefix(name, layer)]
+    needle_list = [needle.casefold() for needle in needles]
+    matches = [name for name in names if any(needle in name.casefold() for needle in needle_list)]
+    if ndim is not None:
+        matches = [name for name in matches if tensors[name].ndim == ndim]
+    if not matches:
+        scope = f" layer {layer}" if layer is not None else ""
+        raise ValueError(f"Could not find model tensor matching {', '.join(needles)}{scope}.")
+    return sorted(matches, key=lambda name: (len(name), name))[0], tensors[
+        sorted(matches, key=lambda name: (len(name), name))[0]
+    ]
+
+
+def model_vector_function(assets: ModelAssets, name: str, args: list[float | str | np.ndarray]) -> np.ndarray:
+    tensors = _all_safetensor_tensors(assets.model_name, revision=assets.revision, allow_download=True)
+    if name == "norm":
+        if len(args) == 2 and str(args[1]).casefold() == "final":
+            vector = np.asarray(args[0], dtype=np.float64)
+            _n, weight = _find_tensor(
+                tensors, ("model.norm.weight", "final_layernorm.weight", "ln_f.weight", "norm.weight"), ndim=1
+            )
+        elif len(args) == 4:
+            vector = np.asarray(args[0], dtype=np.float64)
+            layer = int(args[1])
+            block = str(args[2]).casefold()
+            position = str(args[3]).casefold()
+            if block in {"attn", "attention"} and position in {"input", "before", "in"}:
+                needles = ("input_layernorm.weight", "ln_1.weight", "attention_norm.weight")
+            elif block in {"attn", "attention"} and position in {"output", "after", "out"}:
+                needles = ("post_attention_layernorm.weight", "post_attention_norm.weight", "ln_2.weight")
+            elif block in {"ffn", "mlp"} and position in {"input", "before", "in"}:
+                needles = ("pre_feedforward_layernorm.weight", "post_attention_layernorm.weight", "ln_2.weight")
+            elif block in {"ffn", "mlp"} and position in {"output", "after", "out"}:
+                needles = ("post_feedforward_layernorm.weight", "post_feedforward_norm.weight")
+            else:
+                raise ValueError(
+                    "norm expects norm(vector, layer, 'attn'|'ffn', 'input'|'output') or norm(vector, 'final')."
+                )
+            _n, weight = _find_tensor(tensors, needles, layer=layer, ndim=1)
+        else:
+            raise ValueError(
+                "norm expects norm(vector, layer, 'attn'|'ffn', 'input'|'output') or norm(vector, 'final')."
+            )
+        w = weight.numpy().astype(np.float64)
+        if w.shape[0] != vector.shape[0]:
+            raise ValueError(f"Norm width {w.shape[0]} does not match vector width {vector.shape[0]}.")
+        return vector * w / math.sqrt(float(np.mean(vector * vector)) + 1e-6)
+    if name == "wov":
+        if len(args) != 3:
+            raise ValueError("wov expects wov(vector, layer, head).")
+        vector = np.asarray(args[0], dtype=np.float64)
+        layer = int(args[1])
+        head = int(args[2])
+        _vn, v_weight = _find_tensor(
+            tensors,
+            ("self_attn.v_proj.weight", "attention.v_proj.weight", "attn.v_proj.weight", "value.weight"),
+            layer=layer,
+            ndim=2,
+        )
+        _on, o_weight = _find_tensor(
+            tensors,
+            ("self_attn.o_proj.weight", "attention.o_proj.weight", "attn.o_proj.weight", "out_proj.weight"),
+            layer=layer,
+            ndim=2,
+        )
+        v = v_weight.numpy().astype(np.float64)
+        o = o_weight.numpy().astype(np.float64)
+        if v.shape[1] != vector.shape[0] or o.shape[0] != vector.shape[0]:
+            raise ValueError("Attention projection widths do not match the selected vector space.")
+        if v.shape[0] != o.shape[1]:
+            raise ValueError("Wv output width and Wo input width do not match.")
+        head_count = 0
+        config_path = _try_repo_file(assets.model_name, "config.json", revision=assets.revision, allow_download=True)
+        if config_path is not None:
+            with config_path.open("r", encoding="utf-8") as handle:
+                config = json.load(handle)
+            head_count = int(
+                config.get("num_key_value_heads") or config.get("num_attention_heads") or config.get("n_head") or 0
+            )
+        if head_count <= 0:
+            head_count = 1
+        # Prefer an even partition; users can still select head 0 for single-head or unknown configs.
+        if v.shape[0] % max(head_count, 1) != 0:
+            head_count = 1
+        head_dim = v.shape[0] // head_count
+        if head < 0 or head >= head_count:
+            raise ValueError(f"head must be in [0, {head_count - 1}], got {head}.")
+        start, end = head * head_dim, (head + 1) * head_dim
+        return (vector @ v[start:end, :].T) @ o[:, start:end].T
+    raise ValueError(f"Unknown model function {name!r}.")

--- a/report/threejs/hf-vocab-sphere/app/model_store.py
+++ b/report/threejs/hf-vocab-sphere/app/model_store.py
@@ -1051,40 +1051,64 @@ def _find_tensor(
     ]
 
 
+def _norm_weight_for_args(
+    tensors: dict[str, torch.Tensor], args: list[float | str | np.ndarray]
+) -> tuple[np.ndarray, torch.Tensor]:
+    if len(args) == 2 and str(args[1]).casefold() == "final":
+        vector = np.asarray(args[0], dtype=np.float64)
+        _name, weight = _find_tensor(
+            tensors, ("model.norm.weight", "final_layernorm.weight", "ln_f.weight", "norm.weight"), ndim=1
+        )
+        return vector, weight
+    if len(args) != 4:
+        raise ValueError("norm/invnorm expect (vector, layer, 'attn'|'ffn', 'input'|'output') or (vector, 'final').")
+
+    vector = np.asarray(args[0], dtype=np.float64)
+    layer = int(args[1])
+    block = str(args[2]).casefold()
+    position = str(args[3]).casefold()
+    if block in {"attn", "attention"} and position in {"input", "before", "in"}:
+        needles = ("input_layernorm.weight", "ln_1.weight", "attention_norm.weight")
+    elif block in {"attn", "attention"} and position in {"output", "after", "out"}:
+        needles = ("post_attention_layernorm.weight", "post_attention_norm.weight", "ln_2.weight")
+    elif block in {"ffn", "mlp"} and position in {"input", "before", "in"}:
+        needles = ("pre_feedforward_layernorm.weight", "post_attention_layernorm.weight", "ln_2.weight")
+    elif block in {"ffn", "mlp"} and position in {"output", "after", "out"}:
+        needles = ("post_feedforward_layernorm.weight", "post_feedforward_norm.weight")
+    else:
+        raise ValueError("norm/invnorm expect (vector, layer, 'attn'|'ffn', 'input'|'output') or (vector, 'final').")
+    _name, weight = _find_tensor(tensors, needles, layer=layer, ndim=1)
+    return vector, weight
+
+
+def _apply_rms_norm(vector: np.ndarray, weight: torch.Tensor) -> np.ndarray:
+    w = weight.numpy().astype(np.float64)
+    if w.shape[0] != vector.shape[0]:
+        raise ValueError(f"Norm width {w.shape[0]} does not match vector width {vector.shape[0]}.")
+    return vector * w / math.sqrt(float(np.mean(vector * vector)) + 1e-6)
+
+
+def _apply_inverse_rms_norm(vector: np.ndarray, weight: torch.Tensor) -> np.ndarray:
+    w = weight.numpy().astype(np.float64)
+    if w.shape[0] != vector.shape[0]:
+        raise ValueError(f"Norm width {w.shape[0]} does not match vector width {vector.shape[0]}.")
+    if np.any(np.abs(w) <= 1e-15):
+        raise ValueError("Cannot invert a norm with zero or near-zero weights.")
+    unweighted = vector / w
+    normalized_square_mean = float(np.mean(unweighted * unweighted))
+    if normalized_square_mean >= 1.0:
+        raise ValueError("Cannot invert this norm result because its implied pre-norm magnitude is not finite.")
+    scale = math.sqrt(1e-6 / max(1.0 - normalized_square_mean, 1e-15))
+    return unweighted * scale
+
+
 def model_vector_function(assets: ModelAssets, name: str, args: list[float | str | np.ndarray]) -> np.ndarray:
     tensors = _all_safetensor_tensors(assets.model_name, revision=assets.revision, allow_download=True)
-    if name == "norm":
-        if len(args) == 2 and str(args[1]).casefold() == "final":
-            vector = np.asarray(args[0], dtype=np.float64)
-            _n, weight = _find_tensor(
-                tensors, ("model.norm.weight", "final_layernorm.weight", "ln_f.weight", "norm.weight"), ndim=1
-            )
-        elif len(args) == 4:
-            vector = np.asarray(args[0], dtype=np.float64)
-            layer = int(args[1])
-            block = str(args[2]).casefold()
-            position = str(args[3]).casefold()
-            if block in {"attn", "attention"} and position in {"input", "before", "in"}:
-                needles = ("input_layernorm.weight", "ln_1.weight", "attention_norm.weight")
-            elif block in {"attn", "attention"} and position in {"output", "after", "out"}:
-                needles = ("post_attention_layernorm.weight", "post_attention_norm.weight", "ln_2.weight")
-            elif block in {"ffn", "mlp"} and position in {"input", "before", "in"}:
-                needles = ("pre_feedforward_layernorm.weight", "post_attention_layernorm.weight", "ln_2.weight")
-            elif block in {"ffn", "mlp"} and position in {"output", "after", "out"}:
-                needles = ("post_feedforward_layernorm.weight", "post_feedforward_norm.weight")
-            else:
-                raise ValueError(
-                    "norm expects norm(vector, layer, 'attn'|'ffn', 'input'|'output') or norm(vector, 'final')."
-                )
-            _n, weight = _find_tensor(tensors, needles, layer=layer, ndim=1)
-        else:
-            raise ValueError(
-                "norm expects norm(vector, layer, 'attn'|'ffn', 'input'|'output') or norm(vector, 'final')."
-            )
-        w = weight.numpy().astype(np.float64)
-        if w.shape[0] != vector.shape[0]:
-            raise ValueError(f"Norm width {w.shape[0]} does not match vector width {vector.shape[0]}.")
-        return vector * w / math.sqrt(float(np.mean(vector * vector)) + 1e-6)
+    if name in {"norm", "invnorm", "inverse_norm"}:
+        vector, weight = _norm_weight_for_args(tensors, args)
+        if name == "norm":
+            return _apply_rms_norm(vector, weight)
+        return _apply_inverse_rms_norm(vector, weight)
     if name == "wov":
         if len(args) != 3:
             raise ValueError("wov expects wov(vector, layer, head).")

--- a/report/threejs/hf-vocab-sphere/app/static/app.js
+++ b/report/threejs/hf-vocab-sphere/app/static/app.js
@@ -1354,7 +1354,8 @@ function renderArithmeticPanel() {
 async function addArithmeticResult() {
   const rows = selectedRows();
   const slerpMode = $('arithmeticModeSelect').value === 'slerp';
-  const fraction = Math.max(0, Math.min(1, Number($('slerpFractionInput').value) || 0));
+  const rawFraction = Number($('slerpFractionInput').value);
+  const fraction = Number.isFinite(rawFraction) ? rawFraction : 0;
   const fromAlias = $('slerpFromSelect').value;
   const toAlias = $('slerpToSelect').value;
   const expression = slerpMode
@@ -1848,7 +1849,7 @@ function normalizedWorkspace(snapshot) {
       label: stringValue(editor.label, '', 120),
       slerpFrom: stringValue(editor.slerp_from, 'A', 20),
       slerpTo: stringValue(editor.slerp_to, 'B', 20),
-      slerpFraction: finiteNumber(editor.slerp_fraction, 0.5, 0, 1),
+      slerpFraction: finiteNumber(editor.slerp_fraction, 0.5, -1e9, 1e9),
     },
   };
 }

--- a/report/threejs/hf-vocab-sphere/app/templates/index.html
+++ b/report/threejs/hf-vocab-sphere/app/templates/index.html
@@ -269,7 +269,7 @@
         <label class="field-label top-gap" for="arithmeticLabelInput">Result label</label>
         <input id="arithmeticLabelInput" type="text" placeholder="e.g. analogy result" maxlength="120" />
         <button class="primary hero-button" id="addArithmeticBtn">Add resultant to map</button>
-        <div class="small top-gap">Expressions support aliases, scalars, parentheses, <span class="mono">+ - * /</span>, <span class="mono">mean(...)</span>, <span class="mono">slerp(A,B,t)</span>, <span class="mono">norm(A,0,'attn','input')</span>/<span class="mono">norm(A,'final')</span>, and <span class="mono">wov(A,0,0)</span>. Functions can be nested. Example average: <span class="mono">(A+B+C)/3 + D</span>. Resultants are projected from the original model space, never by adding screen coordinates.</div>
+        <div class="small top-gap">Expressions support aliases, scalars, parentheses, <span class="mono">+ - * /</span>, <span class="mono">mean(...)</span>, <span class="mono">slerp(A,B,t)</span>, <span class="mono">norm(A,0,'attn','input')</span>/<span class="mono">norm(A,'final')</span>, <span class="mono">invnorm(A,...)</span>, and <span class="mono">wov(A,0,0)</span>. Functions can be nested. Example average: <span class="mono">(A+B+C)/3 + D</span>. Resultants are projected from the original model space, never by adding screen coordinates.</div>
         <div id="arithmeticResults" class="arithmetic-result-list top-gap"><div class="empty-selection">No resultants defined.</div></div>
       </section>
 

--- a/report/threejs/hf-vocab-sphere/app/templates/index.html
+++ b/report/threejs/hf-vocab-sphere/app/templates/index.html
@@ -261,15 +261,15 @@
             </div>
           </div>
           <div class="range-wrap top-gap">
-            <div class="range-row"><span>Interpolation fraction</span><span id="slerpFractionLabel">t = 0.50</span></div>
-            <input id="slerpFractionInput" type="range" min="0" max="1" step="0.01" value="0.5" />
+            <div class="range-row"><span>Interpolation / extrapolation value</span><span id="slerpFractionLabel">t = 0.50</span></div>
+            <input id="slerpFractionInput" type="number" step="0.01" value="0.5" />
           </div>
-          <div class="small top-gap">SLERP follows the shortest geodesic between normalized full-dimensional vectors while linearly interpolating their original L2 magnitudes.</div>
+          <div class="small top-gap">SLERP follows the shortest geodesic between normalized full-dimensional vectors while linearly interpolating their original L2 magnitudes; finite negative and positive t values are accepted for extrapolation.</div>
         </div>
         <label class="field-label top-gap" for="arithmeticLabelInput">Result label</label>
         <input id="arithmeticLabelInput" type="text" placeholder="e.g. analogy result" maxlength="120" />
         <button class="primary hero-button" id="addArithmeticBtn">Add resultant to map</button>
-        <div class="small top-gap">Expressions support aliases, scalars, parentheses, <span class="mono">+ - * /</span>, <span class="mono">mean(...)</span>, and <span class="mono">slerp(A,B,t)</span>. Example average: <span class="mono">(A+B+C)/3 + D</span>. Resultants are projected from the original model space, never by adding screen coordinates.</div>
+        <div class="small top-gap">Expressions support aliases, scalars, parentheses, <span class="mono">+ - * /</span>, <span class="mono">mean(...)</span>, <span class="mono">slerp(A,B,t)</span>, <span class="mono">norm(A,0,'attn','input')</span>/<span class="mono">norm(A,'final')</span>, and <span class="mono">wov(A,0,0)</span>. Functions can be nested. Example average: <span class="mono">(A+B+C)/3 + D</span>. Resultants are projected from the original model space, never by adding screen coordinates.</div>
         <div id="arithmeticResults" class="arithmetic-result-list top-gap"><div class="empty-selection">No resultants defined.</div></div>
       </section>
 

--- a/report/threejs/hf-vocab-sphere/app/vector_math.py
+++ b/report/threejs/hf-vocab-sphere/app/vector_math.py
@@ -161,7 +161,7 @@ class _SafeVectorEvaluator:
                     "vector",
                     np.mean(np.stack([np.asarray(value.value) for value in values], axis=0), axis=0),
                 )
-            if function_name in {"norm", "wov"}:
+            if function_name in {"norm", "invnorm", "inverse_norm", "wov"}:
                 if self.model_function is None:
                     raise ValueError(f"{node.func.id} requires model auxiliary tensors loaded by the projection API.")
                 values = [self._visit(argument) for argument in node.args]
@@ -174,7 +174,7 @@ class _SafeVectorEvaluator:
                 return _Value("vector", self.model_function(function_name, args))
             if function_name != "slerp":
                 raise ValueError(
-                    "Only mean(...), slerp(A, B, t), norm(...), and wov(...) vector functions are supported."
+                    "Only mean(...), slerp(A, B, t), norm(...), invnorm(...), and wov(...) vector functions are supported."
                 )
             if len(node.args) != 3:
                 raise ValueError("slerp requires exactly three positional arguments: slerp(A, B, t).")
@@ -221,7 +221,7 @@ class _SafeVectorEvaluator:
                 return _Value("vector", np.asarray(left.value) / denominator)
 
         raise ValueError(
-            "Unsupported expression syntax. Use vector aliases, numeric scalars, parentheses, +, -, *, /, mean(...), slerp(A, B, t), norm(...), and wov(...)."
+            "Unsupported expression syntax. Use vector aliases, numeric scalars, parentheses, +, -, *, /, mean(...), slerp(A, B, t), norm(...), invnorm(...), and wov(...)."
         )
 
 

--- a/report/threejs/hf-vocab-sphere/app/vector_math.py
+++ b/report/threejs/hf-vocab-sphere/app/vector_math.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import ast
 import math
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 import numpy as np
 
@@ -43,7 +43,7 @@ def alias_map(vectors: np.ndarray) -> dict[str, np.ndarray]:
 @dataclass(slots=True)
 class _Value:
     kind: str
-    value: float | np.ndarray
+    value: float | str | np.ndarray
 
 
 def spherical_linear_interpolation(a: np.ndarray, b: np.ndarray, t: float) -> np.ndarray:
@@ -56,17 +56,12 @@ def spherical_linear_interpolation(a: np.ndarray, b: np.ndarray, t: float) -> np
     first = np.asarray(a, dtype=np.float64)
     second = np.asarray(b, dtype=np.float64)
     fraction = float(t)
-    if not math.isfinite(fraction) or fraction < 0.0 or fraction > 1.0:
-        raise ValueError("SLERP t must be a finite scalar in the interval [0, 1].")
+    if not math.isfinite(fraction):
+        raise ValueError("SLERP t must be a finite scalar.")
     norm_a = float(np.linalg.norm(first))
     norm_b = float(np.linalg.norm(second))
     if norm_a <= 1e-15 or norm_b <= 1e-15:
         raise ValueError("SLERP requires two non-zero vectors.")
-    if fraction <= 0.0:
-        return first.copy()
-    if fraction >= 1.0:
-        return second.copy()
-
     unit_a = first / norm_a
     unit_b = second / norm_b
     dot = float(np.clip(np.dot(unit_a, unit_b), -1.0, 1.0))
@@ -85,19 +80,20 @@ def spherical_linear_interpolation(a: np.ndarray, b: np.ndarray, t: float) -> np
     else:
         angle = math.acos(dot)
         sine = math.sin(angle)
-        direction = (
-            math.sin((1.0 - fraction) * angle) / sine * unit_a
-            + math.sin(fraction * angle) / sine * unit_b
-        )
+        direction = math.sin((1.0 - fraction) * angle) / sine * unit_a + math.sin(fraction * angle) / sine * unit_b
         direction /= max(float(np.linalg.norm(direction)), 1e-15)
 
     magnitude = (1.0 - fraction) * norm_a + fraction * norm_b
     return direction * magnitude
 
 
+ModelFunction = Callable[[str, list[float | str | np.ndarray]], np.ndarray]
+
+
 class _SafeVectorEvaluator:
-    def __init__(self, aliases: dict[str, np.ndarray]):
+    def __init__(self, aliases: dict[str, np.ndarray], model_function: ModelFunction | None = None):
         self.aliases = {name.upper(): np.asarray(vector, dtype=np.float64) for name, vector in aliases.items()}
+        self.model_function = model_function
         self.referenced: set[str] = set()
 
     def evaluate(self, expression: str) -> np.ndarray:
@@ -138,6 +134,12 @@ class _SafeVectorEvaluator:
                 raise ValueError("Scalar constants must be finite and reasonably sized.")
             return _Value("scalar", scalar)
 
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            text = node.value.strip().casefold()
+            if not text or len(text) > 40:
+                raise ValueError("String arguments must be short, non-blank selectors.")
+            return _Value("string", text)
+
         if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
             operand = self._visit(node.operand)
             sign = 1.0 if isinstance(node.op, ast.UAdd) else -1.0
@@ -145,7 +147,7 @@ class _SafeVectorEvaluator:
 
         if isinstance(node, ast.Call):
             if not isinstance(node.func, ast.Name):
-                raise ValueError("Only mean(...) and slerp(A, B, t) vector functions are supported.")
+                raise ValueError("Only named vector functions are supported.")
             function_name = node.func.id.casefold()
             if node.keywords:
                 raise ValueError("Vector functions accept positional arguments only.")
@@ -159,15 +161,28 @@ class _SafeVectorEvaluator:
                     "vector",
                     np.mean(np.stack([np.asarray(value.value) for value in values], axis=0), axis=0),
                 )
+            if function_name in {"norm", "wov"}:
+                if self.model_function is None:
+                    raise ValueError(f"{node.func.id} requires model auxiliary tensors loaded by the projection API.")
+                values = [self._visit(argument) for argument in node.args]
+                args: list[float | str | np.ndarray] = [
+                    np.asarray(value.value)
+                    if value.kind == "vector"
+                    else (str(value.value) if value.kind == "string" else float(value.value))
+                    for value in values
+                ]
+                return _Value("vector", self.model_function(function_name, args))
             if function_name != "slerp":
-                raise ValueError("Only mean(...) and slerp(A, B, t) vector functions are supported.")
+                raise ValueError(
+                    "Only mean(...), slerp(A, B, t), norm(...), and wov(...) vector functions are supported."
+                )
             if len(node.args) != 3:
                 raise ValueError("slerp requires exactly three positional arguments: slerp(A, B, t).")
             first = self._visit(node.args[0])
             second = self._visit(node.args[1])
             fraction = self._visit(node.args[2])
             if first.kind != "vector" or second.kind != "vector" or fraction.kind != "scalar":
-                raise ValueError("slerp requires two vectors followed by a scalar t in [0, 1].")
+                raise ValueError("slerp requires two vectors followed by a scalar t.")
             return _Value(
                 "vector",
                 spherical_linear_interpolation(
@@ -206,12 +221,14 @@ class _SafeVectorEvaluator:
                 return _Value("vector", np.asarray(left.value) / denominator)
 
         raise ValueError(
-            "Unsupported expression syntax. Use vector aliases, numeric scalars, parentheses, +, -, *, /, mean(...), and slerp(A, B, t)."
+            "Unsupported expression syntax. Use vector aliases, numeric scalars, parentheses, +, -, *, /, mean(...), slerp(A, B, t), norm(...), and wov(...)."
         )
 
 
-def evaluate_vector_expression(expression: str, aliases: dict[str, np.ndarray]) -> tuple[np.ndarray, tuple[str, ...]]:
-    evaluator = _SafeVectorEvaluator(aliases)
+def evaluate_vector_expression(
+    expression: str, aliases: dict[str, np.ndarray], model_function: ModelFunction | None = None
+) -> tuple[np.ndarray, tuple[str, ...]]:
+    evaluator = _SafeVectorEvaluator(aliases, model_function=model_function)
     vector = evaluator.evaluate(expression)
     return vector, tuple(sorted(evaluator.referenced, key=lambda name: (len(name), name)))
 
@@ -219,6 +236,7 @@ def evaluate_vector_expression(expression: str, aliases: dict[str, np.ndarray]) 
 def evaluate_vector_expressions(
     vectors: np.ndarray,
     expressions: Iterable[object],
+    model_function: ModelFunction | None = None,
 ) -> list[VectorExpressionResult]:
     """Evaluate request-like objects with ``expression`` and optional ``label`` attributes."""
     aliases = alias_map(vectors)
@@ -226,14 +244,12 @@ def evaluate_vector_expressions(
     for index, item in enumerate(expressions):
         expression = str(getattr(item, "expression", "") or "").strip()
         requested_label = str(getattr(item, "label", "") or "").strip()
-        vector, referenced = evaluate_vector_expression(expression, aliases)
+        vector, referenced = evaluate_vector_expression(expression, aliases, model_function=model_function)
         magnitude = float(np.linalg.norm(vector))
         if not math.isfinite(magnitude):
             raise ValueError(f"Resultant {index + 1} has a non-finite magnitude.")
         if magnitude <= 1e-12:
-            raise ValueError(
-                f"Resultant {index + 1} is zero or near-zero and has no direction to project."
-            )
+            raise ValueError(f"Resultant {index + 1} is zero or near-zero and has no direction to project.")
         alias = f"R{index + 1}"
         results.append(
             VectorExpressionResult(

--- a/report/threejs/hf-vocab-sphere/tests/test_vector_math.py
+++ b/report/threejs/hf-vocab-sphere/tests/test_vector_math.py
@@ -83,13 +83,15 @@ def test_zero_resultant_is_rejected() -> None:
 
 def test_model_functions_can_be_nested() -> None:
     aliases = {"A": np.array([1.0, 2.0])}
+    calls: list[str] = []
 
     def model_function(name, args):
-        assert name == "norm"
-        return np.asarray(args[0]) * 2.0
+        calls.append(name)
+        return np.asarray(args[0]) * (2.0 if name == "norm" else 0.5)
 
     result, references = evaluate_vector_expression(
-        "norm(norm(A, 0, 'attn', 'input'), 'final')", aliases, model_function=model_function
+        "invnorm(norm(A, 0, 'attn', 'input'), 'final')", aliases, model_function=model_function
     )
-    np.testing.assert_allclose(result, np.array([4.0, 8.0]))
+    np.testing.assert_allclose(result, aliases["A"])
     assert references == ("A",)
+    assert calls == ["norm", "invnorm"]

--- a/report/threejs/hf-vocab-sphere/tests/test_vector_math.py
+++ b/report/threejs/hf-vocab-sphere/tests/test_vector_math.py
@@ -48,7 +48,7 @@ def test_slerp_interpolates_direction_and_magnitude() -> None:
         "B": np.array([0.0, 4.0, 0.0]),
     }
     midpoint, references = evaluate_vector_expression("slerp(A, B, 0.5)", aliases)
-    expected_direction = np.array([2 ** -0.5, 2 ** -0.5, 0.0])
+    expected_direction = np.array([2**-0.5, 2**-0.5, 0.0])
     np.testing.assert_allclose(midpoint, expected_direction * 3.0, atol=1e-8)
     assert references == ("A", "B")
 
@@ -58,10 +58,11 @@ def test_slerp_interpolates_direction_and_magnitude() -> None:
     np.testing.assert_allclose(end, aliases["B"])
 
 
-def test_slerp_rejects_invalid_fraction() -> None:
+def test_slerp_allows_finite_extrapolation() -> None:
     aliases = {"A": np.array([1.0, 0.0]), "B": np.array([0.0, 1.0])}
-    with pytest.raises(ValueError, match="interval"):
-        evaluate_vector_expression("slerp(A, B, 1.5)", aliases)
+    result, references = evaluate_vector_expression("slerp(A, B, -0.5)", aliases)
+    assert references == ("A", "B")
+    assert np.all(np.isfinite(result))
 
 
 def test_unsafe_vector_math_is_rejected() -> None:
@@ -78,3 +79,17 @@ def test_zero_resultant_is_rejected() -> None:
             vectors,
             [SimpleNamespace(expression="A - A", label="zero")],
         )
+
+
+def test_model_functions_can_be_nested() -> None:
+    aliases = {"A": np.array([1.0, 2.0])}
+
+    def model_function(name, args):
+        assert name == "norm"
+        return np.asarray(args[0]) * 2.0
+
+    result, references = evaluate_vector_expression(
+        "norm(norm(A, 0, 'attn', 'input'), 'final')", aliases, model_function=model_function
+    )
+    np.testing.assert_allclose(result, np.array([4.0, 8.0]))
+    assert references == ("A",)


### PR DESCRIPTION
### Motivation
- Enable users to extrapolate as well as interpolate with SLERP by accepting any finite positive or negative `t` value. 
- Allow arithmetic expressions to reference layerwise normalization and per-head attention projections so users can apply `norm(...)` and `wov(...)` inside expressions and nest functions. 
- Surface these capabilities in the projection pipeline so resultants may be computed from auxiliary model tensors (layer norms, value/projection weights) rather than only raw embedding rows. 

### Description
- Relaxed `slerp` validation in `app/vector_math.py` so finite negative and positive `t` values are accepted and added a `model_function` hook to the safe evaluator for model-backed functions. 
- Extended the expression language to accept short string selectors and new functions `norm(...)` and `wov(...)` (with nesting support) in `app/vector_math.py`. 
- Implemented `model_vector_function` and auxiliary safetensors discovery in `app/model_store.py` to locate layer-norm and attention `v_proj`/`o_proj` tensors and compute `norm(vector, layer, block, position)`, `norm(vector, 'final')`, and `wov(vector, layer, head)`. 
- Wired evaluation to the API in `app/main.py` by passing `model_vector_function` into `evaluate_vector_expressions`, and updated the UI/help text and controls in `app/static/app.js` and `app/templates/index.html` so SLERP accepts numeric input for extrapolation and documents the new functions. 

### Testing
- Ran Python syntax checks with `python -m py_compile` for `app/vector_math.py`, `app/model_store.py`, and `app/main.py`, which succeeded. 
- Ran lint/format checks and auto-fixes with `ruff`, and reformatted files as needed. 
- Executed targeted unit tests: `pytest tests/test_vector_math.py` (including new extrapolation + nesting tests) and `pytest tests/test_frontend_contract.py`, both passed. 
- Full project test run was blocked for some environment targets due to missing/large runtime dependency (`torch`) in the environment, so running the entire `pytest -q` suite requires installing the project dependencies locally or in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5da23777c483269c6306dd548cfa04)