### PR TITLE
Add fused, kernel-accelerated ReLU2Max attention

### DIFF
--- a/docs/relu2max_attention.md
+++ b/docs/relu2max_attention.md
@@ -1,0 +1,27 @@
+# Kernel-accelerated ReLU2Max attention
+
+ReLU2Max replaces softmax attention weights with
+`relu(QK^T / sqrt(head_dim))^2 / divisor`. The eager path is simple, but writes
+the full `T x T` score and weight tensors to memory. That quadratic traffic is
+the same bottleneck avoided by scaled-dot-product/Flash Attention.
+
+The fused path uses PyTorch FlexAttention to generate one CUDA attention kernel
+containing the score transform and causal mask. It therefore retains the
+linear-memory, tiled QK/PV execution model of SDPA while preserving ReLU2Max's
+mathematics and autograd support. It is enabled by default for `relu2max` on a
+supported PyTorch/CUDA build:
+
+```bash
+python train.py --softmax_variant_attn relu2max --use_fused_relu2max
+```
+
+Use `--no-use_fused_relu2max` for A/B comparisons. The implementation falls
+back automatically on CPU and when attention dropout, FIRE, sliding windows,
+logit soft-capping, or learned QK scaling require semantics the kernel does not
+currently cover. Quantized attention continues through the existing eager path.
+
+Benchmark both paths at the intended dtype and sequence length after warm-up;
+the first fused call includes kernel compilation. Compare peak CUDA memory,
+tokens/second, forward/backward time, loss, and gradient norms. The expected
+benefit grows with sequence length: intermediate attention storage changes from
+quadratic to linear, while arithmetic remains quadratic as it does for SDPA.

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -297,6 +297,7 @@ class GPTConfig:
 
     ## ReLUMax options
     relu2max_divisor: float = 256.0
+    use_fused_relu2max: bool = True # fuse ReLU2Max attention on supported CUDA builds
 
     ## SigmoidMax options
     sigmoidmax_divisor: float = 256.0

--- a/tests/test_relu2max_attention.py
+++ b/tests/test_relu2max_attention.py
@@ -1,0 +1,21 @@
+import pytest
+import torch
+
+from variations.relu2max_attention import make_relu2max_score_mod
+
+
+def test_relu2max_score_mod_matches_eager():
+    scores = torch.tensor([-2.0, 0.0, 3.0])
+    score_mod = make_relu2max_score_mod(6.0)
+    actual = torch.stack([score_mod(x, None, None, None, None) for x in scores])
+    torch.testing.assert_close(actual, torch.relu(scores).square() / 6.0)
+
+
+def test_relu2max_score_mod_sequence_scaling():
+    score_mod = make_relu2max_score_mod(2.0, sequence_length=4)
+    assert score_mod(torch.tensor(4.0), None, None, None, None).item() == 2.0
+
+
+def test_relu2max_rejects_invalid_divisor():
+    with pytest.raises(ValueError, match="greater than zero"):
+        make_relu2max_score_mod(0)

--- a/train_args.py
+++ b/train_args.py
@@ -1353,6 +1353,8 @@ def parse_args():
 
     ### ReLU2Max Options
     model_group.add_argument("--relu2max_divisor", type=float, default=256.0)
+    model_group.add_argument('--use_fused_relu2max', default=True, action=argparse.BooleanOptionalAction,
+                             help='use the FlexAttention ReLU2Max CUDA kernel when supported')
 
     ### SimgoidMax Options
     model_group.add_argument("--sigmoidmax_divisor", type=float, default=256.0)

--- a/variations/attention_variations.py
+++ b/variations/attention_variations.py
@@ -12,6 +12,8 @@ from variations.linear_variations import linear_dictionary, wrap_with_flashnorm
 from variations.position_encoding_variations import (
     FIRE, RotaryEmbedding, SymmetricalOverlapAngularPositions)
 from variations.softmax_variations import softmax_dictionary
+from variations.relu2max_attention import (
+    FusedReLU2MaxAttention, flex_relu2max_available)
 from variations.triadic_modulation_variations import mod_fn_dict
 
 
@@ -120,6 +122,21 @@ class CausalSelfAttention(nn.Module):
         self.gate = config.gate
         self.use_fire_embeddings = None
         self.disable_flash_attention = config.disable_flash_attention
+        self.use_fused_relu2max = (
+            getattr(config, "use_fused_relu2max", True)
+            and config.softmax_variant_attn == "relu2max"
+            and flex_relu2max_available()
+            and config.dropout == 0
+            and config.window_size is None
+            and not config.use_fire_embeddings
+            and not config.use_qk_norm_scale
+            and config.attn_logit_softcapping is None
+            and not config.quantize_attn_act
+        )
+        if self.use_fused_relu2max:
+            self.fused_relu2max = FusedReLU2MaxAttention(
+                config.relu2max_divisor, config.div_by_seq_len
+            )
         if config.use_fire_embeddings:
             self.use_fire_embeddings = config.use_fire_embeddings
             if fire_pos_enc is not None:
@@ -336,7 +353,12 @@ class CausalSelfAttention(nn.Module):
             v = v / (v.norm(dim=-1, keepdim=True) + 1e-6)
 
         # causal self-attention; Self-attend: (B, nh, T, hs) x (B, nh, hs, T) -> (B, nh, T, T)
-        if self.flash:
+        if self.use_fused_relu2max and q.is_cuda:
+            # FlexAttention fuses QK, ReLU-square, causal masking, and PV just
+            # like SDPA. CPU and unsupported configurations retain the exact
+            # eager implementation below.
+            y = self.fused_relu2max(q, self._expand_kv(k), self._expand_kv(v))
+        elif self.flash:
 
             k_attn = self._expand_kv(k)
             v_attn = self._expand_kv(v)

--- a/variations/relu2max_attention.py
+++ b/variations/relu2max_attention.py
@@ -1,0 +1,69 @@
+"""Fused ReLU2Max attention built on PyTorch FlexAttention.
+
+FlexAttention keeps the QK matmul, score transform, causal mask, and PV matmul
+inside one generated kernel.  In particular, it does not materialize the
+quadratic attention matrix that the eager ReLU2Max implementation creates.
+"""
+
+import importlib
+import importlib.util
+
+import torch
+
+
+def flex_relu2max_available() -> bool:
+    """Return whether this PyTorch build exposes the required kernel API."""
+    return importlib.util.find_spec("torch.nn.attention.flex_attention") is not None
+
+
+def make_relu2max_score_mod(divisor: float, sequence_length: int | None = None):
+    """Create the pointwise score transform used by ReLU2Max attention."""
+    scale = float(divisor)
+    if scale <= 0:
+        raise ValueError("relu2max_divisor must be greater than zero")
+    if sequence_length is not None:
+        scale *= sequence_length
+
+    def relu2max(score, _batch, _head, _query, _key):
+        return torch.relu(score).square() / scale
+
+    return relu2max
+
+
+class FusedReLU2MaxAttention:
+    """Shape-aware facade around the compiled FlexAttention kernel."""
+
+    def __init__(self, divisor: float, div_by_seq_len: bool):
+        flex_module = importlib.import_module("torch.nn.attention.flex_attention")
+        self._create_block_mask = flex_module.create_block_mask
+        self.divisor = divisor
+        self.div_by_seq_len = div_by_seq_len
+        self._causal_masks = {}
+        self._score_mods = {}
+        # Compiling the FlexAttention higher-order op is what lowers it to a
+        # tiled CUDA kernel instead of executing its eager reference path.
+        self._kernel = torch.compile(flex_module.flex_attention, dynamic=False)
+
+    def _causal_mask(self, length: int, device: torch.device):
+        key = (length, str(device))
+        if key not in self._causal_masks:
+            def causal(_batch, _head, query, key_value):
+                return query >= key_value
+
+            self._causal_masks[key] = self._create_block_mask(
+                causal, B=None, H=None, Q_LEN=length, KV_LEN=length,
+                device=device,
+            )
+        return self._causal_masks[key]
+
+    def __call__(self, query, key, value):
+        length = query.size(-2)
+        if length not in self._score_mods:
+            self._score_mods[length] = make_relu2max_score_mod(
+                self.divisor, length if self.div_by_seq_len else None
+            )
+        return self._kernel(
+            query, key, value,
+            score_mod=self._score_mods[length],
+            block_mask=self._causal_mask(length, query.device),
+        )


### PR DESCRIPTION
### Motivation

- Reduce the quadratic memory traffic of the eager ReLU2Max attention implementation by fusing the QK matmul, ReLU² score transform, causal mask, and PV matmul into a single FlexAttention CUDA kernel so ReLU2Max can achieve the same linear-memory execution model as SDPA/Flash Attention.

### Description

- Add `variations/relu2max_attention.py` which exposes `make_relu2max_score_mod` and `FusedReLU2MaxAttention` that use `torch.nn.attention.flex_attention` and `torch.compile` to produce a compiled fused kernel; masks and score-mod functions are cached per sequence length.
- Integrate the fused path into `variations/attention_variations.py` and select it automatically when `config.softmax_variant_attn == "relu2max"`, the FlexAttention API is present, and semantics are supported (GPU, zero dropout, no sliding windows/FIRE/QK scaling/logit soft-capping/quantized attention); fall back to existing eager or flash paths otherwise.
- Add configuration controls: `use_fused_relu2max` in `gpt_conf.py` and `--use_fused_relu2max`/`--no-use_fused_relu2max` CLI arg in `train_args.py` for benchmarking and opt-out.
- Add `tests/test_relu2max_attention.py` with unit tests for the score modifier math, sequence-length scaling, and invalid-divisor validation, and add `docs/relu2max_attention.md` documenting behavior, fallback rules, and recommended benchmark methodology.

### Testing

- Ran Python syntax checks via `python -m py_compile` on `variations/relu2max_attention.py`, `variations/attention_variations.py`, `gpt_conf.py`, `train_args.py`, and `tests/test_relu2max_attention.py`, and they succeeded.
- Ran lightweight static checks (`git diff --check` equivalent) with no issues reported.
- Executed `python -m pytest -q tests/test_relu2max_attention.py`, but test collection failed due to the environment missing PyTorch (`ModuleNotFoundError: No module named 'torch'`), so the unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a3f5d7d208326a81ba7813e0d851f)