### PR TITLE
Add optional per-token loss and vocabulary coverage reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,28 @@ files from one export directory. The page sorts snapshots by the iteration in
 their filenames and provides previous/next/play controls plus a slider to step
 from the first validation export to the last.
 
+### Per-token loss and vocabulary coverage
+
+Pass `--log_per_token_metrics` to produce a report after every validation in
+`<out_dir>/per_token_metrics` (or set `--per_token_metrics_dir`). The report is
+kept out of TensorBoard and contains:
+
+* `per_token_metrics.csv`: one row per vocabulary token and evaluation, with
+  sampled train/validation cross-entropy, evaluation sample counts, and the
+  cumulative number of times that target token was used by training;
+* `per_token_summary.csv`: mean, median, standard deviation, skew, excess
+  kurtosis, percentiles, range, coefficient of variation, and vocabulary
+  coverage for each metric; and
+* `per_token_metrics.html`: an interactive Plotly scatter plot ordered from
+  highest to lowest validation loss. The training occurrence trace uses the
+  right-hand axis and starts hidden; select it in the legend to compare token
+  exposure without overwhelming the loss scale.
+
+Per-token loss is always ordinary next-token cross-entropy, making reports
+comparable even when a custom aggregate training loss is selected. Only tokens
+sampled during evaluation have a loss value; the accompanying sample-count
+columns make sparse or unrepresentative validation estimates visible.
+
 ## TODO Section:
 
 TODO: Add links and descriptions to other Readme's and Demos.

--- a/tests/test_per_token_metrics.py
+++ b/tests/test_per_token_metrics.py
@@ -1,0 +1,33 @@
+import csv
+import math
+
+import torch
+
+from utils.per_token_metrics import PerTokenMetrics
+
+
+def test_per_token_metrics_exports_counts_losses_summaries_and_plot(tmp_path):
+    tracker = PerTokenMetrics(tmp_path, {"tiny": 3})
+    tracker.count_training_batch("tiny", torch.tensor([[0, 1, 1, 2]]))
+    tracker.begin_evaluation()
+    targets = torch.tensor([[0, 1, 1]])
+    logits = torch.tensor([[[3.0, 0.0, 0.0], [0.0, 3.0, 0.0], [0.0, 0.0, 3.0]]])
+    tracker.add_evaluation_batch("tiny", "train", logits, targets)
+    tracker.add_evaluation_batch("tiny", "val", logits, targets)
+    tracker.export(10)
+
+    with open(tracker.detail_path, newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    assert [int(row["training_seen_count"]) for row in rows] == [1, 2, 1]
+    assert math.isclose(float(rows[0]["val_loss"]), 0.0949229, rel_tol=1e-5)
+    assert int(rows[1]["val_eval_count"]) == 2
+
+    with open(tracker.summary_path, newline="", encoding="utf-8") as handle:
+        summaries = list(csv.DictReader(handle))
+    assert {row["metric"] for row in summaries} == {
+        "train_loss", "val_loss", "training_seen_count"
+    }
+    assert "skew" in summaries[0] and "excess_kurtosis" in summaries[0]
+    html = tracker.plot_path.read_text(encoding="utf-8")
+    assert "validation loss" in html
+    assert "times seen in training" in html

--- a/tests/test_per_token_metrics.py
+++ b/tests/test_per_token_metrics.py
@@ -1,7 +1,12 @@
 import csv
+import json
 import math
+from pathlib import Path
 
+import numpy as np
 import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
 
 from utils.per_token_metrics import PerTokenMetrics
 
@@ -28,6 +33,59 @@ def test_per_token_metrics_exports_counts_losses_summaries_and_plot(tmp_path):
         "train_loss", "val_loss", "training_seen_count"
     }
     assert "skew" in summaries[0] and "excess_kurtosis" in summaries[0]
-    html = tracker.plot_path.read_text(encoding="utf-8")
+    html = Path(tracker.plot_path).read_text(encoding="utf-8")
     assert "validation loss" in html
     assert "times seen in training" in html
+
+    coverage = next(row for row in summaries if row["metric"] == "training_seen_count")
+    assert int(coverage["populated_tokens"]) == 3
+
+
+def test_training_coverage_counts_only_observed_tokens(tmp_path):
+    tracker = PerTokenMetrics(tmp_path, {"tiny": 5})
+    tracker.count_training_batch("tiny", torch.tensor([0, 0, 3]))
+    tracker.export(1)
+
+    with open(tracker.summary_path, newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    coverage = next(row for row in rows if row["metric"] == "training_seen_count")
+    assert int(coverage["populated_tokens"]) == 2
+
+
+def test_resume_restores_and_extends_cumulative_counts(tmp_path):
+    first = PerTokenMetrics(tmp_path / "first", {"tiny": 3})
+    first.count_training_batch("tiny", torch.tensor([0, 1, 1]))
+    first.synchronize_training_counts()
+
+    resumed = PerTokenMetrics(
+        tmp_path / "resumed", {"tiny": 3}, initial_seen=first.state_dict()
+    )
+    resumed.count_training_batch("tiny", torch.tensor([1, 2]))
+    resumed.synchronize_training_counts()
+    np.testing.assert_array_equal(resumed.seen["tiny"], [1, 3, 1])
+
+
+def _distributed_count_worker(rank, world_size, init_file, output_dir):
+    dist.init_process_group(
+        "gloo", rank=rank, world_size=world_size, init_method=f"file://{init_file}"
+    )
+    tracker = PerTokenMetrics(Path(output_dir) / f"rank-{rank}", {"tiny": 4})
+    tracker.count_training_batch("tiny", torch.tensor([rank, rank, 3]))
+    tracker.synchronize_training_counts(distributed=True)
+    Path(output_dir, f"counts-{rank}.json").write_text(
+        json.dumps(tracker.seen["tiny"].tolist()), encoding="utf-8"
+    )
+    dist.destroy_process_group()
+
+
+def test_distributed_counts_are_aggregated_on_every_rank(tmp_path):
+    init_file = tmp_path / "dist-init"
+    mp.spawn(
+        _distributed_count_worker,
+        args=(2, str(init_file), str(tmp_path)),
+        nprocs=2,
+        join=True,
+    )
+    for rank in range(2):
+        counts = json.loads((tmp_path / f"counts-{rank}.json").read_text(encoding="utf-8"))
+        assert counts == [2, 2, 0, 2]

--- a/train.py
+++ b/train.py
@@ -314,6 +314,7 @@ class Trainer:
         self.model_args = {action.dest: getattr(self.args, action.dest) for action in self.model_group._group_actions}
         self.model_args['vocab_size'] = None
         self.model_args['eval_interval'] = self.args.eval_interval
+        self.vocab_size_by_dataset = self._initialize_vocab_sizes()
 
         # Training settings
         self.training_args = {action.dest: getattr(self.args, action.dest) for action in self.training_group._group_actions}
@@ -323,7 +324,7 @@ class Trainer:
             print(self.model_args['lsv_dataset_num'])
 
         if self.args.init_from == 'scratch':
-            self.model_args['vocab_size'] = self.get_vocab_size_from_meta()
+            self.model_args['vocab_size'] = self.vocab_size_by_dataset[self.args.dataset]
 
             # Save full configuration used for training
             config_json = {**self.model_args, **self.training_args}
@@ -374,6 +375,7 @@ class Trainer:
                 ckpt_path = os.path.join(self.args.out_dir, self.args.init_from_ckpt)
                 checkpoint = torch.load(ckpt_path, map_location=self.device)
                 self.iter_num = checkpoint['iter_num']
+                self._per_token_metrics_state = checkpoint.get('per_token_metrics_seen')
             else:
                 ckpt_path = os.path.join(self.args.prev_run_ckpt, self.args.init_from_ckpt)
                 checkpoint = torch.load(ckpt_path, map_location=self.device)
@@ -523,15 +525,13 @@ class Trainer:
         self.load_tokenizer()
         self.per_token_metrics = None
         if self.args.log_per_token_metrics:
-            if self.args.training_mode == 'multicontext':
-                sizes = dict(zip(self.args.multicontext_datasets, self.vocab_sizes))
-            elif self.args.dataset_list:
-                sizes = dict(zip(self.args.dataset_list, self.vocab_sizes))
-            else:
-                sizes = {self.args.dataset: int(self.model_args['vocab_size'])}
             report_dir = (self.args.per_token_metrics_dir
                           or os.path.join(self.args.out_dir, 'per_token_metrics'))
-            self.per_token_metrics = PerTokenMetrics(report_dir, sizes)
+            self.per_token_metrics = PerTokenMetrics(
+                report_dir,
+                self.vocab_size_by_dataset,
+                initial_seen=getattr(self, '_per_token_metrics_state', None),
+            )
 
 
     def _initialize_teacher_if_needed(self):
@@ -780,6 +780,36 @@ class Trainer:
                     sys.exit(f"Error: 'vocab_size' key not found in {meta_path}")
         else:
             sys.exit(f"Error: File not found - {meta_path}")
+
+    def _initialize_vocab_sizes(self):
+        """Read authoritative dataset vocabularies before any data is loaded."""
+        if self.args.training_mode == 'multicontext':
+            datasets = self.args.multicontext_datasets
+            if not datasets:
+                sys.exit("Error: When training_mode is 'multicontext', please provide --multicontext_datasets.")
+        elif self.args.training_mode == 'multidataset':
+            datasets = self.args.dataset_list
+            if not datasets:
+                sys.exit("Error: When training_mode is 'multidataset', please provide --dataset_list.")
+        else:
+            datasets = [self.args.dataset]
+
+        sizes = {}
+        for dataset in datasets:
+            meta_path = os.path.join('data', dataset, 'meta.pkl')
+            if not os.path.exists(meta_path):
+                sys.exit(f"Error: Meta file not found at {meta_path}")
+            with open(meta_path, 'rb') as handle:
+                vocab_size = pickle.load(handle).get('vocab_size')
+            if vocab_size is None:
+                sys.exit(f"Error: 'vocab_size' key not found in {meta_path}")
+            sizes[dataset] = int(vocab_size)
+
+        if self.args.training_mode == 'multicontext':
+            self.vocab_sizes = dict(sizes)
+        elif self.args.training_mode == 'multidataset':
+            self.vocab_sizes = [sizes[dataset] for dataset in datasets]
+        return sizes
 
     def copy_file_to_directory(self, src_file, dest_dir):
         try:
@@ -2131,6 +2161,10 @@ class Trainer:
                 'best_iter': self.best_iter,
                 'best_tokens': self.best_tokens,
                 'config': vars(self.args),
+                'per_token_metrics_seen': (
+                    self.per_token_metrics.state_dict()
+                    if self.per_token_metrics is not None else None
+                ),
                 }
         torch.save(checkpoint, os.path.join(self.args.out_dir, filename))
 
@@ -2493,6 +2527,10 @@ class Trainer:
                 for param_group in self.optimizer.param_groups:
                     param_group['lr'] = self.lr
 
+                if self.iter_num % self.args.eval_interval == 0:
+                    if self.per_token_metrics is not None:
+                        self.per_token_metrics.synchronize_training_counts(distributed=self.ddp)
+
                 if self.iter_num % self.args.eval_interval == 0 and self.master_process:
 
                     losses, num_steps_with_worse_loss = self.run_validation_step(
@@ -2697,8 +2735,10 @@ class Trainer:
                 if stop_reasons:
                     print(f"Stopping training due to: {', '.join(stop_reasons)}")
                     print(self.best_val_loss, self.best_iter, self.best_tokens)
+                    if self.per_token_metrics is not None:
+                        self.per_token_metrics.synchronize_training_counts(distributed=self.ddp)
                     if self.args.only_save_checkpoint_at_end:
-                        if not self.args.never_save_checkpoint:
+                        if self.master_process and not self.args.never_save_checkpoint:
                             self.save_checkpoint('ckpt.pt')
                             print(f"Saved checkpoint to {self.args.out_dir}")
 

--- a/train.py
+++ b/train.py
@@ -70,6 +70,7 @@ from utils.model_stats import (
     compute_activation_stats,
     print_model_stats_table,
 )
+from utils.per_token_metrics import PerTokenMetrics
 
 from sample import (
     sample_with_existing_model,
@@ -520,6 +521,17 @@ class Trainer:
             self.args.csv_name = wandb_run_name
             wandb.init(project=self.args.wandb_project, name=self.args.wandb_run_name, config=self.args)
         self.load_tokenizer()
+        self.per_token_metrics = None
+        if self.args.log_per_token_metrics:
+            if self.args.training_mode == 'multicontext':
+                sizes = dict(zip(self.args.multicontext_datasets, self.vocab_sizes))
+            elif self.args.dataset_list:
+                sizes = dict(zip(self.args.dataset_list, self.vocab_sizes))
+            else:
+                sizes = {self.args.dataset: int(self.model_args['vocab_size'])}
+            report_dir = (self.args.per_token_metrics_dir
+                          or os.path.join(self.args.out_dir, 'per_token_metrics'))
+            self.per_token_metrics = PerTokenMetrics(report_dir, sizes)
 
 
     def _initialize_teacher_if_needed(self):
@@ -1098,6 +1110,8 @@ class Trainer:
     @torch.no_grad()
     def estimate_loss(self):
         out = {'datasets':{}}
+        if self.per_token_metrics is not None:
+            self.per_token_metrics.begin_evaluation()
         compute_rankme = self.args.log_rankme or self.args.log_areq
 
         self.model.eval()
@@ -1126,6 +1140,8 @@ class Trainer:
                                 dataset_idx=idx if self.args.multidataset_wte else None,
                                 loss_fn=self.loss_fn,
                             )
+                        if self.per_token_metrics is not None:
+                            self.per_token_metrics.add_evaluation_batch(dataset, split, logits, Y)
                         handle.remove()
                         dataset_losses[split][k] = loss.item()
                         if split == 'val':
@@ -1272,6 +1288,11 @@ class Trainer:
                             iter_num=self.iter_num,
                             loss_fn=self.loss_fn,
                         )
+                    if self.per_token_metrics is not None:
+                        for i, dataset in enumerate(self.args.multicontext_datasets):
+                            self.per_token_metrics.add_evaluation_batch(
+                                dataset, split, logits[i], y_dict[dataset]
+                            )
                     if handle is not None:
                         handle.remove()
                     for i in range(len(self.args.multicontext_datasets)):
@@ -1393,6 +1414,10 @@ class Trainer:
                             dataset_idx=0 if self.args.multidataset_wte else None,
                             loss_fn=self.loss_fn,
                         )
+                    if self.per_token_metrics is not None:
+                        self.per_token_metrics.add_evaluation_batch(
+                            self.args.dataset, split, logits, Y
+                        )
                     handle.remove()
                     losses[k] = loss.item()
                     if split == 'val':
@@ -1513,6 +1538,8 @@ class Trainer:
                             self.iter_num,
                             )
 
+        if self.per_token_metrics is not None:
+            self.per_token_metrics.export(self.iter_num)
         self.model.train()
         return out
 
@@ -2502,6 +2529,11 @@ class Trainer:
                             # For multicontext training let loss = first dataset loss
                             # loss = training_losses[0]
                             loss = sum(training_losses) / len(training_losses)
+                            if self.per_token_metrics is not None:
+                                for dataset in self.args.multicontext_datasets:
+                                    self.per_token_metrics.count_training_batch(
+                                        dataset, self.Y_dict[dataset]
+                                    )
                         else:
                             idx_ds = self.args.dataset_list.index(current_dataset) if self.args.dataset_list else None
                             logits, loss = self.model(
@@ -2511,6 +2543,10 @@ class Trainer:
                                 dataset_idx=idx_ds if self.args.multidataset_wte else None,
                                 loss_fn=self.loss_fn,
                             )
+                            if self.per_token_metrics is not None:
+                                self.per_token_metrics.count_training_batch(
+                                    current_dataset, self.Y
+                                )
 
                     if hasattr(self.optimizer, "set_entropy") and not isinstance(logits, (list, tuple)):
                         with torch.no_grad():

--- a/train_args.py
+++ b/train_args.py
@@ -1512,6 +1512,11 @@ def parse_args():
     logging_group.add_argument('--csv_log', default=True, action=argparse.BooleanOptionalAction)
     logging_group.add_argument('--csv_dir', default='csv_logs', type=str)
     logging_group.add_argument('--csv_name', default='output', type=str, help="Output csv basename. Note, the .csv will be automatically appended.")
+    logging_group.add_argument('--log_per_token_metrics', default=False,
+                               action=argparse.BooleanOptionalAction,
+                               help='Write per-token train/validation loss, training occurrence counts, summaries, and an interactive Plotly HTML file at each evaluation (never sent to TensorBoard).')
+    logging_group.add_argument('--per_token_metrics_dir', default=None, type=str,
+                               help='Per-token report directory (default: <out_dir>/per_token_metrics).')
     logging_group.add_argument('--zeus_log', default=False, action=argparse.BooleanOptionalAction, help='Enable Zeus GPU energy logging during training')
     logging_group.add_argument('--zeus_log_file', type=str, default=None, help='Optional Zeus monitor log file path')
     logging_group.add_argument('--zeus_approx_instant_energy', default=True, action=argparse.BooleanOptionalAction, help='Use Zeus instant-power fallback for short measurement windows')

--- a/utils/per_token_metrics.py
+++ b/utils/per_token_metrics.py
@@ -1,0 +1,139 @@
+"""Per-token loss/count reporting kept deliberately separate from TensorBoard."""
+
+import csv
+import json
+import math
+import os
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+
+class PerTokenMetrics:
+    """Accumulate training-token exposure and export evaluation snapshots."""
+
+    DETAIL_FIELDS = (
+        "iteration", "dataset", "token_id", "train_loss", "train_eval_count",
+        "val_loss", "val_eval_count", "training_seen_count",
+    )
+
+    def __init__(self, output_dir, vocab_sizes):
+        self.output_dir = output_dir
+        self.vocab_sizes = dict(vocab_sizes)
+        self.seen = {
+            name: np.zeros(size, dtype=np.int64) for name, size in self.vocab_sizes.items()
+        }
+        self.pending = {}
+        os.makedirs(output_dir, exist_ok=True)
+        self.detail_path = os.path.join(output_dir, "per_token_metrics.csv")
+        self.summary_path = os.path.join(output_dir, "per_token_summary.csv")
+        self.plot_path = os.path.join(output_dir, "per_token_metrics.html")
+
+    def count_training_batch(self, dataset, targets):
+        values = targets.detach().reshape(-1).to("cpu", dtype=torch.long)
+        counts = torch.bincount(values, minlength=self.vocab_sizes[dataset]).numpy()
+        self.seen[dataset] += counts[: self.vocab_sizes[dataset]]
+
+    def begin_evaluation(self):
+        self.pending = {}
+
+    def add_evaluation_batch(self, dataset, split, logits, targets):
+        """Aggregate ordinary next-token cross entropy, independent of training loss variants."""
+        vocab_size = self.vocab_sizes[dataset]
+        losses = F.cross_entropy(
+            logits.detach().float().reshape(-1, logits.size(-1)),
+            targets.detach().reshape(-1), reduction="none",
+        ).cpu()
+        ids = targets.detach().reshape(-1).to("cpu", dtype=torch.long)
+        key = (dataset, split)
+        if key not in self.pending:
+            self.pending[key] = (
+                torch.zeros(vocab_size, dtype=torch.float64),
+                torch.zeros(vocab_size, dtype=torch.int64),
+            )
+        sums, counts = self.pending[key]
+        sums.scatter_add_(0, ids, losses.to(torch.float64))
+        counts += torch.bincount(ids, minlength=vocab_size)[:vocab_size]
+
+    @staticmethod
+    def _summary(values):
+        values = np.asarray(values, dtype=np.float64)
+        values = values[np.isfinite(values)]
+        if not values.size:
+            return {key: math.nan for key in ("mean", "median", "std", "skew", "excess_kurtosis", "min", "max", "p10", "p90", "coefficient_of_variation")}
+        mean, std = values.mean(), values.std()
+        centered = values - mean
+        skew = np.mean(centered ** 3) / std ** 3 if std else 0.0
+        kurtosis = np.mean(centered ** 4) / std ** 4 - 3 if std else 0.0
+        return {
+            "mean": mean, "median": np.median(values), "std": std, "skew": skew,
+            "excess_kurtosis": kurtosis, "min": values.min(), "max": values.max(),
+            "p10": np.percentile(values, 10), "p90": np.percentile(values, 90),
+            "coefficient_of_variation": std / mean if mean else math.nan,
+        }
+
+    def export(self, iteration):
+        rows, summaries = [], []
+        for dataset, vocab_size in self.vocab_sizes.items():
+            split_data = {}
+            for split in ("train", "val"):
+                sums, counts = self.pending.get(
+                    (dataset, split),
+                    (torch.zeros(vocab_size), torch.zeros(vocab_size, dtype=torch.long)),
+                )
+                sums, counts = sums.numpy(), counts.numpy()
+                split_data[split] = np.divide(
+                    sums, counts, out=np.full(vocab_size, np.nan), where=counts != 0
+                )
+                split_data[split + "_count"] = counts
+            for token_id in range(vocab_size):
+                rows.append({
+                    "iteration": iteration, "dataset": dataset, "token_id": token_id,
+                    "train_loss": float(split_data["train"][token_id]),
+                    "train_eval_count": int(split_data["train_count"][token_id]),
+                    "val_loss": float(split_data["val"][token_id]),
+                    "val_eval_count": int(split_data["val_count"][token_id]),
+                    "training_seen_count": int(self.seen[dataset][token_id]),
+                })
+            for metric, values in (
+                ("train_loss", split_data["train"]), ("val_loss", split_data["val"]),
+                ("training_seen_count", self.seen[dataset]),
+            ):
+                summary = self._summary(values)
+                summary.update(iteration=iteration, dataset=dataset, metric=metric,
+                               populated_tokens=int(np.isfinite(values).sum()), vocab_size=vocab_size)
+                summaries.append(summary)
+        self._append_csv(self.detail_path, rows, self.DETAIL_FIELDS)
+        summary_fields = ("iteration", "dataset", "metric", "populated_tokens", "vocab_size",
+                          "mean", "median", "std", "skew", "excess_kurtosis", "min", "max",
+                          "p10", "p90", "coefficient_of_variation")
+        self._append_csv(self.summary_path, summaries, summary_fields)
+        self._write_plot(rows, iteration)
+
+    @staticmethod
+    def _append_csv(path, rows, fields):
+        new_file = not os.path.exists(path) or os.path.getsize(path) == 0
+        with open(path, "a", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=fields)
+            if new_file:
+                writer.writeheader()
+            writer.writerows(rows)
+
+    def _write_plot(self, latest_rows, iteration):
+        """Write a self-contained data page; Plotly itself loads from its official CDN."""
+        payload = json.dumps(latest_rows, allow_nan=True)
+        html = """<!doctype html><meta charset='utf-8'><title>Per-token metrics</title>
+<script src='https://cdn.plot.ly/plotly-2.35.2.min.js'></script>
+<h1>Per-token validation loss and training exposure</h1><label>Dataset: <select id='dataset'></select></label>
+<div id='plot' style='height:75vh'></div><script>
+const rows=PAYLOAD, sel=document.getElementById('dataset');
+[...new Set(rows.map(r=>r.dataset))].forEach(x=>sel.add(new Option(x,x)));
+function draw(){const d=rows.filter(r=>r.dataset===sel.value && Number.isFinite(r.val_loss)).sort((a,b)=>b.val_loss-a.val_loss);
+ const labels=d.map(r=>'token '+r.token_id), hover=d.map(r=>`token=${r.token_id}<br>train loss=${r.train_loss}<br>val samples=${r.val_eval_count}`);
+ Plotly.newPlot('plot',[{x:labels,y:d.map(r=>r.val_loss),name:'validation loss',mode:'markers',text:hover,hovertemplate:'%{text}<br>val loss=%{y}<extra></extra>'},
+ {x:labels,y:d.map(r=>r.training_seen_count),name:'times seen in training',mode:'markers',yaxis:'y2',visible:'legendonly'}],
+ {title:'Evaluation iteration ITERATION (ordered highest to lowest validation loss)',xaxis:{title:'token (validation-loss order)'},yaxis:{title:'validation loss'},yaxis2:{title:'training occurrences',overlaying:'y',side:'right',rangemode:'tozero'},legend:{orientation:'h'}});}
+sel.onchange=draw; draw();</script>""".replace("PAYLOAD", payload).replace("ITERATION", str(iteration))
+        with open(self.plot_path, "w", encoding="utf-8") as handle:
+            handle.write(html)

--- a/utils/per_token_metrics.py
+++ b/utils/per_token_metrics.py
@@ -8,6 +8,7 @@ import os
 import numpy as np
 import torch
 import torch.nn.functional as F
+import torch.distributed as dist
 
 
 class PerTokenMetrics:
@@ -18,12 +19,15 @@ class PerTokenMetrics:
         "val_loss", "val_eval_count", "training_seen_count",
     )
 
-    def __init__(self, output_dir, vocab_sizes):
+    def __init__(self, output_dir, vocab_sizes, initial_seen=None):
         self.output_dir = output_dir
         self.vocab_sizes = dict(vocab_sizes)
         self.seen = {
             name: np.zeros(size, dtype=np.int64) for name, size in self.vocab_sizes.items()
         }
+        self._local_seen = {}
+        if initial_seen:
+            self.load_state_dict(initial_seen)
         self.pending = {}
         os.makedirs(output_dir, exist_ok=True)
         self.detail_path = os.path.join(output_dir, "per_token_metrics.csv")
@@ -31,9 +35,60 @@ class PerTokenMetrics:
         self.plot_path = os.path.join(output_dir, "per_token_metrics.html")
 
     def count_training_batch(self, dataset, targets):
-        values = targets.detach().reshape(-1).to("cpu", dtype=torch.long)
-        counts = torch.bincount(values, minlength=self.vocab_sizes[dataset]).numpy()
-        self.seen[dataset] += counts[: self.vocab_sizes[dataset]]
+        """Accumulate on-device; defer the small count-vector transfer until evaluation."""
+        vocab_size = self.vocab_sizes[dataset]
+        values = targets.detach().reshape(-1).to(dtype=torch.long)
+        values = values[(values >= 0) & (values < vocab_size)]
+        counts = torch.bincount(values, minlength=vocab_size)[:vocab_size]
+        pending = self._local_seen.get(dataset)
+        if pending is None or pending.device != counts.device:
+            if pending is not None:
+                self.seen[dataset] += pending.cpu().numpy()
+            pending = torch.zeros(vocab_size, dtype=torch.int64, device=counts.device)
+            self._local_seen[dataset] = pending
+        pending.add_(counts)
+
+    def synchronize_training_counts(self, distributed=False):
+        """Flush rank-local deltas into cumulative CPU counts once per evaluation."""
+        if distributed:
+            if not dist.is_available() or not dist.is_initialized():
+                raise RuntimeError("distributed count synchronization requires an initialized process group")
+            backend = dist.get_backend()
+            default_device = (
+                torch.device("cuda", torch.cuda.current_device())
+                if backend == "nccl" else torch.device("cpu")
+            )
+            for dataset, vocab_size in self.vocab_sizes.items():
+                if dataset not in self._local_seen:
+                    self._local_seen[dataset] = torch.zeros(
+                        vocab_size, dtype=torch.int64, device=default_device
+                    )
+
+        for dataset in self.vocab_sizes:
+            pending = self._local_seen.get(dataset)
+            if pending is None:
+                continue
+            if distributed:
+                dist.all_reduce(pending, op=dist.ReduceOp.SUM)
+            self.seen[dataset] += pending.cpu().numpy()
+            pending.zero_()
+
+    def state_dict(self):
+        state = {dataset: counts.copy() for dataset, counts in self.seen.items()}
+        # Normal checkpoints follow a synchronized evaluation. This also makes an
+        # emergency single-rank checkpoint retain its currently buffered delta.
+        for dataset, pending in self._local_seen.items():
+            state[dataset] += pending.cpu().numpy()
+        return state
+
+    def load_state_dict(self, state):
+        for dataset, values in state.items():
+            if dataset not in self.seen:
+                continue
+            values = np.asarray(values, dtype=np.int64)
+            if values.shape != self.seen[dataset].shape:
+                raise ValueError(f"per-token count shape mismatch for {dataset}")
+            self.seen[dataset][...] = values
 
     def begin_evaluation(self):
         self.pending = {}
@@ -41,10 +96,18 @@ class PerTokenMetrics:
     def add_evaluation_batch(self, dataset, split, logits, targets):
         """Aggregate ordinary next-token cross entropy, independent of training loss variants."""
         vocab_size = self.vocab_sizes[dataset]
-        losses = F.cross_entropy(
-            logits.detach().float().reshape(-1, logits.size(-1)),
-            targets.detach().reshape(-1), reduction="none",
-        ).cpu()
+        flat_logits = logits.detach().reshape(-1, logits.size(-1))
+        flat_targets = targets.detach().reshape(-1)
+        # Bound the temporary float32 allocation instead of copying all B*T*V logits.
+        rows_per_chunk = max(1, 8_000_000 // flat_logits.size(-1))
+        losses = torch.cat([
+            F.cross_entropy(
+                flat_logits[start:start + rows_per_chunk].float(),
+                flat_targets[start:start + rows_per_chunk],
+                reduction="none",
+            ).cpu()
+            for start in range(0, flat_logits.size(0), rows_per_chunk)
+        ])
         ids = targets.detach().reshape(-1).to("cpu", dtype=torch.long)
         key = (dataset, split)
         if key not in self.pending:
@@ -74,6 +137,7 @@ class PerTokenMetrics:
         }
 
     def export(self, iteration):
+        self.synchronize_training_counts(distributed=False)
         rows, summaries = [], []
         for dataset, vocab_size in self.vocab_sizes.items():
             split_data = {}
@@ -101,8 +165,13 @@ class PerTokenMetrics:
                 ("training_seen_count", self.seen[dataset]),
             ):
                 summary = self._summary(values)
+                populated = (
+                    np.count_nonzero(values)
+                    if metric == "training_seen_count"
+                    else np.isfinite(values).sum()
+                )
                 summary.update(iteration=iteration, dataset=dataset, metric=metric,
-                               populated_tokens=int(np.isfinite(values).sum()), vocab_size=vocab_size)
+                               populated_tokens=int(populated), vocab_size=vocab_size)
                 summaries.append(summary)
         self._append_csv(self.detail_path, rows, self.DETAIL_FIELDS)
         summary_fields = ("iteration", "dataset", "metric", "populated_tokens", "vocab_size",


### PR DESCRIPTION
### Motivation

- Provide an opt-in way to inspect per-vocabulary-token next-token cross-entropy and exposure without spamming TensorBoard with extremely high-cardinality metrics.
- Help diagnose tokenization/vocabulary issues by correlating per-token validation loss with how often tokens have been seen during training and expose distributional summary stats like skew and kurtosis.

### Description

- Add a new helper `PerTokenMetrics` in `utils/per_token_metrics.py` that accumulates per-token training exposure, aggregates per-evaluation sampled next-token cross-entropy, computes distribution summaries (mean, median, std, skew, excess kurtosis, percentiles, CV), and writes append-only CSVs plus an interactive Plotly HTML page.
- Add CLI flags in `train_args.py`: `--log_per_token_metrics` and `--per_token_metrics_dir` to enable/locate reports, and document behavior in `README.md` (exports `per_token_metrics.csv`, `per_token_summary.csv`, and `per_token_metrics.html`).
- Integrate collection into `Trainer`: start an evaluation snapshot with `begin_evaluation()`, record per-eval losses in `estimate_loss()` for single-dataset, `multidataset`, and `multicontext` flows, and increment cumulative token exposure during training batches via `count_training_batch()`; export a snapshot after each validation via `PerTokenMetrics.export()`.
- Add a focused unit test `tests/test_per_token_metrics.py` validating CSV outputs, summary fields, and HTML content (test exercises `PerTokenMetrics` logic independent of trainer wiring).

### Testing

- Successfully byte-compiled relevant modules with `python -m py_compile train.py train_args.py utils/per_token_metrics.py tests/test_per_token_metrics.py`.
- Ran repository checks with `git diff --check` and ensured no diff warnings remain.
- Executed `pytest` on the new test, but collection failed because the execution environment lacks `torch` (`ModuleNotFoundError: No module named 'torch'`), so the test logic itself was not able to run end-to-end in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ee2023ac88326a9107fbb21f0acd0)