### PR TITLE
feat(model): add final residual-stream attention over saved block outputs

### DIFF
--- a/explorations/final_residual_attention_comparison.yaml
+++ b/explorations/final_residual_attention_comparison.yaml
@@ -1,0 +1,53 @@
+---
+
+named_static_groups:
+  - named_group: "baseline"
+    attention_variant: ["causal"]
+    use_final_residual_attention: [false]
+
+  - named_group: "final_resid_attn"
+    attention_variant: ["infinite"]
+    use_concat_heads: [true]
+    use_final_residual_attention: [true]
+    final_residual_attention_norm_variant: ["rmsnorm"]
+
+  - named_group: "rotary"
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+  - named_group: "peri_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [true]
+    use_post_ln: [false]
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [2500]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+  compile: [true]
+  log_rankme: [true]
+  log_areq: [true]
+
+parameter_groups:
+  - named_group_static:
+      - "rotary"
+      - "peri_ln"
+      - "baseline"
+    n_layer: [6]
+    n_head: [6]
+    n_embd: [384]
+
+  - named_group_static:
+      - "rotary"
+      - "peri_ln"
+      - "final_resid_attn"
+    n_layer: [6]
+    n_head: [6]
+    n_kv_group: [6]
+    n_embd: [384]
+    n_qk_head_dim: [64]
+    n_v_head_dim: [64]
+    final_residual_attention_n_head: [6]
+    final_residual_attention_n_qk_head_dim: [64]
+    final_residual_attention_n_v_head_dim: [64]

--- a/explorations/final_residual_attention_comparison.yaml
+++ b/explorations/final_residual_attention_comparison.yaml
@@ -9,6 +9,9 @@ named_static_groups:
     attention_variant: ["infinite"]
     use_concat_heads: [true]
     use_final_residual_attention: [true]
+    final_residual_attention_use_qk_norm: [true]
+    final_residual_attention_use_qk_norm_scale: [true]
+    final_residual_attention_softmax_variant: ["relu2max"]
     final_residual_attention_norm_variant: ["rmsnorm"]
 
   - named_group: "rotary"

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -103,6 +103,9 @@ class GPTConfig:
     final_residual_attention_n_head: int | None = None
     final_residual_attention_n_qk_head_dim: int | None = None
     final_residual_attention_n_v_head_dim: int | None = None
+    final_residual_attention_use_qk_norm: bool | None = None
+    final_residual_attention_use_qk_norm_scale: bool | None = None
+    final_residual_attention_softmax_variant: str | None = None
     final_residual_attention_norm_variant: str = "rmsnorm"
 
     # Softcapping params

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -98,6 +98,13 @@ class GPTConfig:
     n_cproj: int = None
     use_concat_heads: bool = False
 
+    # Final residual-stream attention over saved block unit outputs
+    use_final_residual_attention: bool = False
+    final_residual_attention_n_head: int | None = None
+    final_residual_attention_n_qk_head_dim: int | None = None
+    final_residual_attention_n_v_head_dim: int | None = None
+    final_residual_attention_norm_variant: str = "rmsnorm"
+
     # Softcapping params
     attn_logit_softcapping: float | None = None
     final_logit_softcapping: float | None = None

--- a/model.py
+++ b/model.py
@@ -48,6 +48,57 @@ from initializations.initialization_variations import init_dictionary
 from shared_param_utils import SharedParamGroupCreator
 from variations.block_variations import Block
 
+class FinalResidualStreamAttention(nn.Module):
+    """Final attention from the last residual stream into saved block unit outputs."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.n_embd = config.n_embd
+        self.n_head = config.final_residual_attention_n_head or config.n_head
+        default_head_dim = config.n_embd // self.n_head
+        self.n_qk_head_dim = (
+            config.final_residual_attention_n_qk_head_dim
+            or config.n_qk_head_dim
+            or default_head_dim
+        )
+        self.n_v_head_dim = (
+            config.final_residual_attention_n_v_head_dim
+            or config.n_v_head_dim
+            or default_head_dim
+        )
+
+        linear_cls = linear_dictionary[config.linear_variant_attn]
+        self.wq = linear_cls(self.n_embd, self.n_head * self.n_qk_head_dim, config, bias=config.bias)
+        self.wk = linear_cls(self.n_embd, self.n_head * self.n_qk_head_dim, config, bias=config.bias)
+        self.wv = linear_cls(self.n_embd, self.n_head * self.n_v_head_dim, config, bias=config.bias)
+        self.c_proj = linear_cls(self.n_head * self.n_v_head_dim, self.n_embd, config, bias=config.bias)
+        self.attn_dropout = nn.Dropout(config.dropout)
+        self.resid_dropout = nn.Dropout(config.dropout)
+
+    def forward(self, query_source, saved_outputs):
+        if not saved_outputs:
+            return query_source
+
+        B, T, _ = query_source.size()
+        memory = torch.cat(saved_outputs, dim=1)
+        S = memory.size(1)
+        q = self.wq(query_source).view(B, T, self.n_head, self.n_qk_head_dim).transpose(1, 2)
+        k = self.wk(memory).view(B, S, self.n_head, self.n_qk_head_dim).transpose(1, 2)
+        v = self.wv(memory).view(B, S, self.n_head, self.n_v_head_dim).transpose(1, 2)
+
+        att = (q @ k.transpose(-2, -1)) / math.sqrt(self.n_qk_head_dim)
+        q_pos = torch.arange(T, device=query_source.device).view(1, 1, T, 1)
+        repeats = len(saved_outputs)
+        kv_pos = torch.arange(T, device=query_source.device).repeat(repeats).view(1, 1, 1, S)
+        att = att.masked_fill(q_pos < kv_pos, float('-inf'))
+        att = F.softmax(att, dim=-1)
+        att = self.attn_dropout(att)
+        y = att @ v
+        y = y.transpose(1, 2).contiguous().view(B, T, self.n_head * self.n_v_head_dim)
+        y = self.c_proj(y)
+        return self.resid_dropout(y)
+
+
 class GPT(nn.Module):
 
     def __init__(self, config):
@@ -144,6 +195,9 @@ class GPT(nn.Module):
         self.transformer['drop'] = nn.Dropout(config.dropout)
         self.transformer['h'] = nn.ModuleList([Block(config, mlp=shared_mlp_array[i], attn=shared_attn_array[i]) for i in range(config.n_layer)])
         self.transformer['ln_f'] = norm_dictionary[config.norm_variant_output](config)
+        if config.use_final_residual_attention:
+            self.transformer['final_residual_attn'] = FinalResidualStreamAttention(config)
+            self.transformer['final_residual_attn_norm'] = norm_dictionary[config.final_residual_attention_norm_variant](config)
 
         # Optional post-embedding normalizations
         if self.config.norm_variant_wte is not None:
@@ -390,6 +444,18 @@ class GPT(nn.Module):
             return embeddings + noise
         return embeddings
 
+
+    def _append_final_residual_saved_outputs(self, saved_outputs, block):
+        if self.config.use_final_residual_attention:
+            saved_outputs.extend(block.last_residual_outputs)
+
+    def _apply_final_residual_attention(self, x, saved_outputs):
+        x = self.transformer.ln_f(x)
+        if self.config.use_final_residual_attention:
+            x = self.transformer.final_residual_attn(x, saved_outputs)
+            x = self.transformer.final_residual_attn_norm(x)
+        return x
+
     def forward(self, idx, targets=None, iter_num=None, token_dict=None, target_dict=None, dataset_idx=None, loss_fn=None):
         if token_dict is not None:
             token_list = list(token_dict.values())
@@ -439,10 +505,12 @@ class GPT(nn.Module):
 
             if self.use_ln_f_input_mixer:
                 layer_outputs = [x]
+            final_residual_saved_outputs = []
 
             layer_idx = 1
             for block in self.transformer.h:
                 x = block(x, iter_num)
+                self._append_final_residual_saved_outputs(final_residual_saved_outputs, block)
 
                 # Steering logic
                 if self.use_lsv and layer_idx == self.config.apply_lsv_at_layer_idx:
@@ -462,8 +530,8 @@ class GPT(nn.Module):
             if self.use_ln_f_input_mixer:
                 x = self.ln_f_mixer(layer_outputs)
 
-            # 3. Final layer norm
-            x = self.transformer.ln_f(x)
+            # 3. Final layer norm and optional final residual-stream attention
+            x = self._apply_final_residual_attention(x, final_residual_saved_outputs)
 
             # 4. Optionally scale down
             if self.n_embd_wte:
@@ -582,11 +650,13 @@ class GPT(nn.Module):
 
             if self.use_ln_f_input_mixer:
                 layer_outputs = [x]
+            final_residual_saved_outputs = []
 
             layer_idx = 1
             for block in self.transformer.h:
                 # Propagate tokens through layers
                 x = block(x, iter_num)
+                self._append_final_residual_saved_outputs(final_residual_saved_outputs, block)
 
                 # Intercept for Learned Steering Vectors
                 if self.use_lsv and layer_idx == self.config.apply_lsv_at_layer_idx:
@@ -608,7 +678,7 @@ class GPT(nn.Module):
             if self.use_ln_f_input_mixer:
                 x = self.ln_f_mixer(layer_outputs)
 
-            x = self.transformer.ln_f(x)
+            x = self._apply_final_residual_attention(x, final_residual_saved_outputs)
 
             if self.n_embd_wte:
                 x = F.linear(x, self.transformer.scale_down.weight.t())
@@ -704,6 +774,7 @@ class GPT(nn.Module):
         layer_idx = 1
         for block in self.transformer.h:
             x = block(x, iter_num)
+            self._append_final_residual_saved_outputs(final_residual_saved_outputs, block)
             if self.use_lsv and layer_idx == self.config.apply_lsv_at_layer_idx:
                 x = self.lsv_matrix(x)
             if self.use_ln_f_input_mixer:
@@ -713,7 +784,7 @@ class GPT(nn.Module):
         if self.use_ln_f_input_mixer:
             x = self.ln_f_mixer(layer_outputs)
 
-        x = self.transformer.ln_f(x)
+        x = self._apply_final_residual_attention(x, final_residual_saved_outputs)
         if self.n_embd_wte:
             x = F.linear(x, self.transformer.scale_down.weight.t())
 

--- a/model.py
+++ b/model.py
@@ -72,6 +72,29 @@ class FinalResidualStreamAttention(nn.Module):
         self.wk = linear_cls(self.n_embd, self.n_head * self.n_qk_head_dim, config, bias=config.bias)
         self.wv = linear_cls(self.n_embd, self.n_head * self.n_v_head_dim, config, bias=config.bias)
         self.c_proj = linear_cls(self.n_head * self.n_v_head_dim, self.n_embd, config, bias=config.bias)
+
+        self.use_qk_norm = (
+            config.use_qk_norm
+            if config.final_residual_attention_use_qk_norm is None
+            else config.final_residual_attention_use_qk_norm
+        )
+        self.use_qk_norm_scale = (
+            config.use_qk_norm_scale
+            if config.final_residual_attention_use_qk_norm_scale is None
+            else config.final_residual_attention_use_qk_norm_scale
+        )
+        if self.use_qk_norm_scale:
+            L = config.block_size
+            g0 = math.log2(L * L - L)
+            self.qk_norm_factor = nn.Parameter(torch.tensor(g0))
+
+        self.softmax_variant_attn = (
+            config.final_residual_attention_softmax_variant
+            or config.softmax_variant_attn
+        )
+        if self.softmax_variant_attn != "softmax":
+            self.softmax_layer_attn = softmax_dictionary[self.softmax_variant_attn](config)
+
         self.attn_dropout = nn.Dropout(config.dropout)
         self.resid_dropout = nn.Dropout(config.dropout)
 
@@ -86,12 +109,24 @@ class FinalResidualStreamAttention(nn.Module):
         k = self.wk(memory).view(B, S, self.n_head, self.n_qk_head_dim).transpose(1, 2)
         v = self.wv(memory).view(B, S, self.n_head, self.n_v_head_dim).transpose(1, 2)
 
-        att = (q @ k.transpose(-2, -1)) / math.sqrt(self.n_qk_head_dim)
+        if self.use_qk_norm:
+            q = q / (q.norm(dim=-1, keepdim=True) + 1e-6)
+            k = k / (k.norm(dim=-1, keepdim=True) + 1e-6)
+
+        att = q @ k.transpose(-2, -1)
+        if self.use_qk_norm_scale:
+            att = att * self.qk_norm_factor
+        else:
+            att = att / math.sqrt(self.n_qk_head_dim)
+
         q_pos = torch.arange(T, device=query_source.device).view(1, 1, T, 1)
         repeats = len(saved_outputs)
         kv_pos = torch.arange(T, device=query_source.device).repeat(repeats).view(1, 1, 1, S)
         att = att.masked_fill(q_pos < kv_pos, float('-inf'))
-        att = F.softmax(att, dim=-1)
+        if self.softmax_variant_attn != "softmax":
+            att = self.softmax_layer_attn(att)
+        else:
+            att = F.softmax(att, dim=-1)
         att = self.attn_dropout(att)
         y = att @ v
         y = y.transpose(1, 2).contiguous().view(B, T, self.n_head * self.n_v_head_dim)

--- a/train_args.py
+++ b/train_args.py
@@ -1016,6 +1016,9 @@ def parse_args():
     model_group.add_argument("--final_residual_attention_n_head", default=None, type=int, help="Number of heads for final residual-stream attention (defaults to n_head)")
     model_group.add_argument("--final_residual_attention_n_qk_head_dim", default=None, type=int, help="Q/K head dimension for final residual-stream attention (defaults to n_qk_head_dim or n_embd // n_head)")
     model_group.add_argument("--final_residual_attention_n_v_head_dim", default=None, type=int, help="V head dimension for final residual-stream attention (defaults to n_v_head_dim or n_embd // n_head)")
+    model_group.add_argument("--final_residual_attention_use_qk_norm", default=None, action=argparse.BooleanOptionalAction, help="Apply QK norm in final residual-stream attention (defaults to use_qk_norm when unset)")
+    model_group.add_argument("--final_residual_attention_use_qk_norm_scale", default=None, action=argparse.BooleanOptionalAction, help="Use learned QK norm scale in final residual-stream attention (defaults to use_qk_norm_scale when unset)")
+    model_group.add_argument("--final_residual_attention_softmax_variant", type=str, default=None, help="Softmax variant for final residual-stream attention (defaults to softmax_variant_attn when unset)")
     model_group.add_argument("--final_residual_attention_norm_variant", type=str, default="rmsnorm", choices=norm_variations, help="Norm after final residual-stream attention")
 
     ## qk_norm variations

--- a/train_args.py
+++ b/train_args.py
@@ -1011,6 +1011,13 @@ def parse_args():
                              help="L2 normalize attention outputs before c_proj (Infinite Attention)")
     model_group.add_argument("--use_concat_heads",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="concat heads instead of adding in infinite attention")
 
+    ## Final residual-stream attention
+    model_group.add_argument("--use_final_residual_attention", type=bool, default=False, action=argparse.BooleanOptionalAction, help="Route final residual through attention over saved block attention/MLP outputs before LM head")
+    model_group.add_argument("--final_residual_attention_n_head", default=None, type=int, help="Number of heads for final residual-stream attention (defaults to n_head)")
+    model_group.add_argument("--final_residual_attention_n_qk_head_dim", default=None, type=int, help="Q/K head dimension for final residual-stream attention (defaults to n_qk_head_dim or n_embd // n_head)")
+    model_group.add_argument("--final_residual_attention_n_v_head_dim", default=None, type=int, help="V head dimension for final residual-stream attention (defaults to n_v_head_dim or n_embd // n_head)")
+    model_group.add_argument("--final_residual_attention_norm_variant", type=str, default="rmsnorm", choices=norm_variations, help="Norm after final residual-stream attention")
+
     ## qk_norm variations
     model_group.add_argument("--use_qk_norm",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="applies the norm to q and k before attn")
     model_group.add_argument("--use_qk_norm_scale",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="applies norm scale, preloads scale for flash attn, post qk multiplication in manual attn")

--- a/variations/block_variations.py
+++ b/variations/block_variations.py
@@ -100,6 +100,8 @@ def parallel_mlp_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor:
     if block.mlp_resid_scaler is not None:
         mlp_out = block.mlp_resid_scaler(mlp_out)
 
+    block.last_residual_outputs = [attn_out, mlp_out]
+
     # Skip Connection
     combined = attn_out + mlp_out
     x = block._combine_resid("attn", x, combined)
@@ -132,6 +134,8 @@ def attn_then_mlp_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor
     if block.attn_resid_scaler is not None:
         attn_out = block.attn_resid_scaler(attn_out)
 
+    block.last_residual_outputs = [attn_out]
+
     # Attn Skip Connection
     x = block._combine_resid("attn", x, attn_out)
 
@@ -156,6 +160,8 @@ def attn_then_mlp_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor
     # MLP Output Scaling
     if block.mlp_resid_scaler is not None:
         mlp_out = block.mlp_resid_scaler(mlp_out)
+
+    block.last_residual_outputs.append(mlp_out)
 
     # MLP Skip Connection
     x = block._combine_resid("mlp", x, mlp_out)
@@ -203,6 +209,8 @@ def edgellm_asic_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor:
     if block.attn_resid_scaler is not None:
         attn_out = block.attn_resid_scaler(attn_out)
 
+    block.last_residual_outputs = [attn_out]
+
     # Attn Skip Connection -- Note that we skip connect here to the quantized residual
     x_quantized_residual = attn_out + x_quantized_residual
 
@@ -230,6 +238,8 @@ def edgellm_asic_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor:
     # MLP Output Scaling
     if block.mlp_resid_scaler is not None:
         mlp_out = block.mlp_resid_scaler(mlp_out)
+
+    block.last_residual_outputs.append(mlp_out)
 
     chip_output = mlp_out + x_quantized_residual
 
@@ -468,8 +478,13 @@ class Block(nn.Module):
             "mlp": residual_combine_dict[self.mlp_resid_type],
         }
 
+        self.last_residual_outputs = []
+
         # Gradient checkpointing
-        self.use_gradient_checkpointing = getattr(config, "use_gradient_checkpointing", False)
+        self.use_gradient_checkpointing = (
+            getattr(config, "use_gradient_checkpointing", False)
+            and not getattr(config, "use_final_residual_attention", False)
+        )
 
     def forward(self, x: torch.Tensor, iter_num: int):
         if self.use_gradient_checkpointing and x.requires_grad:


### PR DESCRIPTION
### Motivation
- Provide a variant that preserves each block's attention and MLP outputs and lets the final residual vector attend over those saved vectors using an independent Q/K/V head configuration. 
- Allow experimentation with an "infinite"/concat-heads style final attention that can use separate `n_qk_head_dim`, `n_v_head_dim`, and `n_head` for the final query/key/value projections.

### Description
- Add `FinalResidualStreamAttention` in `model.py` which builds `Wq`, `Wk`, `Wv`, a `c_proj` and applies causal attention from the final residual stream into concatenated saved block outputs, then applies a configurable norm; it uses `linear_dictionary` to select linear variants. 
- Wire the final-attention module into `GPT.__init__` and the forward paths so that, when enabled, the model runs `ln_f` → final residual attention → `ln_f`-variant norm before the LM head / `scale_down` path. 
- Modify `variations/block_variations.py` to save each block's `attn_out` and `mlp_out` into `block.last_residual_outputs` immediately before their conventional skip connections while preserving the original residual behavior. 
- Add config fields in `gpt_conf.py` and CLI flags in `train_args.py` for `use_final_residual_attention`, `final_residual_attention_n_head`, `final_residual_attention_n_qk_head_dim`, `final_residual_attention_n_v_head_dim`, and `final_residual_attention_norm_variant`. 
- Disable per-block gradient checkpointing when `use_final_residual_attention` is enabled so saved tensors keep gradients for the final attention path, and add `explorations/final_residual_attention_comparison.yaml` to compare the new variant vs baseline. 

### Testing
- Ran Python compile checks with `python -m py_compile model.py variations/block_variations.py gpt_conf.py train_args.py`, which succeeded. 
- Parsed the new exploration YAML with a small YAML snippet via a Python loader to confirm file validity, which succeeded. 
- Attempted a smoke forward pass with a tiny config to validate runtime behavior, but it could not be executed in this environment due to `torch` not being available (`ModuleNotFoundError: No module named 'torch'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61997edaa08326ad5ce469ccd08f03)