### PR TITLE
Add model-aware vector functions, participation metrics, and UI toggles for magnitudes/participation

### DIFF
--- a/report/threejs/hf-vocab-sphere/app/main.py
+++ b/report/threejs/hf-vocab-sphere/app/main.py
@@ -6,7 +6,6 @@ from html import escape as html_escape
 from pathlib import Path
 
 import numpy as np
-
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
@@ -19,12 +18,13 @@ from .model_store import (
     list_local_models,
     load_model,
     model_status,
+    model_vector_function,
     nearest_neighbors,
     search_tokens,
-    tokenize_text,
     selected_token_rows,
     selected_vectors,
     token_record,
+    tokenize_text,
     unload_model,
 )
 from .projections import nearest_neighbor_edges, project_vectors, projection_catalog
@@ -47,7 +47,7 @@ from .schemas import (
     TokenSearchResponse,
     TokenWindowResponse,
 )
-from .vector_math import VectorExpressionResult, alias_for_index, evaluate_vector_expressions
+from .vector_math import VectorExpressionResult, alias_for_index, evaluate_vector_expressions, vector_dimension_metrics
 
 BASE_DIR = Path(__file__).resolve().parent
 INDEX_PATH = BASE_DIR / "templates" / "index.html"
@@ -237,7 +237,11 @@ def _prepare_projection_selection(
         requested_ids.insert(0, anchor_id)
     ids, base_vectors = selected_vectors(assets, requested_ids)
     anchor_index = ids.index(anchor_id) if anchor_id is not None else None
-    resultants = evaluate_vector_expressions(base_vectors, arithmetic_expressions or [])
+    resultants = evaluate_vector_expressions(
+        base_vectors,
+        arithmetic_expressions or [],
+        model_function=lambda name, args: model_vector_function(assets, name, args),
+    )
     if resultants:
         vectors = np.vstack([base_vectors, *(item.vector[None, :] for item in resultants)])
     else:
@@ -262,6 +266,7 @@ def _projection_rows(
                 "kind": "token",
                 "alias": alias_for_index(index),
                 "label": row["display"],
+                **vector_dimension_metrics(base_vectors[index]),
                 "expression": None,
                 "referenced_aliases": [],
             }
@@ -283,6 +288,7 @@ def _projection_rows(
                 "special": False,
                 "present_in_tokenizer": False,
                 "magnitude": item.magnitude,
+                **vector_dimension_metrics(item.vector),
                 "rank": None,
                 "cosine_similarity": None,
                 "angle_deg": None,

--- a/report/threejs/hf-vocab-sphere/app/model_store.py
+++ b/report/threejs/hf-vocab-sphere/app/model_store.py
@@ -6,9 +6,10 @@ import math
 import os
 import re
 import threading
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 import numpy as np
 import torch
@@ -102,7 +103,10 @@ class ModelAssets:
 
     @property
     def memory_bytes(self) -> int:
-        return int(self.weight.nelement() * self.weight.element_size() + self.magnitudes.nelement() * self.magnitudes.element_size())
+        return int(
+            self.weight.nelement() * self.weight.element_size()
+            + self.magnitudes.nelement() * self.magnitudes.element_size()
+        )
 
     def token(self, token_id: int) -> TokenInfo:
         if token_id < 0 or token_id >= self.vocab_size:
@@ -346,7 +350,9 @@ def _load_full_model(
         try:
             model = model_class.from_pretrained(model_name, **kwargs)
             output = model.get_output_embeddings() if callable(getattr(model, "get_output_embeddings", None)) else None
-            input_embedding = model.get_input_embeddings() if callable(getattr(model, "get_input_embeddings", None)) else None
+            input_embedding = (
+                model.get_input_embeddings() if callable(getattr(model, "get_input_embeddings", None)) else None
+            )
             if requested_source == "output":
                 chosen, source = output, "output"
             elif requested_source == "input":
@@ -354,7 +360,9 @@ def _load_full_model(
             else:
                 chosen, source = (output, "output") if output is not None else (input_embedding, "input")
             if chosen is None or getattr(chosen, "weight", None) is None:
-                raise ValueError(f"{model_class.__name__} does not expose a usable {requested_source} vocabulary matrix.")
+                raise ValueError(
+                    f"{model_class.__name__} does not expose a usable {requested_source} vocabulary matrix."
+                )
             tensor = chosen.weight.detach().cpu().contiguous()
             name = "get_output_embeddings().weight" if source == "output" else "get_input_embeddings().weight"
             return tensor, name, source
@@ -975,3 +983,296 @@ def list_local_models() -> list[LocalModelInfo]:
                 modified = None
             records[name] = LocalModelInfo(name, str(path), None, modified)
     return sorted(records.values(), key=lambda item: item.model_name.casefold())
+
+
+_AUX_TENSOR_CACHE: dict[tuple[str, str, bool], dict[str, torch.Tensor]] = {}
+
+
+def _all_safetensor_tensors(model_name: str, *, revision: str, allow_download: bool = True) -> dict[str, torch.Tensor]:
+    cache_key = (model_name, revision, allow_download)
+    cached = _AUX_TENSOR_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+    tensors: dict[str, torch.Tensor] = {}
+    index_path = _try_repo_file(
+        model_name, "model.safetensors.index.json", revision=revision, allow_download=allow_download
+    )
+    if index_path is not None:
+        with index_path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        weight_map = data.get("weight_map") or {}
+        files = sorted(set(str(value) for value in weight_map.values() if isinstance(value, str)))
+    else:
+        files = _list_safetensors_files(model_name, revision=revision, allow_download=allow_download)
+    for filename in files:
+        path = _try_repo_file(model_name, filename, revision=revision, allow_download=allow_download)
+        if path is None:
+            continue
+        with safe_open(str(path), framework="pt", device="cpu") as handle:
+            for name in handle.keys():
+                lname = str(name).casefold()
+                if (
+                    lname.endswith(("norm.weight", "norm.bias", "layernorm.weight", "layernorm.bias"))
+                    or ".q_proj.weight" in lname
+                    or ".query.weight" in lname
+                    or ".k_proj.weight" in lname
+                    or ".key.weight" in lname
+                    or ".v_proj.weight" in lname
+                    or ".value.weight" in lname
+                    or ".o_proj.weight" in lname
+                    or ".out_proj.weight" in lname
+                ):
+                    tensors[str(name)] = (
+                        handle.get_tensor(str(name)).detach().cpu().to(dtype=torch.float32).contiguous()
+                    )
+    _AUX_TENSOR_CACHE[cache_key] = tensors
+    return tensors
+
+
+def _layer_prefix(tensor_name: str, layer: int) -> str:
+    markers = (f"layers.{layer}.", f"h.{layer}.", f"blocks.{layer}.", f"layer.{layer}.")
+    for marker in markers:
+        if marker in tensor_name:
+            return tensor_name.split(marker, 1)[0] + marker
+    return ""
+
+
+def _find_tensor(
+    tensors: dict[str, torch.Tensor], needles: Iterable[str], *, layer: int | None = None, ndim: int | None = None
+) -> tuple[str, torch.Tensor]:
+    names = list(tensors)
+    if layer is not None:
+        names = [name for name in names if _layer_prefix(name, layer)]
+    needle_list = [needle.casefold() for needle in needles]
+    matches = [name for name in names if any(needle in name.casefold() for needle in needle_list)]
+    if ndim is not None:
+        matches = [name for name in matches if tensors[name].ndim == ndim]
+    if not matches:
+        scope = f" layer {layer}" if layer is not None else ""
+        raise ValueError(f"Could not find model tensor matching {', '.join(needles)}{scope}.")
+    return sorted(matches, key=lambda name: (len(name), name))[0], tensors[
+        sorted(matches, key=lambda name: (len(name), name))[0]
+    ]
+
+
+def _norm_weight_for_args(
+    tensors: dict[str, torch.Tensor], args: list[float | str | np.ndarray]
+) -> tuple[np.ndarray, torch.Tensor]:
+    if len(args) == 2 and str(args[1]).casefold() == "final":
+        vector = np.asarray(args[0], dtype=np.float64)
+        _name, weight = _find_tensor(
+            tensors, ("model.norm.weight", "final_layernorm.weight", "ln_f.weight", "norm.weight"), ndim=1
+        )
+        return vector, weight
+    if len(args) != 4:
+        raise ValueError("norm/invnorm expect (vector, layer, 'attn'|'ffn', 'input'|'output') or (vector, 'final').")
+
+    vector = np.asarray(args[0], dtype=np.float64)
+    layer = int(args[1])
+    block = str(args[2]).casefold()
+    position = str(args[3]).casefold()
+    if block in {"attn", "attention"} and position in {"input", "before", "in"}:
+        needles = ("input_layernorm.weight", "ln_1.weight", "attention_norm.weight")
+    elif block in {"attn", "attention"} and position in {"output", "after", "out"}:
+        needles = ("post_attention_layernorm.weight", "post_attention_norm.weight", "ln_2.weight")
+    elif block in {"ffn", "mlp"} and position in {"input", "before", "in"}:
+        needles = ("pre_feedforward_layernorm.weight", "post_attention_layernorm.weight", "ln_2.weight")
+    elif block in {"ffn", "mlp"} and position in {"output", "after", "out"}:
+        needles = ("post_feedforward_layernorm.weight", "post_feedforward_norm.weight")
+    else:
+        raise ValueError("norm/invnorm expect (vector, layer, 'attn'|'ffn', 'input'|'output') or (vector, 'final').")
+    _name, weight = _find_tensor(tensors, needles, layer=layer, ndim=1)
+    return vector, weight
+
+
+def _apply_rms_norm(vector: np.ndarray, weight: torch.Tensor) -> np.ndarray:
+    w = weight.numpy().astype(np.float64)
+    if w.shape[0] != vector.shape[0]:
+        raise ValueError(f"Norm width {w.shape[0]} does not match vector width {vector.shape[0]}.")
+    return vector * w / math.sqrt(float(np.mean(vector * vector)) + 1e-6)
+
+
+def _apply_inverse_rms_norm(vector: np.ndarray, weight: torch.Tensor) -> np.ndarray:
+    w = weight.numpy().astype(np.float64)
+    if w.shape[0] != vector.shape[0]:
+        raise ValueError(f"Norm width {w.shape[0]} does not match vector width {vector.shape[0]}.")
+    if np.any(np.abs(w) <= 1e-15):
+        raise ValueError("Cannot invert a norm with zero or near-zero weights.")
+    unweighted = vector / w
+    normalized_square_mean = float(np.mean(unweighted * unweighted))
+    if normalized_square_mean >= 1.0:
+        raise ValueError("Cannot invert this norm result because its implied pre-norm magnitude is not finite.")
+    scale = math.sqrt(1e-6 / max(1.0 - normalized_square_mean, 1e-15))
+    return unweighted * scale
+
+
+def _attention_head_counts(assets: ModelAssets) -> tuple[int, int]:
+    config_path = _try_repo_file(assets.model_name, "config.json", revision=assets.revision, allow_download=True)
+    if config_path is None:
+        return 1, 1
+    with config_path.open("r", encoding="utf-8") as handle:
+        config = json.load(handle)
+    attention_heads = int(config.get("num_attention_heads") or config.get("n_head") or 0)
+    key_value_heads = int(config.get("num_key_value_heads") or attention_heads or 0)
+    return max(attention_heads, 1), max(key_value_heads, 1)
+
+
+def _wov_head_slices(
+    *,
+    v_output_width: int,
+    o_input_width: int,
+    attention_heads: int,
+    key_value_heads: int,
+    head: int,
+) -> tuple[slice, slice, int]:
+    if attention_heads <= 0:
+        attention_heads = 1
+    if key_value_heads <= 0:
+        key_value_heads = attention_heads
+    if o_input_width % attention_heads != 0:
+        # Fall back to treating Wo as one concatenated head space when the config
+        # does not divide the tensor cleanly.
+        attention_heads = 1
+    head_dim = o_input_width // attention_heads
+    if head_dim <= 0:
+        raise ValueError("Wo input width is not usable for head slicing.")
+    if head < 0 or head >= attention_heads:
+        raise ValueError(f"head must be in [0, {attention_heads - 1}], got {head}.")
+
+    if v_output_width == o_input_width:
+        key_value_heads = attention_heads
+    elif v_output_width % key_value_heads != 0:
+        if v_output_width == head_dim:
+            key_value_heads = 1
+        elif v_output_width % head_dim == 0:
+            key_value_heads = v_output_width // head_dim
+        else:
+            raise ValueError("Wv output width cannot be partitioned into Wo-compatible heads.")
+
+    v_head_dim = v_output_width // key_value_heads
+    if v_head_dim != head_dim:
+        raise ValueError("Wv head width and Wo head width do not match.")
+    kv_head = min((head * key_value_heads) // attention_heads, key_value_heads - 1)
+    v_start = kv_head * head_dim
+    o_start = head * head_dim
+    return slice(v_start, v_start + head_dim), slice(o_start, o_start + head_dim), attention_heads
+
+
+def _qk_head_slices(
+    *,
+    q_output_width: int,
+    k_output_width: int,
+    attention_heads: int,
+    key_value_heads: int,
+    query_head: int,
+    key_head: int,
+) -> tuple[slice, slice]:
+    if attention_heads <= 0:
+        attention_heads = 1
+    if key_value_heads <= 0:
+        key_value_heads = attention_heads
+    if q_output_width % attention_heads != 0:
+        attention_heads = 1
+    q_head_dim = q_output_width // attention_heads
+    if q_head_dim <= 0:
+        raise ValueError("Wq output width is not usable for head slicing.")
+    if query_head < 0 or query_head >= attention_heads:
+        raise ValueError(f"query head must be in [0, {attention_heads - 1}], got {query_head}.")
+
+    if k_output_width == q_output_width:
+        key_value_heads = attention_heads
+    elif k_output_width % key_value_heads != 0:
+        if k_output_width == q_head_dim:
+            key_value_heads = 1
+        elif k_output_width % q_head_dim == 0:
+            key_value_heads = k_output_width // q_head_dim
+        else:
+            raise ValueError("Wk output width cannot be partitioned into Wq-compatible heads.")
+
+    k_head_dim = k_output_width // key_value_heads
+    if k_head_dim != q_head_dim:
+        raise ValueError("Wq head width and Wk head width do not match.")
+    if key_head < 0 or key_head >= key_value_heads:
+        raise ValueError(f"key head must be in [0, {key_value_heads - 1}], got {key_head}.")
+    q_start = query_head * q_head_dim
+    k_start = key_head * q_head_dim
+    return slice(q_start, q_start + q_head_dim), slice(k_start, k_start + q_head_dim)
+
+
+def model_vector_function(assets: ModelAssets, name: str, args: list[float | str | np.ndarray]) -> np.ndarray:
+    tensors = _all_safetensor_tensors(assets.model_name, revision=assets.revision, allow_download=True)
+    if name in {"norm", "invnorm", "inverse_norm"}:
+        vector, weight = _norm_weight_for_args(tensors, args)
+        if name == "norm":
+            return _apply_rms_norm(vector, weight)
+        return _apply_inverse_rms_norm(vector, weight)
+    if name == "wov":
+        if len(args) != 3:
+            raise ValueError("wov expects wov(vector, layer, head).")
+        vector = np.asarray(args[0], dtype=np.float64)
+        layer = int(args[1])
+        head = int(args[2])
+        _vn, v_weight = _find_tensor(
+            tensors,
+            ("self_attn.v_proj.weight", "attention.v_proj.weight", "attn.v_proj.weight", "value.weight"),
+            layer=layer,
+            ndim=2,
+        )
+        _on, o_weight = _find_tensor(
+            tensors,
+            ("self_attn.o_proj.weight", "attention.o_proj.weight", "attn.o_proj.weight", "out_proj.weight"),
+            layer=layer,
+            ndim=2,
+        )
+        v = v_weight.numpy().astype(np.float64)
+        o = o_weight.numpy().astype(np.float64)
+        if v.shape[1] != vector.shape[0] or o.shape[0] != vector.shape[0]:
+            raise ValueError("Attention projection widths do not match the selected vector space.")
+        attention_heads, key_value_heads = _attention_head_counts(assets)
+        v_slice, o_slice, _head_count = _wov_head_slices(
+            v_output_width=v.shape[0],
+            o_input_width=o.shape[1],
+            attention_heads=attention_heads,
+            key_value_heads=key_value_heads,
+            head=head,
+        )
+        # Multiplying by the selected Wo slice is equivalent to padding the
+        # selected Wv-head output with zeros before/after its head slot and then
+        # applying the full Wo matrix, but avoids materializing the padded vector.
+        return (vector @ v[v_slice, :].T) @ o[:, o_slice].T
+    if name in {"wqk", "wkq"}:
+        if len(args) != 4:
+            raise ValueError("wqk/wkq expect (vector, layer, query_head, key_head).")
+        vector = np.asarray(args[0], dtype=np.float64)
+        layer = int(args[1])
+        query_head = int(args[2])
+        key_head = int(args[3])
+        _qn, q_weight = _find_tensor(
+            tensors,
+            ("self_attn.q_proj.weight", "attention.q_proj.weight", "attn.q_proj.weight", "query.weight"),
+            layer=layer,
+            ndim=2,
+        )
+        _kn, k_weight = _find_tensor(
+            tensors,
+            ("self_attn.k_proj.weight", "attention.k_proj.weight", "attn.k_proj.weight", "key.weight"),
+            layer=layer,
+            ndim=2,
+        )
+        q = q_weight.numpy().astype(np.float64)
+        k = k_weight.numpy().astype(np.float64)
+        if q.shape[1] != vector.shape[0] or k.shape[1] != vector.shape[0]:
+            raise ValueError("Attention Q/K projection widths do not match the selected vector space.")
+        attention_heads, key_value_heads = _attention_head_counts(assets)
+        q_slice, k_slice = _qk_head_slices(
+            q_output_width=q.shape[0],
+            k_output_width=k.shape[0],
+            attention_heads=attention_heads,
+            key_value_heads=key_value_heads,
+            query_head=query_head,
+            key_head=key_head,
+        )
+        if name == "wqk":
+            return (vector @ q[q_slice, :].T) @ k[k_slice, :]
+        return (vector @ k[k_slice, :].T) @ q[q_slice, :]
+    raise ValueError(f"Unknown model function {name!r}.")

--- a/report/threejs/hf-vocab-sphere/app/model_store.py
+++ b/report/threejs/hf-vocab-sphere/app/model_store.py
@@ -1227,6 +1227,16 @@ def _apply_attention_layer(
     layer: int,
     kv_vectors: list[np.ndarray],
 ) -> np.ndarray:
+    return _attention_layer_stages(assets, tensors, latest_vector, layer, kv_vectors)["pre_skip"]
+
+
+def _attention_layer_stages(
+    assets: ModelAssets,
+    tensors: dict[str, torch.Tensor],
+    latest_vector: np.ndarray,
+    layer: int,
+    kv_vectors: list[np.ndarray],
+) -> dict[str, np.ndarray | list[np.ndarray]]:
     _qn, q_weight = _find_tensor(
         tensors,
         ("self_attn.q_proj.weight", "attention.q_proj.weight", "attn.q_proj.weight", "query.weight"),
@@ -1265,7 +1275,7 @@ def _apply_attention_layer(
     # The latest/query token also contributes its own K/V entry after the supplied cache order.
     kv_norms.append(latest_norm)
     attention_heads, key_value_heads = _attention_head_counts(assets)
-    output = np.zeros(width, dtype=np.float64)
+    head_outputs: list[np.ndarray] = []
     for query_head in range(attention_heads):
         kv_head = min((query_head * key_value_heads) // attention_heads, key_value_heads - 1)
         q_slice, k_slice = _qk_head_slices(
@@ -1288,8 +1298,14 @@ def _apply_attention_layer(
         values = np.stack([vector @ v[v_slice, :].T for vector in kv_norms], axis=0)
         scores = keys @ query / math.sqrt(max(query.shape[0], 1))
         context = _softmax(scores) @ values
-        output += context @ o[:, o_slice].T
-    return _optional_norm(tensors, [output, layer, "attn", "output"])
+        head_outputs.append(context @ o[:, o_slice].T)
+    output = np.sum(head_outputs, axis=0)
+    return {
+        "input_norm": latest_norm,
+        "pre_output_norm": output,
+        "pre_skip": _optional_norm(tensors, [output, layer, "attn", "output"]),
+        "heads": head_outputs,
+    }
 
 
 def _activation(name: str, values: np.ndarray) -> np.ndarray:
@@ -1302,6 +1318,12 @@ def _activation(name: str, values: np.ndarray) -> np.ndarray:
 def _apply_mlp_layer(
     assets: ModelAssets, tensors: dict[str, torch.Tensor], vector: np.ndarray, layer: int
 ) -> np.ndarray:
+    return _mlp_layer_stages(assets, tensors, vector, layer)["pre_skip"]
+
+
+def _mlp_layer_stages(
+    assets: ModelAssets, tensors: dict[str, torch.Tensor], vector: np.ndarray, layer: int
+) -> dict[str, np.ndarray]:
     hidden = _apply_rms_norm(*_norm_weight_for_args(tensors, [vector, layer, "ffn", "input"]))
     try:
         _gn, gate_weight = _find_tensor(
@@ -1330,7 +1352,77 @@ def _apply_mlp_layer(
             output = _activation("gelu", hidden @ fc.T) @ proj.T
         else:
             output = _activation("gelu", hidden @ fc) @ proj
-    return _optional_norm(tensors, [output, layer, "ffn", "output"])
+    return {
+        "input_norm": hidden,
+        "pre_output_norm": output,
+        "pre_skip": _optional_norm(tensors, [output, layer, "ffn", "output"]),
+    }
+
+
+def _selected_heads(selector: str, head_count: int) -> list[int]:
+    if selector.casefold() in {"all", "*"}:
+        return list(range(head_count))
+    heads: set[int] = set()
+    for part in selector.split(","):
+        part = part.strip()
+        if "-" in part:
+            start_text, end_text = part.split("-", 1)
+            start, end = int(start_text), int(end_text)
+            heads.update(range(start, end + 1))
+        elif part:
+            heads.add(int(part))
+    if not heads or min(heads) < 0 or max(heads) >= head_count:
+        raise ValueError(f"Head selector must choose heads in [0, {head_count - 1}].")
+    return sorted(heads)
+
+
+def _simulate_to_point(
+    assets: ModelAssets,
+    tensors: dict[str, torch.Tensor],
+    latest_vector: np.ndarray,
+    target_layer: int,
+    block: str,
+    point: str,
+    head_selector: str,
+    context_vectors: list[np.ndarray],
+) -> np.ndarray:
+    if target_layer < 0:
+        raise ValueError("Simulation layer must be non-negative.")
+    block = block.casefold()
+    point = point.casefold()
+    if block not in {"attn", "attention", "mlp", "ffn"}:
+        raise ValueError("Simulation block must be 'attn' or 'mlp'.")
+    if point not in {"input_norm", "pre_output_norm", "pre_skip", "post_skip", "heads"}:
+        raise ValueError("Simulation point must be input_norm, pre_output_norm, pre_skip, post_skip, or heads.")
+    if point == "heads" and block not in {"attn", "attention"}:
+        raise ValueError("The heads simulation point is available only for attention.")
+
+    # Keep every token's residual stream because each later attention layer needs
+    # a causal cache produced by all preceding layers, not the original embeddings.
+    residuals = [np.asarray(value, dtype=np.float64).copy() for value in context_vectors]
+    residuals.append(np.asarray(latest_vector, dtype=np.float64).copy())
+    for layer in range(target_layer + 1):
+        attention_updates: list[np.ndarray] = []
+        for index, residual in enumerate(residuals):
+            stages = _attention_layer_stages(assets, tensors, residual, layer, residuals[:index])
+            if layer == target_layer and index == len(residuals) - 1 and block in {"attn", "attention"}:
+                if point == "heads":
+                    outputs = stages["heads"]
+                    assert isinstance(outputs, list)
+                    chosen = _selected_heads(head_selector, len(outputs))
+                    return np.sum([outputs[head] for head in chosen], axis=0)
+                selected = np.asarray(stages[point if point != "post_skip" else "pre_skip"])
+                return residual + selected if point == "post_skip" else selected
+            attention_updates.append(np.asarray(stages["pre_skip"]))
+        residuals = [residual + update for residual, update in zip(residuals, attention_updates)]
+
+        for index, residual in enumerate(residuals):
+            stages = _mlp_layer_stages(assets, tensors, residual, layer)
+            if layer == target_layer and index == len(residuals) - 1 and block in {"mlp", "ffn"}:
+                selected = stages[point if point != "post_skip" else "pre_skip"]
+                return residual + selected if point == "post_skip" else selected
+            residuals[index] = residual + stages["pre_skip"]
+    raise ValueError("Could not reach the requested simulation point.")
 
 
 def model_vector_function(assets: ModelAssets, name: str, args: list[float | str | np.ndarray]) -> np.ndarray:
@@ -1387,6 +1479,21 @@ def model_vector_function(assets: ModelAssets, name: str, args: list[float | str
         vector = np.asarray(args[0], dtype=np.float64)
         layer = int(args[1])
         return _apply_mlp_layer(assets, tensors, vector, layer)
+    if name == "model_state":
+        if len(args) < 5:
+            raise ValueError(
+                "model_state expects (latest, layer, 'attn'|'mlp', point, head_selector, optional_context, ...)."
+            )
+        return _simulate_to_point(
+            assets,
+            tensors,
+            np.asarray(args[0], dtype=np.float64),
+            int(args[1]),
+            str(args[2]),
+            str(args[3]),
+            str(args[4]),
+            [np.asarray(value, dtype=np.float64) for value in args[5:]],
+        )
     if name in {"wqk", "wkq"}:
         if len(args) != 4:
             raise ValueError("wqk/wkq expect (vector, layer, query_head, key_head).")

--- a/report/threejs/hf-vocab-sphere/app/model_store.py
+++ b/report/threejs/hf-vocab-sphere/app/model_store.py
@@ -1021,6 +1021,13 @@ def _all_safetensor_tensors(model_name: str, *, revision: str, allow_download: b
                     or ".value.weight" in lname
                     or ".o_proj.weight" in lname
                     or ".out_proj.weight" in lname
+                    or ".gate_proj.weight" in lname
+                    or ".up_proj.weight" in lname
+                    or ".down_proj.weight" in lname
+                    or ".fc1.weight" in lname
+                    or ".fc2.weight" in lname
+                    or ".c_fc.weight" in lname
+                    or ".c_proj.weight" in lname
                 ):
                     tensors[str(name)] = (
                         handle.get_tensor(str(name)).detach().cpu().to(dtype=torch.float32).contiguous()
@@ -1199,6 +1206,133 @@ def _qk_head_slices(
     return slice(q_start, q_start + q_head_dim), slice(k_start, k_start + q_head_dim)
 
 
+def _optional_norm(tensors: dict[str, torch.Tensor], args: list[float | str | np.ndarray]) -> np.ndarray:
+    try:
+        vector, weight = _norm_weight_for_args(tensors, args)
+    except ValueError:
+        return np.asarray(args[0], dtype=np.float64)
+    return _apply_rms_norm(vector, weight)
+
+
+def _softmax(values: np.ndarray) -> np.ndarray:
+    shifted = values - float(np.max(values))
+    exp = np.exp(shifted)
+    return exp / max(float(np.sum(exp)), 1e-15)
+
+
+def _apply_attention_layer(
+    assets: ModelAssets,
+    tensors: dict[str, torch.Tensor],
+    latest_vector: np.ndarray,
+    layer: int,
+    kv_vectors: list[np.ndarray],
+) -> np.ndarray:
+    _qn, q_weight = _find_tensor(
+        tensors,
+        ("self_attn.q_proj.weight", "attention.q_proj.weight", "attn.q_proj.weight", "query.weight"),
+        layer=layer,
+        ndim=2,
+    )
+    _kn, k_weight = _find_tensor(
+        tensors,
+        ("self_attn.k_proj.weight", "attention.k_proj.weight", "attn.k_proj.weight", "key.weight"),
+        layer=layer,
+        ndim=2,
+    )
+    _vn, v_weight = _find_tensor(
+        tensors,
+        ("self_attn.v_proj.weight", "attention.v_proj.weight", "attn.v_proj.weight", "value.weight"),
+        layer=layer,
+        ndim=2,
+    )
+    _on, o_weight = _find_tensor(
+        tensors,
+        ("self_attn.o_proj.weight", "attention.o_proj.weight", "attn.o_proj.weight", "out_proj.weight"),
+        layer=layer,
+        ndim=2,
+    )
+    q = q_weight.numpy().astype(np.float64)
+    k = k_weight.numpy().astype(np.float64)
+    v = v_weight.numpy().astype(np.float64)
+    o = o_weight.numpy().astype(np.float64)
+    width = latest_vector.shape[0]
+    if q.shape[1] != width or k.shape[1] != width or v.shape[1] != width or o.shape[0] != width:
+        raise ValueError("Attention layer projection widths do not match the selected vector space.")
+    latest_norm = _apply_rms_norm(*_norm_weight_for_args(tensors, [latest_vector, layer, "attn", "input"]))
+    kv_norms = [
+        _apply_rms_norm(*_norm_weight_for_args(tensors, [vector, layer, "attn", "input"])) for vector in kv_vectors
+    ]
+    # The latest/query token also contributes its own K/V entry after the supplied cache order.
+    kv_norms.append(latest_norm)
+    attention_heads, key_value_heads = _attention_head_counts(assets)
+    output = np.zeros(width, dtype=np.float64)
+    for query_head in range(attention_heads):
+        kv_head = min((query_head * key_value_heads) // attention_heads, key_value_heads - 1)
+        q_slice, k_slice = _qk_head_slices(
+            q_output_width=q.shape[0],
+            k_output_width=k.shape[0],
+            attention_heads=attention_heads,
+            key_value_heads=key_value_heads,
+            query_head=query_head,
+            key_head=kv_head,
+        )
+        v_slice, o_slice, _head_count = _wov_head_slices(
+            v_output_width=v.shape[0],
+            o_input_width=o.shape[1],
+            attention_heads=attention_heads,
+            key_value_heads=key_value_heads,
+            head=query_head,
+        )
+        query = latest_norm @ q[q_slice, :].T
+        keys = np.stack([vector @ k[k_slice, :].T for vector in kv_norms], axis=0)
+        values = np.stack([vector @ v[v_slice, :].T for vector in kv_norms], axis=0)
+        scores = keys @ query / math.sqrt(max(query.shape[0], 1))
+        context = _softmax(scores) @ values
+        output += context @ o[:, o_slice].T
+    return _optional_norm(tensors, [output, layer, "attn", "output"])
+
+
+def _activation(name: str, values: np.ndarray) -> np.ndarray:
+    key = name.casefold()
+    if key in {"gelu", "gelu_new"}:
+        return 0.5 * values * (1.0 + np.tanh(np.sqrt(2.0 / np.pi) * (values + 0.044715 * values**3)))
+    return values / (1.0 + np.exp(-values))
+
+
+def _apply_mlp_layer(
+    assets: ModelAssets, tensors: dict[str, torch.Tensor], vector: np.ndarray, layer: int
+) -> np.ndarray:
+    hidden = _apply_rms_norm(*_norm_weight_for_args(tensors, [vector, layer, "ffn", "input"]))
+    try:
+        _gn, gate_weight = _find_tensor(
+            tensors, ("mlp.gate_proj.weight", "feed_forward.gate_proj.weight"), layer=layer, ndim=2
+        )
+        _un, up_weight = _find_tensor(
+            tensors, ("mlp.up_proj.weight", "feed_forward.up_proj.weight"), layer=layer, ndim=2
+        )
+        _dn, down_weight = _find_tensor(
+            tensors, ("mlp.down_proj.weight", "feed_forward.down_proj.weight"), layer=layer, ndim=2
+        )
+        gate = gate_weight.numpy().astype(np.float64)
+        up = up_weight.numpy().astype(np.float64)
+        down = down_weight.numpy().astype(np.float64)
+        output = (_activation("silu", hidden @ gate.T) * (hidden @ up.T)) @ down.T
+    except ValueError:
+        _fn, fc_weight = _find_tensor(
+            tensors, ("mlp.fc1.weight", "mlp.c_fc.weight", "feed_forward.fc1.weight"), layer=layer, ndim=2
+        )
+        _pn, proj_weight = _find_tensor(
+            tensors, ("mlp.fc2.weight", "mlp.c_proj.weight", "feed_forward.fc2.weight"), layer=layer, ndim=2
+        )
+        fc = fc_weight.numpy().astype(np.float64)
+        proj = proj_weight.numpy().astype(np.float64)
+        if fc.shape[1] == hidden.shape[0]:
+            output = _activation("gelu", hidden @ fc.T) @ proj.T
+        else:
+            output = _activation("gelu", hidden @ fc) @ proj
+    return _optional_norm(tensors, [output, layer, "ffn", "output"])
+
+
 def model_vector_function(assets: ModelAssets, name: str, args: list[float | str | np.ndarray]) -> np.ndarray:
     tensors = _all_safetensor_tensors(assets.model_name, revision=assets.revision, allow_download=True)
     if name in {"norm", "invnorm", "inverse_norm"}:
@@ -1240,6 +1374,19 @@ def model_vector_function(assets: ModelAssets, name: str, args: list[float | str
         # selected Wv-head output with zeros before/after its head slot and then
         # applying the full Wo matrix, but avoids materializing the padded vector.
         return (vector @ v[v_slice, :].T) @ o[:, o_slice].T
+    if name == "attn_layer":
+        if len(args) < 2:
+            raise ValueError("attn_layer expects (latest_vector, layer, optional_cache_vector, ...).")
+        latest_vector = np.asarray(args[0], dtype=np.float64)
+        layer = int(args[1])
+        kv_vectors = [np.asarray(value, dtype=np.float64) for value in args[2:]]
+        return _apply_attention_layer(assets, tensors, latest_vector, layer, kv_vectors)
+    if name == "mlp_layer":
+        if len(args) != 2:
+            raise ValueError("mlp_layer expects (vector, layer).")
+        vector = np.asarray(args[0], dtype=np.float64)
+        layer = int(args[1])
+        return _apply_mlp_layer(assets, tensors, vector, layer)
     if name in {"wqk", "wkq"}:
         if len(args) != 4:
             raise ValueError("wqk/wkq expect (vector, layer, query_head, key_head).")

--- a/report/threejs/hf-vocab-sphere/app/schemas.py
+++ b/report/threejs/hf-vocab-sphere/app/schemas.py
@@ -46,6 +46,9 @@ class TokenRecord(BaseModel):
     special: bool = False
     present_in_tokenizer: bool = True
     magnitude: float | None = None
+    effective_dimension: float | None = None
+    dimensions_for_angle: int | None = Field(default=None, ge=0)
+    continuous_dimensions_for_angle: float | None = None
     rank: int | None = Field(default=None, ge=1)
     cosine_similarity: float | None = None
     angle_deg: float | None = None
@@ -138,6 +141,9 @@ class ProjectionPoint(BaseModel):
     special: bool = False
     present_in_tokenizer: bool = True
     magnitude: float | None = None
+    effective_dimension: float | None = None
+    dimensions_for_angle: int | None = Field(default=None, ge=0)
+    continuous_dimensions_for_angle: float | None = None
     rank: int | None = Field(default=None, ge=1)
     cosine_similarity: float | None = None
     angle_deg: float | None = None

--- a/report/threejs/hf-vocab-sphere/app/static/app.js
+++ b/report/threejs/hf-vocab-sphere/app/static/app.js
@@ -1371,6 +1371,41 @@ function renderArithmeticPanel() {
   }
 }
 
+
+function insertAttentionLayerExpression() {
+  const rows = selectedRows();
+  if (!rows.length) return showToast('Select tokens before inserting an attention layer helper.', 'error');
+  const defaultLatest = aliasForIndex(rows.length - 1);
+  const latest = (window.prompt('Latest token alias for Wq plus its final Wk/Wv cache entry:', defaultLatest) || '').trim().toUpperCase();
+  if (!latest) return;
+  const layerText = (window.prompt('Attention layer index:', '0') || '').trim();
+  const layer = Number(layerText);
+  if (!Number.isInteger(layer) || layer < 0) return showToast('Layer must be a non-negative integer.', 'error');
+  const defaultKv = rows.slice(0, Math.max(0, rows.length - 1)).map((_, index) => aliasForIndex(index)).join(',');
+  const kvText = (window.prompt('Comma-separated prior KV-cache aliases in order; latest is appended automatically:', defaultKv) || '').trim();
+  const kvAliases = kvText.split(',').map((value) => value.trim().toUpperCase()).filter(Boolean);
+  const cacheSuffix = kvAliases.length ? `, ${kvAliases.join(', ')}` : '';
+  $('arithmeticExpressionInput').value = `attn_layer(${latest}, ${layer}${cacheSuffix})`;
+  $('arithmeticModeSelect').value = 'expression';
+  syncArithmeticMode();
+  $('arithmeticExpressionInput').focus();
+}
+
+function insertMlpLayerExpression() {
+  const rows = selectedRows();
+  if (!rows.length) return showToast('Select tokens before inserting an MLP layer helper.', 'error');
+  const defaultTarget = aliasForIndex(rows.length - 1);
+  const target = (window.prompt('Target token alias for the MLP layer:', defaultTarget) || '').trim().toUpperCase();
+  if (!target) return;
+  const layerText = (window.prompt('MLP layer index:', '0') || '').trim();
+  const layer = Number(layerText);
+  if (!Number.isInteger(layer) || layer < 0) return showToast('Layer must be a non-negative integer.', 'error');
+  $('arithmeticExpressionInput').value = `mlp_layer(${target}, ${layer})`;
+  $('arithmeticModeSelect').value = 'expression';
+  syncArithmeticMode();
+  $('arithmeticExpressionInput').focus();
+}
+
 async function addArithmeticResult() {
   const rows = selectedRows();
   const slerpMode = $('arithmeticModeSelect').value === 'slerp';
@@ -2184,6 +2219,8 @@ $('selectedTokens').addEventListener('click', (event) => {
 });
 $('anchorIdInput').addEventListener('change', () => { renderSelected(); markProjectionStale(); });
 $('arithmeticModeSelect').addEventListener('change', syncArithmeticMode);
+$('insertAttentionLayerBtn').addEventListener('click', insertAttentionLayerExpression);
+$('insertMlpLayerBtn').addEventListener('click', insertMlpLayerExpression);
 $('slerpFractionInput').addEventListener('input', (event) => {
   $('slerpFractionLabel').textContent = `t = ${Number(event.target.value).toFixed(2)}`;
 });

--- a/report/threejs/hf-vocab-sphere/app/static/app.js
+++ b/report/threejs/hf-vocab-sphere/app/static/app.js
@@ -38,6 +38,8 @@ const state = {
   showLabels: false,
   showLabelAliases: true,
   showLabelIds: true,
+  showLabelMagnitudes: false,
+  showLabelParticipation: false,
   showEdgeLabels: false,
   edgeColorMode: 'angle',
   edgeWidth: 1.8,
@@ -363,14 +365,32 @@ function clearEdgeLabels() {
   edgeLabelEntries = [];
 }
 
+function labelMagnitudeText(point) {
+  return state.showLabelMagnitudes && Number.isFinite(Number(point.magnitude))
+    ? `‖v‖ ${formatNumber(point.magnitude, 3)}`
+    : '';
+}
+
+function labelParticipationText(point) {
+  return state.showLabelParticipation && Number.isFinite(Number(point.effective_dimension))
+    ? `PR ${formatNumber(point.effective_dimension, 2)}`
+    : '';
+}
+
 function labelTextForPoint(point) {
-  if (point.kind === 'resultant') return `${point.alias || 'R'}: ${point.label || point.display}`;
+  const magnitudeText = labelMagnitudeText(point);
+  const participationText = labelParticipationText(point);
+  if (point.kind === 'resultant') {
+    return [`${point.alias || 'R'}: ${point.label || point.display}`, magnitudeText, participationText]
+      .filter((value) => value.length)
+      .join(' · ');
+  }
   const prefix = state.showLabelAliases && point.alias ? `${point.alias}: ` : '';
   const tokenText = point.display !== null && point.display !== undefined ? String(point.display) : '';
   const tokenId = state.showLabelIds && point.token_id !== null && point.token_id !== undefined
     ? String(point.token_id)
     : '';
-  const body = [tokenText, tokenId].filter((value) => value.length).join(' · ');
+  const body = [tokenText, tokenId, magnitudeText, participationText].filter((value) => value.length).join(' · ');
   return `${prefix}${body}`.trim();
 }
 
@@ -1354,7 +1374,8 @@ function renderArithmeticPanel() {
 async function addArithmeticResult() {
   const rows = selectedRows();
   const slerpMode = $('arithmeticModeSelect').value === 'slerp';
-  const fraction = Math.max(0, Math.min(1, Number($('slerpFractionInput').value) || 0));
+  const rawFraction = Number($('slerpFractionInput').value);
+  const fraction = Number.isFinite(rawFraction) ? rawFraction : 0;
   const fromAlias = $('slerpFromSelect').value;
   const toAlias = $('slerpToSelect').value;
   const expression = slerpMode
@@ -1737,6 +1758,8 @@ function buildSettingsSnapshot() {
       show_node_labels: state.showLabels,
       show_alias_letters: state.showLabelAliases,
       show_label_ids: state.showLabelIds,
+      show_label_magnitudes: state.showLabelMagnitudes,
+      show_label_participation: state.showLabelParticipation,
       show_edge_labels: state.showEdgeLabels,
       edge_color_mode: state.edgeColorMode,
       edge_width: state.edgeWidth,
@@ -1848,7 +1871,7 @@ function normalizedWorkspace(snapshot) {
       label: stringValue(editor.label, '', 120),
       slerpFrom: stringValue(editor.slerp_from, 'A', 20),
       slerpTo: stringValue(editor.slerp_to, 'B', 20),
-      slerpFraction: finiteNumber(editor.slerp_fraction, 0.5, 0, 1),
+      slerpFraction: finiteNumber(editor.slerp_fraction, 0.5, -1e9, 1e9),
     },
   };
 }
@@ -1944,6 +1967,8 @@ function applySettingsControls(snapshot) {
   state.showLabels = booleanValue(appearance.show_node_labels, false);
   state.showLabelAliases = booleanValue(appearance.show_alias_letters, true);
   state.showLabelIds = booleanValue(appearance.show_label_ids, true);
+  state.showLabelMagnitudes = booleanValue(appearance.show_label_magnitudes, false);
+  state.showLabelParticipation = booleanValue(appearance.show_label_participation, false);
   state.showEdgeLabels = booleanValue(appearance.show_edge_labels, false) && state.showEdges;
   state.edgeColorMode = appearance.edge_color_mode === 'uniform' ? 'uniform' : 'angle';
   state.edgeWidth = finiteNumber(appearance.edge_width, 1.8, 0.5, 8);
@@ -2015,6 +2040,8 @@ function syncAppearanceControls() {
   $('showLabelsInput').checked = state.showLabels;
   $('showLabelAliasesInput').checked = state.showLabelAliases;
   $('showLabelIdsInput').checked = state.showLabelIds;
+  $('showLabelMagnitudesInput').checked = state.showLabelMagnitudes;
+  $('showLabelParticipationInput').checked = state.showLabelParticipation;
   $('showEdgeLabelsInput').checked = state.showEdgeLabels;
   $('pointSizeInput').value = String(state.pointSize);
   $('pointSizeLabel').textContent = state.pointSize.toFixed(3);
@@ -2064,6 +2091,14 @@ function setShowLabelAliases(value) {
 }
 function setShowLabelIds(value) {
   state.showLabelIds = Boolean(value);
+  syncAppearanceControls();
+}
+function setShowLabelMagnitudes(value) {
+  state.showLabelMagnitudes = Boolean(value);
+  syncAppearanceControls();
+}
+function setShowLabelParticipation(value) {
+  state.showLabelParticipation = Boolean(value);
   syncAppearanceControls();
 }
 function setShowEdgeLabels(value) {
@@ -2247,6 +2282,8 @@ $('showEdgeLabelsInput').addEventListener('change', (event) => setShowEdgeLabels
 $('showLabelsInput').addEventListener('change', (event) => setShowLabels(event.target.checked));
 $('showLabelAliasesInput').addEventListener('change', (event) => setShowLabelAliases(event.target.checked));
 $('showLabelIdsInput').addEventListener('change', (event) => setShowLabelIds(event.target.checked));
+$('showLabelMagnitudesInput').addEventListener('change', (event) => setShowLabelMagnitudes(event.target.checked));
+$('showLabelParticipationInput').addEventListener('change', (event) => setShowLabelParticipation(event.target.checked));
 $('resetCameraBtn').addEventListener('click', resetCamera);
 $('toggleRotateBtn').addEventListener('click', () => setAutoRotate(!state.autoRotate));
 $('toggleEdgesBtn').addEventListener('click', () => setShowEdges(!state.showEdges));
@@ -2269,6 +2306,8 @@ document.addEventListener('keydown', (event) => {
   else if (event.key.toLowerCase() === 'l') setShowLabels(!state.showLabels);
   else if (event.key.toLowerCase() === 't') setShowLabelAliases(!state.showLabelAliases);
   else if (event.key.toLowerCase() === 'i') setShowLabelIds(!state.showLabelIds);
+  else if (event.key.toLowerCase() === 'm') setShowLabelMagnitudes(!state.showLabelMagnitudes);
+  else if (event.key.toLowerCase() === 'p') setShowLabelParticipation(!state.showLabelParticipation);
   else if (event.key === 'Escape') {
     state.pinnedIndex = null;
     renderInspector();

--- a/report/threejs/hf-vocab-sphere/app/static/app.js
+++ b/report/threejs/hf-vocab-sphere/app/static/app.js
@@ -1406,6 +1406,32 @@ function insertMlpLayerExpression() {
   $('arithmeticExpressionInput').focus();
 }
 
+function insertModelStateExpression() {
+  const rows = selectedRows();
+  if (!rows.length) return showToast('Select context tokens before simulating the model.', 'error');
+  const latest = (window.prompt('Latest/target token alias:', aliasForIndex(rows.length - 1)) || '').trim().toUpperCase();
+  if (!latest) return;
+  const layer = Number((window.prompt('Stop at layer index:', '0') || '').trim());
+  if (!Number.isInteger(layer) || layer < 0) return showToast('Layer must be a non-negative integer.', 'error');
+  const block = (window.prompt("Block to inspect: 'attn' or 'mlp':", 'attn') || '').trim().toLowerCase();
+  if (!['attn', 'mlp'].includes(block)) return showToast("Block must be 'attn' or 'mlp'.", 'error');
+  const point = (window.prompt('Point: input_norm, pre_output_norm, pre_skip, post_skip, or heads:', 'post_skip') || '').trim().toLowerCase();
+  if (!['input_norm', 'pre_output_norm', 'pre_skip', 'post_skip', 'heads'].includes(point)) return showToast('Unknown simulation point.', 'error');
+  if (point === 'heads' && block !== 'attn') return showToast('Head sums are available only for attention.', 'error');
+  const heads = point === 'heads'
+    ? (window.prompt("Heads to sum ('all', '0,2', or '1-3'):", 'all') || '').trim().toLowerCase()
+    : 'all';
+  if (!heads) return;
+  const defaultContext = rows.slice(0, -1).map((_, index) => aliasForIndex(index)).join(',');
+  const contextText = (window.prompt('Prior context aliases in causal order:', defaultContext) || '').trim();
+  const context = contextText.split(',').map((value) => value.trim().toUpperCase()).filter(Boolean);
+  const contextSuffix = context.length ? `, ${context.join(', ')}` : '';
+  $('arithmeticExpressionInput').value = `model_state(${latest}, ${layer}, '${block}', '${point}', '${heads}'${contextSuffix})`;
+  $('arithmeticModeSelect').value = 'expression';
+  syncArithmeticMode();
+  $('arithmeticExpressionInput').focus();
+}
+
 async function addArithmeticResult() {
   const rows = selectedRows();
   const slerpMode = $('arithmeticModeSelect').value === 'slerp';
@@ -2221,6 +2247,7 @@ $('anchorIdInput').addEventListener('change', () => { renderSelected(); markProj
 $('arithmeticModeSelect').addEventListener('change', syncArithmeticMode);
 $('insertAttentionLayerBtn').addEventListener('click', insertAttentionLayerExpression);
 $('insertMlpLayerBtn').addEventListener('click', insertMlpLayerExpression);
+$('insertModelStateBtn').addEventListener('click', insertModelStateExpression);
 $('slerpFractionInput').addEventListener('input', (event) => {
   $('slerpFractionLabel').textContent = `t = ${Number(event.target.value).toFixed(2)}`;
 });

--- a/report/threejs/hf-vocab-sphere/app/templates/index.html
+++ b/report/threejs/hf-vocab-sphere/app/templates/index.html
@@ -251,6 +251,7 @@
           <div class="button-grid top-gap">
             <button class="small-button" id="insertAttentionLayerBtn" type="button">Add attention layer helper</button>
             <button class="small-button" id="insertMlpLayerBtn" type="button">Add MLP layer helper</button>
+            <button class="small-button" id="insertModelStateBtn" type="button">Simulate to model point</button>
           </div>
         </div>
         <div id="slerpControlsWrap" class="hidden top-gap">
@@ -273,7 +274,7 @@
         <label class="field-label top-gap" for="arithmeticLabelInput">Result label</label>
         <input id="arithmeticLabelInput" type="text" placeholder="e.g. analogy result" maxlength="120" />
         <button class="primary hero-button" id="addArithmeticBtn">Add resultant to map</button>
-        <div class="small top-gap">Expressions support aliases, scalars, parentheses, <span class="mono">+ - * /</span>, <span class="mono">mean(...)</span>, <span class="mono">slerp(A,B,t)</span>, <span class="mono">norm(A,0,'attn','input')</span>/<span class="mono">norm(A,'final')</span>, <span class="mono">invnorm(A,...)</span>, <span class="mono">wov(A,0,0)</span>, <span class="mono">wqk(A,0,0,0)</span>, <span class="mono">wkq(A,0,0,0)</span>, <span class="mono">attn_layer(A,0,B,C)</span>, and <span class="mono">mlp_layer(A,0)</span>. Functions can be nested. Example average: <span class="mono">(A+B+C)/3 + D</span>. Resultants are projected from the original model space, never by adding screen coordinates.</div>
+        <div class="small top-gap">Expressions support aliases, scalars, parentheses, <span class="mono">+ - * /</span>, <span class="mono">mean(...)</span>, <span class="mono">slerp(A,B,t)</span>, <span class="mono">norm(A,0,'attn','input')</span>/<span class="mono">norm(A,'final')</span>, <span class="mono">invnorm(A,...)</span>, <span class="mono">wov(A,0,0)</span>, <span class="mono">wqk(A,0,0,0)</span>, <span class="mono">wkq(A,0,0,0)</span>, <span class="mono">attn_layer(A,0,B,C)</span>, <span class="mono">mlp_layer(A,0)</span>, and <span class="mono">model_state(C,2,'attn','post_skip','all',A,B)</span>. Simulation points are <span class="mono">input_norm</span>, <span class="mono">pre_output_norm</span>, <span class="mono">pre_skip</span>, <span class="mono">post_skip</span>, or <span class="mono">heads</span>; head selectors accept <span class="mono">all</span>, <span class="mono">0,2</span>, or <span class="mono">1-3</span>. Functions can be nested. Example average: <span class="mono">(A+B+C)/3 + D</span>. Resultants are projected from the original model space, never by adding screen coordinates.</div>
         <div id="arithmeticResults" class="arithmetic-result-list top-gap"><div class="empty-selection">No resultants defined.</div></div>
       </section>
 

--- a/report/threejs/hf-vocab-sphere/app/templates/index.html
+++ b/report/threejs/hf-vocab-sphere/app/templates/index.html
@@ -261,15 +261,15 @@
             </div>
           </div>
           <div class="range-wrap top-gap">
-            <div class="range-row"><span>Interpolation fraction</span><span id="slerpFractionLabel">t = 0.50</span></div>
-            <input id="slerpFractionInput" type="range" min="0" max="1" step="0.01" value="0.5" />
+            <div class="range-row"><span>Interpolation / extrapolation value</span><span id="slerpFractionLabel">t = 0.50</span></div>
+            <input id="slerpFractionInput" type="number" step="0.01" value="0.5" />
           </div>
-          <div class="small top-gap">SLERP follows the shortest geodesic between normalized full-dimensional vectors while linearly interpolating their original L2 magnitudes.</div>
+          <div class="small top-gap">SLERP follows the shortest geodesic between normalized full-dimensional vectors while linearly interpolating their original L2 magnitudes; finite negative and positive t values are accepted for extrapolation.</div>
         </div>
         <label class="field-label top-gap" for="arithmeticLabelInput">Result label</label>
         <input id="arithmeticLabelInput" type="text" placeholder="e.g. analogy result" maxlength="120" />
         <button class="primary hero-button" id="addArithmeticBtn">Add resultant to map</button>
-        <div class="small top-gap">Expressions support aliases, scalars, parentheses, <span class="mono">+ - * /</span>, <span class="mono">mean(...)</span>, and <span class="mono">slerp(A,B,t)</span>. Example average: <span class="mono">(A+B+C)/3 + D</span>. Resultants are projected from the original model space, never by adding screen coordinates.</div>
+        <div class="small top-gap">Expressions support aliases, scalars, parentheses, <span class="mono">+ - * /</span>, <span class="mono">mean(...)</span>, <span class="mono">slerp(A,B,t)</span>, <span class="mono">norm(A,0,'attn','input')</span>/<span class="mono">norm(A,'final')</span>, <span class="mono">invnorm(A,...)</span>, <span class="mono">wov(A,0,0)</span>, <span class="mono">wqk(A,0,0,0)</span>, and <span class="mono">wkq(A,0,0,0)</span>. Functions can be nested. Example average: <span class="mono">(A+B+C)/3 + D</span>. Resultants are projected from the original model space, never by adding screen coordinates.</div>
         <div id="arithmeticResults" class="arithmetic-result-list top-gap"><div class="empty-selection">No resultants defined.</div></div>
       </section>
 
@@ -452,6 +452,8 @@
           <label class="toggle"><span>Show node labels</span><input id="showLabelsInput" type="checkbox" /></label>
           <label class="toggle label-component-toggle"><span>Include A/B/C alias letters <small>T</small></span><input id="showLabelAliasesInput" type="checkbox" checked /></label>
           <label class="toggle label-component-toggle"><span>Include token IDs in labels <small>I</small></span><input id="showLabelIdsInput" type="checkbox" checked /></label>
+          <label class="toggle label-component-toggle"><span>Include vector magnitudes <small>M</small></span><input id="showLabelMagnitudesInput" type="checkbox" /></label>
+          <label class="toggle label-component-toggle"><span>Include participation ratio <small>P</small></span><input id="showLabelParticipationInput" type="checkbox" /></label>
           <label class="inline-number edge-label-limit">Angle label cap (0 = all) <input id="edgeLabelLimitInput" type="number" min="0" max="20000" value="0" /></label>
         </div>
       </section>
@@ -468,6 +470,8 @@
           <kbd>L</kbd><span>Toggle node labels</span>
           <kbd>T</kbd><span>Show / hide A/B/C alias tags</span>
           <kbd>I</kbd><span>Show / hide token IDs in labels</span>
+          <kbd>M</kbd><span>Show / hide vector magnitudes in labels</span>
+          <kbd>P</kbd><span>Show / hide participation ratio in labels</span>
           <kbd>Esc</kbd><span>Clear pinned token</span>
         </div>
       </section>

--- a/report/threejs/hf-vocab-sphere/app/templates/index.html
+++ b/report/threejs/hf-vocab-sphere/app/templates/index.html
@@ -248,6 +248,10 @@
         <div id="arithmeticExpressionWrap" class="top-gap">
           <label class="field-label" for="arithmeticExpressionInput">Expression</label>
           <input id="arithmeticExpressionInput" type="text" value="(A - B) + C" spellcheck="false" placeholder="(A - B) + C" />
+          <div class="button-grid top-gap">
+            <button class="small-button" id="insertAttentionLayerBtn" type="button">Add attention layer helper</button>
+            <button class="small-button" id="insertMlpLayerBtn" type="button">Add MLP layer helper</button>
+          </div>
         </div>
         <div id="slerpControlsWrap" class="hidden top-gap">
           <div class="controls-row slerp-vector-row">
@@ -269,7 +273,7 @@
         <label class="field-label top-gap" for="arithmeticLabelInput">Result label</label>
         <input id="arithmeticLabelInput" type="text" placeholder="e.g. analogy result" maxlength="120" />
         <button class="primary hero-button" id="addArithmeticBtn">Add resultant to map</button>
-        <div class="small top-gap">Expressions support aliases, scalars, parentheses, <span class="mono">+ - * /</span>, <span class="mono">mean(...)</span>, <span class="mono">slerp(A,B,t)</span>, <span class="mono">norm(A,0,'attn','input')</span>/<span class="mono">norm(A,'final')</span>, <span class="mono">invnorm(A,...)</span>, <span class="mono">wov(A,0,0)</span>, <span class="mono">wqk(A,0,0,0)</span>, and <span class="mono">wkq(A,0,0,0)</span>. Functions can be nested. Example average: <span class="mono">(A+B+C)/3 + D</span>. Resultants are projected from the original model space, never by adding screen coordinates.</div>
+        <div class="small top-gap">Expressions support aliases, scalars, parentheses, <span class="mono">+ - * /</span>, <span class="mono">mean(...)</span>, <span class="mono">slerp(A,B,t)</span>, <span class="mono">norm(A,0,'attn','input')</span>/<span class="mono">norm(A,'final')</span>, <span class="mono">invnorm(A,...)</span>, <span class="mono">wov(A,0,0)</span>, <span class="mono">wqk(A,0,0,0)</span>, <span class="mono">wkq(A,0,0,0)</span>, <span class="mono">attn_layer(A,0,B,C)</span>, and <span class="mono">mlp_layer(A,0)</span>. Functions can be nested. Example average: <span class="mono">(A+B+C)/3 + D</span>. Resultants are projected from the original model space, never by adding screen coordinates.</div>
         <div id="arithmeticResults" class="arithmetic-result-list top-gap"><div class="empty-selection">No resultants defined.</div></div>
       </section>
 

--- a/report/threejs/hf-vocab-sphere/app/vector_math.py
+++ b/report/threejs/hf-vocab-sphere/app/vector_math.py
@@ -200,7 +200,17 @@ class _SafeVectorEvaluator:
                     "vector",
                     np.mean(np.stack([np.asarray(value.value) for value in values], axis=0), axis=0),
                 )
-            if function_name in {"norm", "invnorm", "inverse_norm", "wov", "wqk", "wkq", "attn_layer", "mlp_layer"}:
+            if function_name in {
+                "norm",
+                "invnorm",
+                "inverse_norm",
+                "wov",
+                "wqk",
+                "wkq",
+                "attn_layer",
+                "mlp_layer",
+                "model_state",
+            }:
                 if self.model_function is None:
                     raise ValueError(f"{node.func.id} requires model auxiliary tensors loaded by the projection API.")
                 values = [self._visit(argument) for argument in node.args]
@@ -213,7 +223,7 @@ class _SafeVectorEvaluator:
                 return _Value("vector", self.model_function(function_name, args))
             if function_name != "slerp":
                 raise ValueError(
-                    "Only mean(...), slerp(A, B, t), norm(...), invnorm(...), wov(...), wqk(...), wkq(...), attn_layer(...), and mlp_layer(...) vector functions are supported."
+                    "Only mean(...), slerp(A, B, t), norm(...), invnorm(...), wov(...), wqk(...), wkq(...), attn_layer(...), mlp_layer(...), and model_state(...) vector functions are supported."
                 )
             if len(node.args) != 3:
                 raise ValueError("slerp requires exactly three positional arguments: slerp(A, B, t).")

--- a/report/threejs/hf-vocab-sphere/app/vector_math.py
+++ b/report/threejs/hf-vocab-sphere/app/vector_math.py
@@ -200,7 +200,7 @@ class _SafeVectorEvaluator:
                     "vector",
                     np.mean(np.stack([np.asarray(value.value) for value in values], axis=0), axis=0),
                 )
-            if function_name in {"norm", "invnorm", "inverse_norm", "wov", "wqk", "wkq"}:
+            if function_name in {"norm", "invnorm", "inverse_norm", "wov", "wqk", "wkq", "attn_layer", "mlp_layer"}:
                 if self.model_function is None:
                     raise ValueError(f"{node.func.id} requires model auxiliary tensors loaded by the projection API.")
                 values = [self._visit(argument) for argument in node.args]
@@ -213,7 +213,7 @@ class _SafeVectorEvaluator:
                 return _Value("vector", self.model_function(function_name, args))
             if function_name != "slerp":
                 raise ValueError(
-                    "Only mean(...), slerp(A, B, t), norm(...), invnorm(...), wov(...), wqk(...), and wkq(...) vector functions are supported."
+                    "Only mean(...), slerp(A, B, t), norm(...), invnorm(...), wov(...), wqk(...), wkq(...), attn_layer(...), and mlp_layer(...) vector functions are supported."
                 )
             if len(node.args) != 3:
                 raise ValueError("slerp requires exactly three positional arguments: slerp(A, B, t).")
@@ -260,7 +260,7 @@ class _SafeVectorEvaluator:
                 return _Value("vector", np.asarray(left.value) / denominator)
 
         raise ValueError(
-            "Unsupported expression syntax. Use vector aliases, numeric scalars, parentheses, +, -, *, /, mean(...), slerp(A, B, t), norm(...), invnorm(...), wov(...), wqk(...), and wkq(...)."
+            "Unsupported expression syntax. Use vector aliases, numeric scalars, parentheses, +, -, *, /, mean(...), slerp(A, B, t), norm(...), invnorm(...), wov(...), wqk(...), wkq(...), attn_layer(...), and mlp_layer(...)."
         )
 
 

--- a/report/threejs/hf-vocab-sphere/app/vector_math.py
+++ b/report/threejs/hf-vocab-sphere/app/vector_math.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import ast
 import math
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 import numpy as np
 
@@ -43,7 +43,7 @@ def alias_map(vectors: np.ndarray) -> dict[str, np.ndarray]:
 @dataclass(slots=True)
 class _Value:
     kind: str
-    value: float | np.ndarray
+    value: float | str | np.ndarray
 
 
 def spherical_linear_interpolation(a: np.ndarray, b: np.ndarray, t: float) -> np.ndarray:
@@ -56,17 +56,12 @@ def spherical_linear_interpolation(a: np.ndarray, b: np.ndarray, t: float) -> np
     first = np.asarray(a, dtype=np.float64)
     second = np.asarray(b, dtype=np.float64)
     fraction = float(t)
-    if not math.isfinite(fraction) or fraction < 0.0 or fraction > 1.0:
-        raise ValueError("SLERP t must be a finite scalar in the interval [0, 1].")
+    if not math.isfinite(fraction):
+        raise ValueError("SLERP t must be a finite scalar.")
     norm_a = float(np.linalg.norm(first))
     norm_b = float(np.linalg.norm(second))
     if norm_a <= 1e-15 or norm_b <= 1e-15:
         raise ValueError("SLERP requires two non-zero vectors.")
-    if fraction <= 0.0:
-        return first.copy()
-    if fraction >= 1.0:
-        return second.copy()
-
     unit_a = first / norm_a
     unit_b = second / norm_b
     dot = float(np.clip(np.dot(unit_a, unit_b), -1.0, 1.0))
@@ -85,19 +80,59 @@ def spherical_linear_interpolation(a: np.ndarray, b: np.ndarray, t: float) -> np
     else:
         angle = math.acos(dot)
         sine = math.sin(angle)
-        direction = (
-            math.sin((1.0 - fraction) * angle) / sine * unit_a
-            + math.sin(fraction * angle) / sine * unit_b
-        )
+        direction = math.sin((1.0 - fraction) * angle) / sine * unit_a + math.sin(fraction * angle) / sine * unit_b
         direction /= max(float(np.linalg.norm(direction)), 1e-15)
 
     magnitude = (1.0 - fraction) * norm_a + fraction * norm_b
     return direction * magnitude
 
 
+def vector_dimension_metrics(
+    vector: np.ndarray, max_angle_degrees: float = 5.0, eps: float = 1e-12
+) -> dict[str, float | int]:
+    values = np.asarray(vector, dtype=np.float64).reshape(-1)
+    energy = values * values
+    total = float(np.sum(energy))
+    if total <= eps:
+        return {
+            "effective_dimension": 0.0,
+            "dimensions_for_angle": 0,
+            "continuous_dimensions_for_angle": 0.0,
+            "retained_energy": 0.0,
+            "resulting_angle_degrees": 0.0,
+        }
+
+    probabilities = energy / total
+    square_sum = float(np.sum(probabilities * probabilities))
+    effective_dimension = 1.0 / max(square_sum, eps)
+    sorted_probabilities = np.sort(probabilities)[::-1]
+    cumulative = np.cumsum(sorted_probabilities)
+    angle = math.radians(float(max_angle_degrees))
+    required_energy = math.cos(angle) ** 2
+    k = int(np.searchsorted(cumulative, required_energy, side="left")) + 1
+    k = min(max(k, 1), values.size)
+    previous_energy = float(cumulative[k - 2]) if k > 1 else 0.0
+    current_coordinate_energy = float(sorted_probabilities[k - 1])
+    fractional_k = (k - 1) + (required_energy - previous_energy) / max(current_coordinate_energy, eps)
+    fractional_k = max(1.0, min(float(k), float(fractional_k)))
+    retained_energy = float(cumulative[k - 1])
+    resulting_angle = math.degrees(math.acos(math.sqrt(min(1.0, retained_energy))))
+    return {
+        "effective_dimension": float(effective_dimension),
+        "dimensions_for_angle": int(k),
+        "continuous_dimensions_for_angle": float(fractional_k),
+        "retained_energy": retained_energy,
+        "resulting_angle_degrees": float(resulting_angle),
+    }
+
+
+ModelFunction = Callable[[str, list[float | str | np.ndarray]], np.ndarray]
+
+
 class _SafeVectorEvaluator:
-    def __init__(self, aliases: dict[str, np.ndarray]):
+    def __init__(self, aliases: dict[str, np.ndarray], model_function: ModelFunction | None = None):
         self.aliases = {name.upper(): np.asarray(vector, dtype=np.float64) for name, vector in aliases.items()}
+        self.model_function = model_function
         self.referenced: set[str] = set()
 
     def evaluate(self, expression: str) -> np.ndarray:
@@ -138,6 +173,12 @@ class _SafeVectorEvaluator:
                 raise ValueError("Scalar constants must be finite and reasonably sized.")
             return _Value("scalar", scalar)
 
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            text = node.value.strip().casefold()
+            if not text or len(text) > 40:
+                raise ValueError("String arguments must be short, non-blank selectors.")
+            return _Value("string", text)
+
         if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
             operand = self._visit(node.operand)
             sign = 1.0 if isinstance(node.op, ast.UAdd) else -1.0
@@ -145,7 +186,7 @@ class _SafeVectorEvaluator:
 
         if isinstance(node, ast.Call):
             if not isinstance(node.func, ast.Name):
-                raise ValueError("Only mean(...) and slerp(A, B, t) vector functions are supported.")
+                raise ValueError("Only named vector functions are supported.")
             function_name = node.func.id.casefold()
             if node.keywords:
                 raise ValueError("Vector functions accept positional arguments only.")
@@ -159,15 +200,28 @@ class _SafeVectorEvaluator:
                     "vector",
                     np.mean(np.stack([np.asarray(value.value) for value in values], axis=0), axis=0),
                 )
+            if function_name in {"norm", "invnorm", "inverse_norm", "wov", "wqk", "wkq"}:
+                if self.model_function is None:
+                    raise ValueError(f"{node.func.id} requires model auxiliary tensors loaded by the projection API.")
+                values = [self._visit(argument) for argument in node.args]
+                args: list[float | str | np.ndarray] = [
+                    np.asarray(value.value)
+                    if value.kind == "vector"
+                    else (str(value.value) if value.kind == "string" else float(value.value))
+                    for value in values
+                ]
+                return _Value("vector", self.model_function(function_name, args))
             if function_name != "slerp":
-                raise ValueError("Only mean(...) and slerp(A, B, t) vector functions are supported.")
+                raise ValueError(
+                    "Only mean(...), slerp(A, B, t), norm(...), invnorm(...), wov(...), wqk(...), and wkq(...) vector functions are supported."
+                )
             if len(node.args) != 3:
                 raise ValueError("slerp requires exactly three positional arguments: slerp(A, B, t).")
             first = self._visit(node.args[0])
             second = self._visit(node.args[1])
             fraction = self._visit(node.args[2])
             if first.kind != "vector" or second.kind != "vector" or fraction.kind != "scalar":
-                raise ValueError("slerp requires two vectors followed by a scalar t in [0, 1].")
+                raise ValueError("slerp requires two vectors followed by a scalar t.")
             return _Value(
                 "vector",
                 spherical_linear_interpolation(
@@ -206,12 +260,14 @@ class _SafeVectorEvaluator:
                 return _Value("vector", np.asarray(left.value) / denominator)
 
         raise ValueError(
-            "Unsupported expression syntax. Use vector aliases, numeric scalars, parentheses, +, -, *, /, mean(...), and slerp(A, B, t)."
+            "Unsupported expression syntax. Use vector aliases, numeric scalars, parentheses, +, -, *, /, mean(...), slerp(A, B, t), norm(...), invnorm(...), wov(...), wqk(...), and wkq(...)."
         )
 
 
-def evaluate_vector_expression(expression: str, aliases: dict[str, np.ndarray]) -> tuple[np.ndarray, tuple[str, ...]]:
-    evaluator = _SafeVectorEvaluator(aliases)
+def evaluate_vector_expression(
+    expression: str, aliases: dict[str, np.ndarray], model_function: ModelFunction | None = None
+) -> tuple[np.ndarray, tuple[str, ...]]:
+    evaluator = _SafeVectorEvaluator(aliases, model_function=model_function)
     vector = evaluator.evaluate(expression)
     return vector, tuple(sorted(evaluator.referenced, key=lambda name: (len(name), name)))
 
@@ -219,6 +275,7 @@ def evaluate_vector_expression(expression: str, aliases: dict[str, np.ndarray]) 
 def evaluate_vector_expressions(
     vectors: np.ndarray,
     expressions: Iterable[object],
+    model_function: ModelFunction | None = None,
 ) -> list[VectorExpressionResult]:
     """Evaluate request-like objects with ``expression`` and optional ``label`` attributes."""
     aliases = alias_map(vectors)
@@ -226,14 +283,12 @@ def evaluate_vector_expressions(
     for index, item in enumerate(expressions):
         expression = str(getattr(item, "expression", "") or "").strip()
         requested_label = str(getattr(item, "label", "") or "").strip()
-        vector, referenced = evaluate_vector_expression(expression, aliases)
+        vector, referenced = evaluate_vector_expression(expression, aliases, model_function=model_function)
         magnitude = float(np.linalg.norm(vector))
         if not math.isfinite(magnitude):
             raise ValueError(f"Resultant {index + 1} has a non-finite magnitude.")
         if magnitude <= 1e-12:
-            raise ValueError(
-                f"Resultant {index + 1} is zero or near-zero and has no direction to project."
-            )
+            raise ValueError(f"Resultant {index + 1} is zero or near-zero and has no direction to project.")
         alias = f"R{index + 1}"
         results.append(
             VectorExpressionResult(

--- a/report/threejs/hf-vocab-sphere/tests/test_frontend_contract.py
+++ b/report/threejs/hf-vocab-sphere/tests/test_frontend_contract.py
@@ -4,7 +4,6 @@ import re
 from html.parser import HTMLParser
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 HTML_PATH = ROOT / "app" / "templates" / "index.html"
 JS_PATH = ROOT / "app" / "static" / "app.js"
@@ -42,6 +41,8 @@ def test_frontend_control_contract_and_unique_ids() -> None:
         "slerpFractionInput",
         "showLabelAliasesInput",
         "showLabelIdsInput",
+        "showLabelMagnitudesInput",
+        "showLabelParticipationInput",
         "saveSettingsBtn",
         "loadSettingsBtn",
         "settingsFileInput",
@@ -74,9 +75,15 @@ def test_label_component_and_settings_contract() -> None:
 
     assert "showLabelAliases: true" in javascript
     assert "showLabelIds: true" in javascript
+    assert "showLabelMagnitudes: false" in javascript
+    assert "showLabelParticipation: false" in javascript
+    assert "show_label_magnitudes: state.showLabelMagnitudes" in javascript
+    assert "show_label_participation: state.showLabelParticipation" in javascript
     assert "filter((value) => value.length).join(' · ')" in javascript
     assert "event.key.toLowerCase() === 't'" in javascript
     assert "event.key.toLowerCase() === 'i'" in javascript
+    assert "event.key.toLowerCase() === 'm'" in javascript
+    assert "event.key.toLowerCase() === 'p'" in javascript
 
     assert "const SETTINGS_SCHEMA = 'hf-vocab-sphere/settings'" in javascript
     assert "function buildSettingsSnapshot()" in javascript

--- a/report/threejs/hf-vocab-sphere/tests/test_frontend_contract.py
+++ b/report/threejs/hf-vocab-sphere/tests/test_frontend_contract.py
@@ -36,6 +36,8 @@ def test_frontend_control_contract_and_unique_ids() -> None:
         "addAllTokenizedBtn",
         "replaceTokenizedBtn",
         "arithmeticModeSelect",
+        "insertAttentionLayerBtn",
+        "insertMlpLayerBtn",
         "slerpFromSelect",
         "slerpToSelect",
         "slerpFractionInput",
@@ -84,6 +86,8 @@ def test_label_component_and_settings_contract() -> None:
     assert "event.key.toLowerCase() === 'i'" in javascript
     assert "event.key.toLowerCase() === 'm'" in javascript
     assert "event.key.toLowerCase() === 'p'" in javascript
+    assert "function insertAttentionLayerExpression()" in javascript
+    assert "function insertMlpLayerExpression()" in javascript
 
     assert "const SETTINGS_SCHEMA = 'hf-vocab-sphere/settings'" in javascript
     assert "function buildSettingsSnapshot()" in javascript

--- a/report/threejs/hf-vocab-sphere/tests/test_frontend_contract.py
+++ b/report/threejs/hf-vocab-sphere/tests/test_frontend_contract.py
@@ -38,6 +38,7 @@ def test_frontend_control_contract_and_unique_ids() -> None:
         "arithmeticModeSelect",
         "insertAttentionLayerBtn",
         "insertMlpLayerBtn",
+        "insertModelStateBtn",
         "slerpFromSelect",
         "slerpToSelect",
         "slerpFractionInput",
@@ -88,6 +89,7 @@ def test_label_component_and_settings_contract() -> None:
     assert "event.key.toLowerCase() === 'p'" in javascript
     assert "function insertAttentionLayerExpression()" in javascript
     assert "function insertMlpLayerExpression()" in javascript
+    assert "function insertModelStateExpression()" in javascript
 
     assert "const SETTINGS_SCHEMA = 'hf-vocab-sphere/settings'" in javascript
     assert "function buildSettingsSnapshot()" in javascript

--- a/report/threejs/hf-vocab-sphere/tests/test_vector_math.py
+++ b/report/threejs/hf-vocab-sphere/tests/test_vector_math.py
@@ -5,7 +5,12 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
-from app.vector_math import alias_for_index, evaluate_vector_expression, evaluate_vector_expressions
+from app.vector_math import (
+    alias_for_index,
+    evaluate_vector_expression,
+    evaluate_vector_expressions,
+    vector_dimension_metrics,
+)
 
 
 def test_aliases_are_excel_style() -> None:
@@ -48,7 +53,7 @@ def test_slerp_interpolates_direction_and_magnitude() -> None:
         "B": np.array([0.0, 4.0, 0.0]),
     }
     midpoint, references = evaluate_vector_expression("slerp(A, B, 0.5)", aliases)
-    expected_direction = np.array([2 ** -0.5, 2 ** -0.5, 0.0])
+    expected_direction = np.array([2**-0.5, 2**-0.5, 0.0])
     np.testing.assert_allclose(midpoint, expected_direction * 3.0, atol=1e-8)
     assert references == ("A", "B")
 
@@ -58,10 +63,11 @@ def test_slerp_interpolates_direction_and_magnitude() -> None:
     np.testing.assert_allclose(end, aliases["B"])
 
 
-def test_slerp_rejects_invalid_fraction() -> None:
+def test_slerp_allows_finite_extrapolation() -> None:
     aliases = {"A": np.array([1.0, 0.0]), "B": np.array([0.0, 1.0])}
-    with pytest.raises(ValueError, match="interval"):
-        evaluate_vector_expression("slerp(A, B, 1.5)", aliases)
+    result, references = evaluate_vector_expression("slerp(A, B, -0.5)", aliases)
+    assert references == ("A", "B")
+    assert np.all(np.isfinite(result))
 
 
 def test_unsafe_vector_math_is_rejected() -> None:
@@ -78,3 +84,43 @@ def test_zero_resultant_is_rejected() -> None:
             vectors,
             [SimpleNamespace(expression="A - A", label="zero")],
         )
+
+
+def test_model_functions_can_be_nested() -> None:
+    aliases = {"A": np.array([1.0, 2.0])}
+    calls: list[str] = []
+
+    def model_function(name, args):
+        calls.append(name)
+        return np.asarray(args[0]) * (2.0 if name == "norm" else 0.5)
+
+    result, references = evaluate_vector_expression(
+        "invnorm(norm(A, 0, 'attn', 'input'), 'final')", aliases, model_function=model_function
+    )
+    np.testing.assert_allclose(result, aliases["A"])
+    assert references == ("A",)
+    assert calls == ["norm", "invnorm"]
+
+
+def test_vector_dimension_metrics_participation_ratio() -> None:
+    assert vector_dimension_metrics(np.array([1.0, 0.0, 0.0]))["effective_dimension"] == pytest.approx(1.0)
+    assert vector_dimension_metrics(np.array([1.0, 1.0, 1.0]))["effective_dimension"] == pytest.approx(3.0)
+    skewed = vector_dimension_metrics(np.array([10.0, 1.0, 0.0]))
+    assert skewed["effective_dimension"] == pytest.approx((101.0**2) / 10001.0)
+    assert skewed["dimensions_for_angle"] >= 1
+
+
+def test_qk_model_functions_are_dispatched() -> None:
+    aliases = {"A": np.array([1.0, 2.0])}
+    calls: list[str] = []
+
+    def model_function(name, args):
+        calls.append(name)
+        return np.asarray(args[0]) + (1.0 if name == "wqk" else 2.0)
+
+    result, references = evaluate_vector_expression(
+        "wkq(wqk(A, 0, 1, 2), 0, 1, 2)", aliases, model_function=model_function
+    )
+    np.testing.assert_allclose(result, np.array([4.0, 5.0]))
+    assert references == ("A",)
+    assert calls == ["wqk", "wkq"]

--- a/report/threejs/hf-vocab-sphere/tests/test_vector_math.py
+++ b/report/threejs/hf-vocab-sphere/tests/test_vector_math.py
@@ -140,3 +140,27 @@ def test_layer_model_functions_are_dispatched() -> None:
     np.testing.assert_allclose(result, np.array([111.0, 112.0]))
     assert references == ("A", "B")
     assert calls == ["attn_layer", "mlp_layer"]
+
+
+def test_model_state_function_dispatches_context_and_selectors() -> None:
+    aliases = {
+        "A": np.array([1.0, 0.0]),
+        "B": np.array([0.0, 1.0]),
+        "C": np.array([1.0, 1.0]),
+    }
+    captured = []
+
+    def model_function(name, args):
+        captured.append((name, args))
+        return np.asarray(args[0])
+
+    result, references = evaluate_vector_expression(
+        "model_state(C, 2, 'attn', 'heads', '0,2', A, B)", aliases, model_function=model_function
+    )
+
+    np.testing.assert_array_equal(result, aliases["C"])
+    assert references == ("A", "B", "C")
+    assert captured[0][0] == "model_state"
+    assert captured[0][1][1:5] == [2.0, "attn", "heads", "0,2"]
+    np.testing.assert_array_equal(captured[0][1][5], aliases["A"])
+    np.testing.assert_array_equal(captured[0][1][6], aliases["B"])

--- a/report/threejs/hf-vocab-sphere/tests/test_vector_math.py
+++ b/report/threejs/hf-vocab-sphere/tests/test_vector_math.py
@@ -124,3 +124,19 @@ def test_qk_model_functions_are_dispatched() -> None:
     np.testing.assert_allclose(result, np.array([4.0, 5.0]))
     assert references == ("A",)
     assert calls == ["wqk", "wkq"]
+
+
+def test_layer_model_functions_are_dispatched() -> None:
+    aliases = {"A": np.array([1.0, 2.0]), "B": np.array([3.0, 4.0])}
+    calls: list[str] = []
+
+    def model_function(name, args):
+        calls.append(name)
+        return np.asarray(args[0]) + (10.0 if name == "attn_layer" else 100.0)
+
+    result, references = evaluate_vector_expression(
+        "mlp_layer(attn_layer(A, 0, A, B), 0)", aliases, model_function=model_function
+    )
+    np.testing.assert_allclose(result, np.array([111.0, 112.0]))
+    assert references == ("A", "B")
+    assert calls == ["attn_layer", "mlp_layer"]


### PR DESCRIPTION
### Motivation
- Provide richer vector-expression primitives that can reference model auxiliary tensors (layer norms, attention projections) and enable norm-based and head-projection transforms in arithmetic expressions. 
- Surface per-vector participation metrics so users can inspect effective dimensionality and how many coordinates are needed to preserve a small-angle projection. 
- Give the UI options to display vector magnitudes and participation ratio in labels and allow SLERP extrapolation for advanced interpolation/extrapolation workflows.

### Description
- Add a `model_vector_function` in `model_store.py` that loads auxiliary safetensors, exposes helpers (`_all_safetensor_tensors`, `_find_tensor`, head/attention slicing, `_norm_weight_for_args`, `_apply_rms_norm`, `_apply_inverse_rms_norm`, and handlers for `norm`, `invnorm`, `wov`, `wqk`, `wkq`) and is callable from the projection API. 
- Extend `vector_math.py` to accept an optional `model_function` when evaluating expressions, support string constants for function args, register additional named functions (`norm`, `invnorm`, `wov`, `wqk`, `wkq`), relax SLERP constraints to allow finite extrapolation `t`, and add `vector_dimension_metrics` to compute `effective_dimension`, `dimensions_for_angle`, `continuous_dimensions_for_angle` and related metrics. 
- Propagate computed participation metrics into responses by adding fields to `schemas.py` (`effective_dimension`, `dimensions_for_angle`, `continuous_dimensions_for_angle`) and include those metrics for both token rows and resultant rows in `main.py` by calling `vector_dimension_metrics`. 
- Wire the frontend to display these new fields: update `app.js` and `index.html` to add toggles/hotkeys for showing magnitudes (`M`) and participation ratio (`P`), include participation/magnitude text in label rendering and settings snapshot/restore, and change the SLERP input to accept numeric extrapolation values with explanatory text. 

### Testing
- Unit tests under `tests/test_vector_math.py` were updated to exercise nested model function dispatch, SLERP extrapolation, and `vector_dimension_metrics`, and `tests/test_frontend_contract.py` was updated to validate new DOM IDs and settings defaults. 
- Ran the test suite with `pytest tests/` and the modified tests (`test_vector_math` and `test_frontend_contract`) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5da23777c483269c6306dd548cfa04)