### PR TITLE
Add per-token loss and training-coverage reporting with exports, CLI flags, and Trainer hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,9 @@ kept out of TensorBoard and contains:
   Plotly scatter plots. The first is ordered from highest to lowest validation
   loss, while the second is ordered from lowest to highest training occurrence.
   Both show escaped token text next to the token ID and provide independently
-  selectable loss and occurrence traces on separate axes.
+  selectable loss and occurrence traces on separate axes. A multi-select token
+  picker also drives two historical graphs: sampled train/validation loss
+  versus evaluation iteration and versus cumulative training appearances.
 
 Per-token loss is always ordinary next-token cross-entropy, making reports
 comparable even when a custom aggregate training loss is selected. Only tokens

--- a/README.md
+++ b/README.md
@@ -304,6 +304,30 @@ files from one export directory. The page sorts snapshots by the iteration in
 their filenames and provides previous/next/play controls plus a slider to step
 from the first validation export to the last.
 
+### Per-token loss and vocabulary coverage
+
+Pass `--log_per_token_metrics` to produce a report after every validation in
+`<out_dir>/per_token_metrics` (or set `--per_token_metrics_dir`). The report is
+kept out of TensorBoard and contains:
+
+* `per_token_metrics.csv`: one row per vocabulary token and evaluation, with
+  its escaped decoded text (for example, `\\n`), sampled train/validation
+  cross-entropy, evaluation sample counts, and the cumulative number of times
+  that target token was used by training;
+* `per_token_summary.csv`: mean, median, standard deviation, skew, excess
+  kurtosis, percentiles, range, coefficient of variation, and vocabulary
+  coverage for each metric; and
+* `per_token_metrics.html`: an interactive summary-statistics table and two
+  Plotly scatter plots. The first is ordered from highest to lowest validation
+  loss, while the second is ordered from lowest to highest training occurrence.
+  Both show escaped token text next to the token ID and provide independently
+  selectable loss and occurrence traces on separate axes.
+
+Per-token loss is always ordinary next-token cross-entropy, making reports
+comparable even when a custom aggregate training loss is selected. Only tokens
+sampled during evaluation have a loss value; the accompanying sample-count
+columns make sparse or unrepresentative validation estimates visible.
+
 ## TODO Section:
 
 TODO: Add links and descriptions to other Readme's and Demos.

--- a/tests/test_per_token_metrics.py
+++ b/tests/test_per_token_metrics.py
@@ -17,11 +17,16 @@ def test_per_token_metrics_exports_counts_losses_summaries_and_plot(tmp_path):
     tracker.add_evaluation_batch("tiny", "train", logits, targets)
     tracker.add_evaluation_batch("tiny", "val", logits, targets)
     tracker.export(10)
+    tracker.begin_evaluation()
+    tracker.add_evaluation_batch("tiny", "train", logits, targets)
+    tracker.add_evaluation_batch("tiny", "val", logits, targets)
+    tracker.export(20)
 
     with open(tracker.detail_path, newline="", encoding="utf-8") as handle:
         rows = list(csv.DictReader(handle))
-    assert [int(row["training_seen_count"]) for row in rows] == [1, 2, 1]
-    assert [row["token_text_escaped"] for row in rows] == ["\\n", "a", "\\t"]
+    assert len(rows) == 6
+    assert [int(row["training_seen_count"]) for row in rows[:3]] == [1, 2, 1]
+    assert [row["token_text_escaped"] for row in rows[:3]] == ["\\n", "a", "\\t"]
     assert math.isclose(float(rows[0]["val_loss"]), 0.0949229, rel_tol=1e-5)
     assert int(rows[1]["val_eval_count"]) == 2
 
@@ -37,3 +42,6 @@ def test_per_token_metrics_exports_counts_losses_summaries_and_plot(tmp_path):
     assert "Summary statistics" in html
     assert "ordered lowest to highest training occurrence" in html
     assert "token_text_escaped" in html
+    assert "Selected-token loss vs iteration" in html
+    assert "Selected-token loss vs cumulative appearances" in html
+    assert "multiple" in html

--- a/tests/test_per_token_metrics.py
+++ b/tests/test_per_token_metrics.py
@@ -1,0 +1,39 @@
+import csv
+import math
+
+import torch
+
+from utils.per_token_metrics import PerTokenMetrics
+
+
+def test_per_token_metrics_exports_counts_losses_summaries_and_plot(tmp_path):
+    tracker = PerTokenMetrics(
+        tmp_path, {"tiny": 3}, {"tiny": {0: "\\n", 1: "a", 2: "\\t"}}
+    )
+    tracker.count_training_batch("tiny", torch.tensor([[0, 1, 1, 2]]))
+    tracker.begin_evaluation()
+    targets = torch.tensor([[0, 1, 1]])
+    logits = torch.tensor([[[3.0, 0.0, 0.0], [0.0, 3.0, 0.0], [0.0, 0.0, 3.0]]])
+    tracker.add_evaluation_batch("tiny", "train", logits, targets)
+    tracker.add_evaluation_batch("tiny", "val", logits, targets)
+    tracker.export(10)
+
+    with open(tracker.detail_path, newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    assert [int(row["training_seen_count"]) for row in rows] == [1, 2, 1]
+    assert [row["token_text_escaped"] for row in rows] == ["\\n", "a", "\\t"]
+    assert math.isclose(float(rows[0]["val_loss"]), 0.0949229, rel_tol=1e-5)
+    assert int(rows[1]["val_eval_count"]) == 2
+
+    with open(tracker.summary_path, newline="", encoding="utf-8") as handle:
+        summaries = list(csv.DictReader(handle))
+    assert {row["metric"] for row in summaries} == {
+        "train_loss", "val_loss", "training_seen_count"
+    }
+    assert "skew" in summaries[0] and "excess_kurtosis" in summaries[0]
+    html = tracker.plot_path.read_text(encoding="utf-8")
+    assert "validation loss" in html
+    assert "times seen in training" in html
+    assert "Summary statistics" in html
+    assert "ordered lowest to highest training occurrence" in html
+    assert "token_text_escaped" in html

--- a/train.py
+++ b/train.py
@@ -70,6 +70,7 @@ from utils.model_stats import (
     compute_activation_stats,
     print_model_stats_table,
 )
+from utils.per_token_metrics import PerTokenMetrics
 
 from sample import (
     sample_with_existing_model,
@@ -520,6 +521,31 @@ class Trainer:
             self.args.csv_name = wandb_run_name
             wandb.init(project=self.args.wandb_project, name=self.args.wandb_run_name, config=self.args)
         self.load_tokenizer()
+        self.per_token_metrics = None
+        if self.args.log_per_token_metrics:
+            if self.args.training_mode == 'multicontext':
+                sizes = dict(zip(self.args.multicontext_datasets, self.vocab_sizes))
+            elif self.args.dataset_list:
+                sizes = dict(zip(self.args.dataset_list, self.vocab_sizes))
+            else:
+                sizes = {self.args.dataset: int(self.model_args['vocab_size'])}
+            report_dir = (self.args.per_token_metrics_dir
+                          or os.path.join(self.args.out_dir, 'per_token_metrics'))
+            token_texts = {}
+            for dataset, vocab_size in sizes.items():
+                decode = (self.decode_dict.get(dataset, self.decode)
+                          if hasattr(self, 'decode_dict') else self.decode)
+                rendered = {}
+                for token_id in range(vocab_size):
+                    try:
+                        token_text = decode([token_id])
+                    except (KeyError, IndexError, TypeError, ValueError):
+                        token_text = ''
+                    rendered[token_id] = json.dumps(
+                        token_text, ensure_ascii=False
+                    )[1:-1]
+                token_texts[dataset] = rendered
+            self.per_token_metrics = PerTokenMetrics(report_dir, sizes, token_texts)
 
 
     def _initialize_teacher_if_needed(self):
@@ -1098,6 +1124,8 @@ class Trainer:
     @torch.no_grad()
     def estimate_loss(self):
         out = {'datasets':{}}
+        if self.per_token_metrics is not None:
+            self.per_token_metrics.begin_evaluation()
         compute_rankme = self.args.log_rankme or self.args.log_areq
 
         self.model.eval()
@@ -1126,6 +1154,8 @@ class Trainer:
                                 dataset_idx=idx if self.args.multidataset_wte else None,
                                 loss_fn=self.loss_fn,
                             )
+                        if self.per_token_metrics is not None:
+                            self.per_token_metrics.add_evaluation_batch(dataset, split, logits, Y)
                         handle.remove()
                         dataset_losses[split][k] = loss.item()
                         if split == 'val':
@@ -1272,6 +1302,11 @@ class Trainer:
                             iter_num=self.iter_num,
                             loss_fn=self.loss_fn,
                         )
+                    if self.per_token_metrics is not None:
+                        for i, dataset in enumerate(self.args.multicontext_datasets):
+                            self.per_token_metrics.add_evaluation_batch(
+                                dataset, split, logits[i], y_dict[dataset]
+                            )
                     if handle is not None:
                         handle.remove()
                     for i in range(len(self.args.multicontext_datasets)):
@@ -1393,6 +1428,10 @@ class Trainer:
                             dataset_idx=0 if self.args.multidataset_wte else None,
                             loss_fn=self.loss_fn,
                         )
+                    if self.per_token_metrics is not None:
+                        self.per_token_metrics.add_evaluation_batch(
+                            self.args.dataset, split, logits, Y
+                        )
                     handle.remove()
                     losses[k] = loss.item()
                     if split == 'val':
@@ -1513,6 +1552,8 @@ class Trainer:
                             self.iter_num,
                             )
 
+        if self.per_token_metrics is not None:
+            self.per_token_metrics.export(self.iter_num)
         self.model.train()
         return out
 
@@ -2502,6 +2543,11 @@ class Trainer:
                             # For multicontext training let loss = first dataset loss
                             # loss = training_losses[0]
                             loss = sum(training_losses) / len(training_losses)
+                            if self.per_token_metrics is not None:
+                                for dataset in self.args.multicontext_datasets:
+                                    self.per_token_metrics.count_training_batch(
+                                        dataset, self.Y_dict[dataset]
+                                    )
                         else:
                             idx_ds = self.args.dataset_list.index(current_dataset) if self.args.dataset_list else None
                             logits, loss = self.model(
@@ -2511,6 +2557,10 @@ class Trainer:
                                 dataset_idx=idx_ds if self.args.multidataset_wte else None,
                                 loss_fn=self.loss_fn,
                             )
+                            if self.per_token_metrics is not None:
+                                self.per_token_metrics.count_training_batch(
+                                    current_dataset, self.Y
+                                )
 
                     if hasattr(self.optimizer, "set_entropy") and not isinstance(logits, (list, tuple)):
                         with torch.no_grad():

--- a/train_args.py
+++ b/train_args.py
@@ -1512,6 +1512,11 @@ def parse_args():
     logging_group.add_argument('--csv_log', default=True, action=argparse.BooleanOptionalAction)
     logging_group.add_argument('--csv_dir', default='csv_logs', type=str)
     logging_group.add_argument('--csv_name', default='output', type=str, help="Output csv basename. Note, the .csv will be automatically appended.")
+    logging_group.add_argument('--log_per_token_metrics', default=False,
+                               action=argparse.BooleanOptionalAction,
+                               help='Write per-token train/validation loss, training occurrence counts, summaries, and an interactive Plotly HTML file at each evaluation (never sent to TensorBoard).')
+    logging_group.add_argument('--per_token_metrics_dir', default=None, type=str,
+                               help='Per-token report directory (default: <out_dir>/per_token_metrics).')
     logging_group.add_argument('--zeus_log', default=False, action=argparse.BooleanOptionalAction, help='Enable Zeus GPU energy logging during training')
     logging_group.add_argument('--zeus_log_file', type=str, default=None, help='Optional Zeus monitor log file path')
     logging_group.add_argument('--zeus_approx_instant_energy', default=True, action=argparse.BooleanOptionalAction, help='Use Zeus instant-power fallback for short measurement windows')

--- a/utils/per_token_metrics.py
+++ b/utils/per_token_metrics.py
@@ -1,0 +1,153 @@
+"""Per-token loss/count reporting kept deliberately separate from TensorBoard."""
+
+import csv
+import json
+import math
+import os
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+
+class PerTokenMetrics:
+    """Accumulate training-token exposure and export evaluation snapshots."""
+
+    DETAIL_FIELDS = (
+        "iteration", "dataset", "token_id", "token_text_escaped", "train_loss", "train_eval_count",
+        "val_loss", "val_eval_count", "training_seen_count",
+    )
+
+    def __init__(self, output_dir, vocab_sizes, token_texts=None):
+        self.output_dir = output_dir
+        self.vocab_sizes = dict(vocab_sizes)
+        self.token_texts = token_texts or {}
+        self.seen = {
+            name: np.zeros(size, dtype=np.int64) for name, size in self.vocab_sizes.items()
+        }
+        self.pending = {}
+        os.makedirs(output_dir, exist_ok=True)
+        self.detail_path = os.path.join(output_dir, "per_token_metrics.csv")
+        self.summary_path = os.path.join(output_dir, "per_token_summary.csv")
+        self.plot_path = os.path.join(output_dir, "per_token_metrics.html")
+
+    def count_training_batch(self, dataset, targets):
+        values = targets.detach().reshape(-1).to("cpu", dtype=torch.long)
+        counts = torch.bincount(values, minlength=self.vocab_sizes[dataset]).numpy()
+        self.seen[dataset] += counts[: self.vocab_sizes[dataset]]
+
+    def begin_evaluation(self):
+        self.pending = {}
+
+    def add_evaluation_batch(self, dataset, split, logits, targets):
+        """Aggregate ordinary next-token cross entropy, independent of training loss variants."""
+        vocab_size = self.vocab_sizes[dataset]
+        losses = F.cross_entropy(
+            logits.detach().float().reshape(-1, logits.size(-1)),
+            targets.detach().reshape(-1), reduction="none",
+        ).cpu()
+        ids = targets.detach().reshape(-1).to("cpu", dtype=torch.long)
+        key = (dataset, split)
+        if key not in self.pending:
+            self.pending[key] = (
+                torch.zeros(vocab_size, dtype=torch.float64),
+                torch.zeros(vocab_size, dtype=torch.int64),
+            )
+        sums, counts = self.pending[key]
+        sums.scatter_add_(0, ids, losses.to(torch.float64))
+        counts += torch.bincount(ids, minlength=vocab_size)[:vocab_size]
+
+    @staticmethod
+    def _summary(values):
+        values = np.asarray(values, dtype=np.float64)
+        values = values[np.isfinite(values)]
+        if not values.size:
+            return {key: math.nan for key in ("mean", "median", "std", "skew", "excess_kurtosis", "min", "max", "p10", "p90", "coefficient_of_variation")}
+        mean, std = values.mean(), values.std()
+        centered = values - mean
+        skew = np.mean(centered ** 3) / std ** 3 if std else 0.0
+        kurtosis = np.mean(centered ** 4) / std ** 4 - 3 if std else 0.0
+        return {
+            "mean": mean, "median": np.median(values), "std": std, "skew": skew,
+            "excess_kurtosis": kurtosis, "min": values.min(), "max": values.max(),
+            "p10": np.percentile(values, 10), "p90": np.percentile(values, 90),
+            "coefficient_of_variation": std / mean if mean else math.nan,
+        }
+
+    def export(self, iteration):
+        rows, summaries = [], []
+        for dataset, vocab_size in self.vocab_sizes.items():
+            split_data = {}
+            for split in ("train", "val"):
+                sums, counts = self.pending.get(
+                    (dataset, split),
+                    (torch.zeros(vocab_size), torch.zeros(vocab_size, dtype=torch.long)),
+                )
+                sums, counts = sums.numpy(), counts.numpy()
+                split_data[split] = np.divide(
+                    sums, counts, out=np.full(vocab_size, np.nan), where=counts != 0
+                )
+                split_data[split + "_count"] = counts
+            for token_id in range(vocab_size):
+                rows.append({
+                    "iteration": iteration, "dataset": dataset, "token_id": token_id,
+                    "token_text_escaped": self.token_texts.get(dataset, {}).get(token_id, ""),
+                    "train_loss": float(split_data["train"][token_id]),
+                    "train_eval_count": int(split_data["train_count"][token_id]),
+                    "val_loss": float(split_data["val"][token_id]),
+                    "val_eval_count": int(split_data["val_count"][token_id]),
+                    "training_seen_count": int(self.seen[dataset][token_id]),
+                })
+            for metric, values in (
+                ("train_loss", split_data["train"]), ("val_loss", split_data["val"]),
+                ("training_seen_count", self.seen[dataset]),
+            ):
+                summary = self._summary(values)
+                summary.update(iteration=iteration, dataset=dataset, metric=metric,
+                               populated_tokens=int(np.isfinite(values).sum()), vocab_size=vocab_size)
+                summaries.append(summary)
+        self._append_csv(self.detail_path, rows, self.DETAIL_FIELDS)
+        summary_fields = ("iteration", "dataset", "metric", "populated_tokens", "vocab_size",
+                          "mean", "median", "std", "skew", "excess_kurtosis", "min", "max",
+                          "p10", "p90", "coefficient_of_variation")
+        self._append_csv(self.summary_path, summaries, summary_fields)
+        self._write_plot(rows, summaries, iteration)
+
+    @staticmethod
+    def _append_csv(path, rows, fields):
+        new_file = not os.path.exists(path) or os.path.getsize(path) == 0
+        with open(path, "a", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=fields)
+            if new_file:
+                writer.writeheader()
+            writer.writerows(rows)
+
+    def _write_plot(self, latest_rows, summaries, iteration):
+        """Write a self-contained data page; Plotly itself loads from its official CDN."""
+        payload = json.dumps(latest_rows, allow_nan=True)
+        summary_payload = json.dumps(summaries, allow_nan=True)
+        html = """<!doctype html><meta charset='utf-8'><title>Per-token metrics</title>
+<script src='https://cdn.plot.ly/plotly-2.35.2.min.js'></script>
+<h1>Per-token validation loss and training exposure</h1><label>Dataset: <select id='dataset'></select></label>
+<h2>Summary statistics</h2><div id='summary'></div>
+<div id='lossPlot' style='height:75vh'></div>
+<div id='occurrencePlot' style='height:75vh'></div><script>
+const rows=PAYLOAD, summaries=SUMMARY_PAYLOAD, sel=document.getElementById('dataset');
+[...new Set(rows.map(r=>r.dataset))].forEach(x=>sel.add(new Option(x,x)));
+function label(r){return `token ${r.token_id} '${r.token_text_escaped}'`;}
+function hover(r){return `token=${r.token_id}<br>text='${r.token_text_escaped}'<br>train loss=${r.train_loss}<br>val samples=${r.val_eval_count}<br>times seen=${r.training_seen_count}`;}
+function draw(){const available=rows.filter(r=>r.dataset===sel.value && Number.isFinite(r.val_loss));
+ const byLoss=[...available].sort((a,b)=>b.val_loss-a.val_loss), lossLabels=byLoss.map(label), lossHover=byLoss.map(hover);
+ Plotly.newPlot('lossPlot',[{x:lossLabels,y:byLoss.map(r=>r.val_loss),name:'validation loss',mode:'markers',text:lossHover,hovertemplate:'%{text}<br>val loss=%{y}<extra></extra>'},
+ {x:lossLabels,y:byLoss.map(r=>r.training_seen_count),name:'times seen in training',mode:'markers',yaxis:'y2'}],
+ {title:'Evaluation iteration ITERATION (ordered highest to lowest validation loss)',xaxis:{title:'token (validation-loss order)'},yaxis:{title:'validation loss'},yaxis2:{title:'training occurrences',overlaying:'y',side:'right',rangemode:'tozero'},legend:{orientation:'h'}});}
+function drawOccurrence(){const d=rows.filter(r=>r.dataset===sel.value).sort((a,b)=>a.training_seen_count-b.training_seen_count || a.token_id-b.token_id), labels=d.map(label), h=d.map(hover);
+ Plotly.newPlot('occurrencePlot',[{x:labels,y:d.map(r=>r.training_seen_count),name:'times seen in training',mode:'markers',text:h,hovertemplate:'%{text}<extra></extra>'},
+ {x:labels,y:d.map(r=>r.val_loss),name:'validation loss',mode:'markers',yaxis:'y2',text:h,hovertemplate:'%{text}<br>val loss=%{y}<extra></extra>'}],
+ {title:'Evaluation iteration ITERATION (ordered lowest to highest training occurrence)',xaxis:{title:'token (training-occurrence order)'},yaxis:{title:'training occurrences',rangemode:'tozero'},yaxis2:{title:'validation loss',overlaying:'y',side:'right'},legend:{orientation:'h'}});}
+function drawSummary(){const d=summaries.filter(r=>r.dataset===sel.value), fields=['populated_tokens','vocab_size','mean','median','std','skew','excess_kurtosis','min','max','p10','p90','coefficient_of_variation'];
+ let table='<table border="1" cellpadding="5" style="border-collapse:collapse"><thead><tr><th>metric</th>'+fields.map(x=>`<th>${x}</th>`).join('')+'</tr></thead><tbody>';
+ table+=d.map(r=>'<tr><th>'+r.metric+'</th>'+fields.map(f=>`<td>${typeof r[f]==='number' ? Number(r[f]).toPrecision(6) : r[f]}</td>`).join('')+'</tr>').join('')+'</tbody></table>'; document.getElementById('summary').innerHTML=table;}
+sel.onchange=()=>{draw();drawOccurrence();drawSummary();}; draw();drawOccurrence();drawSummary();</script>""".replace("SUMMARY_PAYLOAD", summary_payload).replace("PAYLOAD", payload).replace("ITERATION", str(iteration))
+        with open(self.plot_path, "w", encoding="utf-8") as handle:
+            handle.write(html)

--- a/utils/per_token_metrics.py
+++ b/utils/per_token_metrics.py
@@ -111,7 +111,7 @@ class PerTokenMetrics:
                           "mean", "median", "std", "skew", "excess_kurtosis", "min", "max",
                           "p10", "p90", "coefficient_of_variation")
         self._append_csv(self.summary_path, summaries, summary_fields)
-        self._write_plot(rows, summaries, iteration)
+        self._write_plot(self._read_detail_rows(), summaries, iteration)
 
     @staticmethod
     def _append_csv(path, rows, fields):
@@ -122,6 +122,24 @@ class PerTokenMetrics:
                 writer.writeheader()
             writer.writerows(rows)
 
+    def _read_detail_rows(self):
+        """Load all snapshots so the HTML can plot a token's history."""
+        rows = []
+        with open(self.detail_path, newline="", encoding="utf-8") as handle:
+            for row in csv.DictReader(handle):
+                rows.append({
+                    "iteration": int(row["iteration"]),
+                    "dataset": row["dataset"],
+                    "token_id": int(row["token_id"]),
+                    "token_text_escaped": row["token_text_escaped"],
+                    "train_loss": float(row["train_loss"]),
+                    "train_eval_count": int(row["train_eval_count"]),
+                    "val_loss": float(row["val_loss"]),
+                    "val_eval_count": int(row["val_eval_count"]),
+                    "training_seen_count": int(row["training_seen_count"]),
+                })
+        return rows
+
     def _write_plot(self, latest_rows, summaries, iteration):
         """Write a self-contained data page; Plotly itself loads from its official CDN."""
         payload = json.dumps(latest_rows, allow_nan=True)
@@ -131,23 +149,40 @@ class PerTokenMetrics:
 <h1>Per-token validation loss and training exposure</h1><label>Dataset: <select id='dataset'></select></label>
 <h2>Summary statistics</h2><div id='summary'></div>
 <div id='lossPlot' style='height:75vh'></div>
-<div id='occurrencePlot' style='height:75vh'></div><script>
+<div id='occurrencePlot' style='height:75vh'></div>
+<h2>Token history</h2>
+<p>Select one or more tokens (Ctrl/Cmd-click to toggle individual entries):</p>
+<select id='tokens' multiple size='12' style='min-width:24em'></select>
+<div id='iterationPlot' style='height:65vh'></div>
+<div id='appearancePlot' style='height:65vh'></div><script>
 const rows=PAYLOAD, summaries=SUMMARY_PAYLOAD, sel=document.getElementById('dataset');
+const tokenSel=document.getElementById('tokens');
 [...new Set(rows.map(r=>r.dataset))].forEach(x=>sel.add(new Option(x,x)));
 function label(r){return `token ${r.token_id} '${r.token_text_escaped}'`;}
 function hover(r){return `token=${r.token_id}<br>text='${r.token_text_escaped}'<br>train loss=${r.train_loss}<br>val samples=${r.val_eval_count}<br>times seen=${r.training_seen_count}`;}
-function draw(){const available=rows.filter(r=>r.dataset===sel.value && Number.isFinite(r.val_loss));
+function latestRows(){const datasetRows=rows.filter(r=>r.dataset===sel.value), latestIteration=Math.max(...datasetRows.map(r=>r.iteration)); return datasetRows.filter(r=>r.iteration===latestIteration);}
+function draw(){const available=latestRows().filter(r=>Number.isFinite(r.val_loss));
  const byLoss=[...available].sort((a,b)=>b.val_loss-a.val_loss), lossLabels=byLoss.map(label), lossHover=byLoss.map(hover);
  Plotly.newPlot('lossPlot',[{x:lossLabels,y:byLoss.map(r=>r.val_loss),name:'validation loss',mode:'markers',text:lossHover,hovertemplate:'%{text}<br>val loss=%{y}<extra></extra>'},
  {x:lossLabels,y:byLoss.map(r=>r.training_seen_count),name:'times seen in training',mode:'markers',yaxis:'y2'}],
  {title:'Evaluation iteration ITERATION (ordered highest to lowest validation loss)',xaxis:{title:'token (validation-loss order)'},yaxis:{title:'validation loss'},yaxis2:{title:'training occurrences',overlaying:'y',side:'right',rangemode:'tozero'},legend:{orientation:'h'}});}
-function drawOccurrence(){const d=rows.filter(r=>r.dataset===sel.value).sort((a,b)=>a.training_seen_count-b.training_seen_count || a.token_id-b.token_id), labels=d.map(label), h=d.map(hover);
+function drawOccurrence(){const d=latestRows().sort((a,b)=>a.training_seen_count-b.training_seen_count || a.token_id-b.token_id), labels=d.map(label), h=d.map(hover);
  Plotly.newPlot('occurrencePlot',[{x:labels,y:d.map(r=>r.training_seen_count),name:'times seen in training',mode:'markers',text:h,hovertemplate:'%{text}<extra></extra>'},
  {x:labels,y:d.map(r=>r.val_loss),name:'validation loss',mode:'markers',yaxis:'y2',text:h,hovertemplate:'%{text}<br>val loss=%{y}<extra></extra>'}],
  {title:'Evaluation iteration ITERATION (ordered lowest to highest training occurrence)',xaxis:{title:'token (training-occurrence order)'},yaxis:{title:'training occurrences',rangemode:'tozero'},yaxis2:{title:'validation loss',overlaying:'y',side:'right'},legend:{orientation:'h'}});}
 function drawSummary(){const d=summaries.filter(r=>r.dataset===sel.value), fields=['populated_tokens','vocab_size','mean','median','std','skew','excess_kurtosis','min','max','p10','p90','coefficient_of_variation'];
  let table='<table border="1" cellpadding="5" style="border-collapse:collapse"><thead><tr><th>metric</th>'+fields.map(x=>`<th>${x}</th>`).join('')+'</tr></thead><tbody>';
  table+=d.map(r=>'<tr><th>'+r.metric+'</th>'+fields.map(f=>`<td>${typeof r[f]==='number' ? Number(r[f]).toPrecision(6) : r[f]}</td>`).join('')+'</tr>').join('')+'</tbody></table>'; document.getElementById('summary').innerHTML=table;}
-sel.onchange=()=>{draw();drawOccurrence();drawSummary();}; draw();drawOccurrence();drawSummary();</script>""".replace("SUMMARY_PAYLOAD", summary_payload).replace("PAYLOAD", payload).replace("ITERATION", str(iteration))
+function populateTokens(){tokenSel.replaceChildren(); const d=latestRows(), worst=[...d].filter(r=>Number.isFinite(r.val_loss)).sort((a,b)=>b.val_loss-a.val_loss).slice(0,5).map(r=>r.token_id);
+ d.sort((a,b)=>a.token_id-b.token_id).forEach(r=>{const o=new Option(label(r),r.token_id);o.selected=worst.includes(r.token_id);tokenSel.add(o);});}
+function selectedTokens(){return [...tokenSel.selectedOptions].map(o=>Number(o.value));}
+function historyTraces(xField){const palette=['#1f77b4','#ff7f0e','#2ca02c','#d62728','#9467bd','#8c564b','#e377c2','#7f7f7f','#bcbd22','#17becf']; const traces=[];
+ selectedTokens().forEach((id,i)=>{const d=rows.filter(r=>r.dataset===sel.value&&r.token_id===id).sort((a,b)=>a.iteration-b.iteration), name=d.length?label(d[0]):`token ${id}`, color=palette[i%palette.length];
+  traces.push({x:d.map(r=>r[xField]),y:d.map(r=>r.val_loss),name:`${name} validation`,mode:'lines+markers',legendgroup:String(id),line:{color}});
+  traces.push({x:d.map(r=>r[xField]),y:d.map(r=>r.train_loss),name:`${name} train`,mode:'lines+markers',legendgroup:String(id),line:{color,dash:'dot'}});}); return traces;}
+function drawHistory(){Plotly.newPlot('iterationPlot',historyTraces('iteration'),{title:'Selected-token loss vs iteration',xaxis:{title:'training iteration'},yaxis:{title:'cross-entropy loss'},legend:{orientation:'h'}});
+ Plotly.newPlot('appearancePlot',historyTraces('training_seen_count'),{title:'Selected-token loss vs cumulative appearances',xaxis:{title:'cumulative training appearances'},yaxis:{title:'cross-entropy loss'},legend:{orientation:'h'}});}
+function drawAll(){draw();drawOccurrence();drawSummary();populateTokens();drawHistory();}
+sel.onchange=drawAll;tokenSel.onchange=drawHistory;drawAll();</script>""".replace("SUMMARY_PAYLOAD", summary_payload).replace("PAYLOAD", payload).replace("ITERATION", str(iteration))
         with open(self.plot_path, "w", encoding="utf-8") as handle:
             handle.write(html)


### PR DESCRIPTION
### Motivation

- Provide per-vocabulary-token next-token cross-entropy and training-exposure counts to make sparse or undertrained tokens visible and comparable across evaluations. 
- Make these per-token reports easy to inspect programmatically (CSV) and interactively (self-contained Plotly HTML), while keeping them out of TensorBoard.

### Description

- Add `utils/per_token_metrics.py` implementing `PerTokenMetrics` to accumulate training token counts, compute per-token evaluation losses, write `per_token_metrics.csv`, `per_token_summary.csv`, and a self-contained `per_token_metrics.html` interactive viewer. 
- Add CLI flags `--log_per_token_metrics` and `--per_token_metrics_dir` in `train_args.py` and render token text safely when initializing reports. 
- Integrate into `train.py` by initializing `PerTokenMetrics` when enabled, calling `count_training_batch` during training, calling `add_evaluation_batch` during validation/estimate pass for all training modes, and exporting on evaluation with the current iteration. 
- Document the feature in `README.md` and add `tests/test_per_token_metrics.py` to validate CSV/summary/HTML outputs and basic numeric expectations. 

### Testing

- Ran the new unit test `tests/test_per_token_metrics.py` which asserts CSV fields, summary presence, numeric loss closeness, and HTML content, and the test passed. 
- The test exercises `PerTokenMetrics.count_training_batch`, `begin_evaluation`, `add_evaluation_batch`, and `export`, and validated output file contents produced by the implementation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ee2023ac88326a9107fbb21f0acd0)