### PR TITLE
feat(attention): accelerate relu2max with inductor

### DIFF
--- a/documentation/ReLU2Max_Kernel.md
+++ b/documentation/ReLU2Max_Kernel.md
@@ -1,0 +1,54 @@
+# Kernel-accelerated ReLU2Max attention
+
+## What ReLU2Max does
+
+The `relu2max` attention variant replaces softmax with
+
+```text
+weight = ReLU(QKᵀ / √d)² / divisor
+```
+
+and, when `--div_by_seq_len` is enabled, divides the result by the key sequence
+length as well. This is the squared-ReLU attention transformation explored by
+[Primer](https://arxiv.org/abs/2109.08668). Unlike softmax, it is not
+row-normalized: changing `relu2max_divisor` therefore changes the scale of the
+attention output. Causal masking remains correct because masked `-inf` logits
+become zero after ReLU.
+
+The existing manual attention path materializes `QKᵀ`, applies the selected
+transformation, and multiplies by `V`. The accelerated implementation only
+fuses the pointwise ReLU, square, and scaling operations; it does **not** yet
+fuse the two matrix multiplications or avoid materializing the quadratic score
+matrix. It is consequently a safe incremental optimization, not a ReLU2Max
+equivalent of FlashAttention.
+
+## Using the kernel
+
+Run training with:
+
+```bash
+python train.py \
+  --softmax_variant_attn relu2max \
+  --relu2max_use_kernel \
+  --relu2max_divisor 256 \
+  --div_by_seq_len
+```
+
+`--relu2max_use_kernel` sends the pointwise transform through
+[`torch.compile`](https://docs.pytorch.org/docs/stable/generated/torch.compile.html).
+PyTorch Inductor specializes it lazily for the input device, dtype, and shape;
+on CUDA, Inductor normally emits a Triton kernel. AOTAutograd generates the
+corresponding backward kernel, so the option works in both training and
+inference. The default remains the eager implementation to avoid first-call
+compilation cost on short runs and preserve compatibility with older PyTorch
+installations.
+
+## Measuring the result
+
+Benchmark after a warm-up call so compilation is excluded. Compare otherwise
+identical runs with and without `--relu2max_use_kernel`, and report both step
+time and peak memory. The expected benefit is limited to fewer pointwise kernel
+launches and score-matrix reads/writes. A future fully fused kernel should tile
+`QKᵀ`, apply causal masking and squared ReLU in SRAM, immediately accumulate
+against `V`, and implement matching backward kernels; that larger change would
+remove the `T × T` score allocation and provide the FlashAttention-like gain.

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -295,8 +295,9 @@ class GPTConfig:
     ## ReLUMax options
     relumax_divisor: float = 256.0
 
-    ## ReLUMax options
+    ## ReLU2Max options
     relu2max_divisor: float = 256.0
+    relu2max_use_kernel: bool = False
 
     ## SigmoidMax options
     sigmoidmax_divisor: float = 256.0

--- a/tests/test_relu2max.py
+++ b/tests/test_relu2max.py
@@ -1,0 +1,43 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from variations.softmax_variations import ReLU2Max
+
+
+class TestReLU2Max(unittest.TestCase):
+    @staticmethod
+    def config(*, use_kernel=False, div_by_seq_len=False, divisor=4.0):
+        return SimpleNamespace(
+            relu2max_divisor=divisor,
+            relu2max_use_kernel=use_kernel,
+            div_by_seq_len=div_by_seq_len,
+        )
+
+    def test_eager_values_and_sequence_scaling(self):
+        inputs = torch.tensor([[[-2.0, 0.0, 2.0, 4.0]]])
+        layer = ReLU2Max(self.config(div_by_seq_len=True))
+        expected = torch.tensor([[[0.0, 0.0, 0.25, 1.0]]])
+        torch.testing.assert_close(layer(inputs), expected)
+
+    def test_kernel_matches_eager_forward_and_backward(self):
+        eager_input = torch.randn(2, 3, 5, requires_grad=True)
+        kernel_input = eager_input.detach().clone().requires_grad_(True)
+        eager = ReLU2Max(self.config(div_by_seq_len=True))(eager_input)
+        kernel = ReLU2Max(
+            self.config(use_kernel=True, div_by_seq_len=True)
+        )(kernel_input)
+
+        torch.testing.assert_close(kernel, eager)
+        eager.sum().backward()
+        kernel.sum().backward()
+        torch.testing.assert_close(kernel_input.grad, eager_input.grad)
+
+    def test_rejects_non_positive_divisor(self):
+        with self.assertRaisesRegex(ValueError, "must be positive"):
+            ReLU2Max(self.config(divisor=0.0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/train_args.py
+++ b/train_args.py
@@ -1353,6 +1353,12 @@ def parse_args():
 
     ### ReLU2Max Options
     model_group.add_argument("--relu2max_divisor", type=float, default=256.0)
+    model_group.add_argument(
+        "--relu2max_use_kernel",
+        default=False,
+        action=argparse.BooleanOptionalAction,
+        help="compile ReLU2Max into a fused Inductor pointwise kernel",
+    )
 
     ### SimgoidMax Options
     model_group.add_argument("--sigmoidmax_divisor", type=float, default=256.0)

--- a/variations/relu2max_kernel.py
+++ b/variations/relu2max_kernel.py
@@ -1,0 +1,13 @@
+"""Inductor-compiled implementation of the elementwise ReLU2Max transform."""
+
+import torch
+
+
+def _relu2max(x: torch.Tensor, divisor: float, sequence_length: int) -> torch.Tensor:
+    """Keep this function small so Inductor can emit one pointwise kernel."""
+    return torch.relu(x).square() / (divisor * sequence_length)
+
+
+# Compilation is lazy: importing nanoGPT does not initialize a compiler or CUDA.
+# AOTAutograd also derives a compiled backward kernel from this function.
+relu2max_kernel = torch.compile(_relu2max, fullgraph=True, dynamic=True)

--- a/variations/softmax_variations.py
+++ b/variations/softmax_variations.py
@@ -564,17 +564,26 @@ class ReLU2Max(nn.Module):
         self.dim = dim
         self.relu2max_divisor = config.relu2max_divisor
         self.div_by_seq_len = config.div_by_seq_len
+        self.use_kernel = getattr(config, "relu2max_use_kernel", False)
+
+        if self.relu2max_divisor <= 0:
+            raise ValueError("relu2max_divisor must be positive")
+
+        if self.use_kernel:
+            # Keep torch.compile/Inductor optional for every other softmax variant.
+            from variations.relu2max_kernel import relu2max_kernel
+            self.relu2max_kernel = relu2max_kernel
 
     def forward(self, x):
 
-        result = torch.relu(x) ** 2 / self.relu2max_divisor
-
-        # divide by sequence length
-        if self.div_by_seq_len:
-            seq_len = x.shape[self.dim]
-            result = result / seq_len
-
-        return result
+        sequence_length = x.shape[self.dim] if self.div_by_seq_len else 1
+        if self.use_kernel:
+            return self.relu2max_kernel(
+                x, self.relu2max_divisor, sequence_length
+            )
+        return torch.relu(x).square() / (
+            self.relu2max_divisor * sequence_length
+        )
 
 
 class Softplus2Max(nn.Module):


### PR DESCRIPTION
### Motivation

- Provide an opt-in kernel-accelerated implementation of the ReLU² attention transform (`relu2max`) to reduce pointwise kernel overheads while preserving the existing eager path and compatibility.
- Keep change incremental and safe by only fusing the pointwise ReLU → square → scale (and optional sequence-length division) while leaving matrix multiplies and causal masking unchanged.

### Description

- Add `variations/relu2max_kernel.py` which defines a small `_relu2max` function and compiles it with `torch.compile` (Inductor/AOTAutograd friendly) as `relu2max_kernel`.
- Integrate the optional compiled path into `ReLU2Max` in `variations/softmax_variations.py` with a runtime toggle, validate that `relu2max_divisor > 0`, and preserve the eager fallback when the kernel is disabled.
- Expose configuration and CLI switches via `gpt_conf.py` (`relu2max_use_kernel`) and `train_args.py` (`--relu2max_use_kernel`) to opt into compilation at runtime.
- Add `tests/test_relu2max.py` to cover eager behavior, sequence-length scaling, forward/backward equivalence between eager and compiled runs, and invalid-divisor validation, and add `documentation/ReLU2Max_Kernel.md` describing semantics and usage.

### Testing

- Ran compilation checks: `python -m compileall -q variations/relu2max_kernel.py variations/softmax_variations.py tests/test_relu2max.py gpt_conf.py train_args.py` (succeeded).
- Ran repository checks: `git diff --check` and `git diff --cached --check` (no issues reported).
- Attempted unit tests: `python -m unittest tests.test_relu2max` but the test run failed in this environment due to missing PyTorch (`ModuleNotFoundError: No module named 'torch'`), so functional test assertions could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6618159b78832684030e05eda31354)