### PR TITLE
Add mel_mc_int: tooling, demos, and viewer for mel→multicontext workflows

### DIFF
--- a/data/mel_mc_int/README.md
+++ b/data/mel_mc_int/README.md
@@ -68,4 +68,7 @@ The script writes per-file mel CSVs to
 values into `all_music.max.mel.csv`, prepares `data/mel_mc_int_music/`, trains
 into `out/mel_mc_int_music`, and then calls `data/mel_mc_int/demo_infer.sh`.
 Set `MEL_MC_SKIP_ENCODE=1` or `MEL_MC_SKIP_TRAIN=1` to reuse existing encoded
-CSVs or checkpoints while iterating.
+CSVs or checkpoints while iterating. The pipeline disables TensorBoard by default
+(`MEL_MC_TENSORBOARD=0`) so training does not import TensorFlow/TensorBoard in
+environments with incompatible NumPy/TensorFlow wheels; set
+`MEL_MC_TENSORBOARD=1` if your environment supports it.

--- a/data/mel_mc_int/README.md
+++ b/data/mel_mc_int/README.md
@@ -72,3 +72,15 @@ CSVs or checkpoints while iterating. The pipeline disables TensorBoard by defaul
 (`MEL_MC_TENSORBOARD=0`) so training does not import TensorFlow/TensorBoard in
 environments with incompatible NumPy/TensorFlow wheels; set
 `MEL_MC_TENSORBOARD=1` if your environment supports it.
+
+Both concatenation and dataset preparation are streaming operations. They scan
+the CSV data in multiple passes for validation and metadata, but never hold the
+combined state matrix in memory. Consequently, peak memory is bounded by one
+CSV row during concatenation and by `--buffer_rows` per mel band during
+preparation (4096 rows by default, approximately 3 MiB for 384 bands of
+16-bit states). This is suitable for large music folders; the tradeoff is extra
+sequential disk reads. Make sure the output filesystem has room for the combined
+CSV plus the train/validation binaries. The folder pipeline also passes inputs
+through a newline-delimited list file instead of placing every filename on the
+command line, avoiding the operating system's command-argument size limit for
+very large collections.

--- a/data/mel_mc_int/README.md
+++ b/data/mel_mc_int/README.md
@@ -52,3 +52,20 @@ reference mel metadata, reconstructs `generated.wav`, and writes a small
 `index.html` viewer. The viewer includes a browser-side file picker and cutoff
 field for auditioning/selecting the next source file before re-running the demo
 command.
+
+## Whole-folder music pipeline
+
+For a single command that encodes a directory of music files, concatenates the
+resulting mel-state CSV rows into one training CSV, prepares multicontext data,
+trains, and runs continuation inference, use:
+
+```bash
+bash demos/mel_mc_int_music_pipeline.sh path/to/music_dir path/to/prompt.wav 10.0
+```
+
+The script writes per-file mel CSVs to
+`data/mel_mc_int/music_pipeline_out/encoded/`, concatenates their `mel_*_q`
+values into `all_music.max.mel.csv`, prepares `data/mel_mc_int_music/`, trains
+into `out/mel_mc_int_music`, and then calls `data/mel_mc_int/demo_infer.sh`.
+Set `MEL_MC_SKIP_ENCODE=1` or `MEL_MC_SKIP_TRAIN=1` to reuse existing encoded
+CSVs or checkpoints while iterating.

--- a/data/mel_mc_int/README.md
+++ b/data/mel_mc_int/README.md
@@ -1,0 +1,54 @@
+# Mel integer multicontext
+
+`data/mel_mc_int` bridges the self-describing mel CSVs from
+`data/mel_spectrogram` with the integer CSV multicontext pattern used by
+`data/csv_mc_int`. Each mel band (`mel_000_q`, `mel_001_q`, ...) becomes one
+regular nanoGPT multicontext dataset with token IDs equal to the quantized mel
+state.
+
+## Defaults
+
+`run.sh` intentionally mirrors the high-fidelity settings in
+`data/mel_spectrogram/run.sh`:
+
+- preset `max`
+- sample rate `48000`
+- `fmin=10`, `fmax=20000`
+- `384` mel columns per timestep
+- `64` states per column
+- `15 ms` timestep and `60 ms` window
+- `n_fft=8192`, `top_db=96`
+- `reference-mode=file_percentile`
+
+## Build a dataset
+
+```bash
+bash data/mel_mc_int/run.sh path/to/audio.wav mel_mc_int
+```
+
+This writes the intermediate mel CSV/PNG under `data/mel_mc_int/mel_out/` and
+the multicontext dataset under `data/mel_mc_int/` by default. The manifest lists
+all mel-band dataset names for training or inference:
+
+```bash
+python3 - <<'PY'
+import json
+m = json.load(open('data/mel_mc_int/manifest.json'))
+print(' '.join(m['multicontext_datasets']))
+PY
+```
+
+## Inference and continuation demo
+
+After training a multicontext model on the generated manifest, run:
+
+```bash
+bash data/mel_mc_int/demo_infer.sh out/your_run path/to/audio.wav 4.5 200
+```
+
+The demo encodes the selected audio, cuts the prompt at `4.5` seconds, asks
+`sample.py` to continue all mel-band contexts, wraps the generated CSV with the
+reference mel metadata, reconstructs `generated.wav`, and writes a small
+`index.html` viewer. The viewer includes a browser-side file picker and cutoff
+field for auditioning/selecting the next source file before re-running the demo
+command.

--- a/data/mel_mc_int/demo_infer.sh
+++ b/data/mel_mc_int/demo_infer.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Encode an audio prefix, run multicontext sampling, reconstruct continuation audio, and create a viewer.
+set -euo pipefail
+
+usage() { echo "Usage: bash data/mel_mc_int/demo_infer.sh OUT_DIR INPUT_AUDIO CUTOFF_SECONDS [MAX_NEW_TOKENS]"; }
+[[ $# -ge 3 ]] || { usage >&2; exit 1; }
+RUN_OUT_DIR="$1"; INPUT="$2"; CUTOFF="$3"; MAX_NEW="${4:-200}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+MEL_DIR="${REPO_ROOT}/data/mel_spectrogram"
+OUT="${SCRIPT_DIR}/demo_out/$(date +%Y%m%d_%H%M%S)"
+mkdir -p "${OUT}"
+
+python3 "${MEL_DIR}/audio_to_token_mel.py" "${INPUT}" --force \
+  --preset max --samples-per-second 48000 --fmin 10 --fmax 20000 \
+  --columns-per-timestep 384 --states-per-column 64 --timestep-ms 15 \
+  --win-ms 60 --n-fft 8192 --top-db 96 --reference-mode file_percentile \
+  --output-format csv --output-dir "${OUT}"
+stem="$(basename "${INPUT}")"; stem="${stem%.*}"
+REF_CSV="${OUT}/${stem}.max.mel.csv"
+python3 "${SCRIPT_DIR}/mel_mc_int_tools.py" cut-prompt "${REF_CSV}" --cutoff_s "${CUTOFF}" --output_dir "${OUT}/prompt"
+
+mapfile -t DATASETS < <(python3 - <<'PY'
+import json
+m=json.load(open('data/mel_mc_int/manifest.json'))
+print('\n'.join(m['multicontext_datasets']))
+PY
+)
+python3 sample.py --init_from resume --out_dir "${RUN_OUT_DIR}" \
+  --multicontext --multicontext_datasets "${DATASETS[@]}" \
+  --multicontext_csv_input "${OUT}/prompt/prompt.csv" \
+  --multicontext_csv_output_file "${OUT}/generated.csv" \
+  --max_new_tokens "${MAX_NEW}" --num_samples 1
+
+python3 "${SCRIPT_DIR}/mel_mc_int_tools.py" wrap-csv "${OUT}/generated.csv" --reference_mel_csv "${REF_CSV}" --output_csv "${OUT}/generated.mel.csv"
+python3 "${MEL_DIR}/token_mel_to_audio.py" "${OUT}/generated.mel.csv" --output "${OUT}/generated.wav" --force
+python3 "${SCRIPT_DIR}/make_viewer.py" --output_dir "${OUT}" --input_audio "${INPUT}" --cutoff_s "${CUTOFF}"
+echo "Viewer: ${OUT}/index.html"

--- a/data/mel_mc_int/make_viewer.py
+++ b/data/mel_mc_int/make_viewer.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Write a small static HTML report for mel_mc_int continuation runs."""
+from __future__ import annotations
+
+import argparse
+import html
+from pathlib import Path
+
+p = argparse.ArgumentParser()
+p.add_argument('--output_dir', required=True)
+p.add_argument('--input_audio', required=True)
+p.add_argument('--cutoff_s', required=True)
+args = p.parse_args()
+out = Path(args.output_dir)
+body = f'''<!doctype html>
+<meta charset="utf-8">
+<title>Mel MC continuation viewer</title>
+<style>
+body{{font-family:system-ui,-apple-system,Segoe UI,sans-serif;margin:2rem;max-width:960px;line-height:1.45}}
+audio{{width:100%}} .card{{border:1px solid #ddd;border-radius:10px;padding:1rem;margin:1rem 0}}
+code,pre{{background:#f6f8fa;border-radius:6px;padding:.15rem .35rem}} pre{{padding:1rem;overflow:auto}}
+label{{display:block;margin:.5rem 0}}
+</style>
+<h1>Mel multicontext audio continuation</h1>
+<p>Source: <code>{html.escape(str(args.input_audio))}</code>; cutoff: <strong>{html.escape(str(args.cutoff_s))}s</strong>.</p>
+<div class="card"><h2>Reconstructed inference / continuation</h2><audio controls src="generated.wav"></audio></div>
+<div class="card"><h2>Generated artifacts</h2><p><a href="generated.csv">generated.csv</a> · <a href="generated.mel.csv">self-describing mel CSV</a></p></div>
+<div class="card">
+  <h2>Select the next input audio and cutoff</h2>
+  <p>This viewer is static, so it cannot run Python by itself. Use it to audition a local file, choose the cutoff, then copy the command below into the repo shell.</p>
+  <label>Audio file <input id="file" type="file" accept="audio/*"></label>
+  <audio id="preview" controls></audio>
+  <label>Cutoff seconds <input id="cutoff" type="number" min="0" step="0.01" value="{html.escape(str(args.cutoff_s))}"></label>
+  <label>Run output directory <input id="outdir" value="out/mel_mc_int"></label>
+  <label>Max new mel frames <input id="frames" type="number" min="1" step="1" value="200"></label>
+  <pre id="cmd">bash data/mel_mc_int/demo_infer.sh out/mel_mc_int path/to/audio.wav {html.escape(str(args.cutoff_s))} 200</pre>
+</div>
+<script>
+const file = document.getElementById('file'), preview = document.getElementById('preview');
+const cutoff = document.getElementById('cutoff'), outdir = document.getElementById('outdir'), frames = document.getElementById('frames'), cmd = document.getElementById('cmd');
+let name = 'path/to/audio.wav';
+function q(s) {{ return '"' + String(s).replaceAll('"', '\\"') + '"'; }}
+function update() {{ cmd.textContent = `bash data/mel_mc_int/demo_infer.sh ${{q(outdir.value)}} ${{q(name)}} ${{q(cutoff.value)}} ${{q(frames.value)}}`; }}
+file.addEventListener('change', () => {{
+  const f = file.files && file.files[0];
+  if (!f) return;
+  name = f.name;
+  preview.src = URL.createObjectURL(f);
+  update();
+}});
+for (const el of [cutoff, outdir, frames]) el.addEventListener('input', update);
+update();
+</script>
+'''
+(out / 'index.html').write_text(body, encoding='utf-8')
+print(out / 'index.html')

--- a/data/mel_mc_int/mel_mc_int_tools.py
+++ b/data/mel_mc_int/mel_mc_int_tools.py
@@ -2,7 +2,7 @@
 """Utilities for mel-spectrogram integer multicontext datasets and demos."""
 from __future__ import annotations
 
-import argparse, csv, json, pickle, re, shutil, subprocess, sys, wave
+import argparse, csv, json, pickle, re, shutil, sys, wave
 from array import array
 from pathlib import Path
 from typing import Sequence
@@ -55,10 +55,102 @@ def read_mel_csv(path: Path):
     return header, cols, np.asarray(rows, dtype=np.int64), metadata
 
 
+
+def metadata_signature(metadata: dict | None) -> tuple:
+    if not metadata:
+        return ()
+    shape = metadata.get("shape", {})
+    waveform = metadata.get("waveform", {})
+    stft = metadata.get("stft", {})
+    mel = metadata.get("mel", {})
+    quantizer = metadata.get("quantizer", {})
+    return (
+        int(shape.get("bands", -1)),
+        int(waveform.get("sample_rate", -1)),
+        int(stft.get("n_fft", -1)),
+        int(stft.get("win_length", -1)),
+        int(stft.get("hop_length", -1)),
+        int(mel.get("n_mels", -1)),
+        float(mel.get("fmin", -1.0)),
+        float(mel.get("fmax", -1.0)),
+        int(quantizer.get("levels", -1)),
+        float(quantizer.get("db_min", 0.0)),
+        float(quantizer.get("db_max", 0.0)),
+        metadata.get("profile"),
+    )
+
+
+def metadata_for_states(reference: dict | None, states: np.ndarray) -> dict | None:
+    if not reference:
+        return None
+    metadata = dict(reference)
+    metadata["shape"] = dict(metadata["shape"])
+    metadata["shape"]["timesteps"] = int(states.shape[0])
+    metadata["waveform"] = dict(metadata["waveform"])
+    metadata["waveform"]["decoded_sample_count"] = int(
+        states.shape[0] * int(metadata["stft"]["hop_length"])
+    )
+    metadata["csv"] = dict(metadata.get("csv", {}))
+    metadata["csv"]["time_columns_included"] = False
+    metadata["integrity"] = dict(metadata["integrity"])
+    metadata["integrity"]["state_crc32"] = (
+        f"{canonical_state_crc(states, int(metadata['quantizer']['levels'])):08x}"
+    )
+    return metadata
+
+
+def write_mel_state_csv(path: Path, columns: Sequence[str], states: np.ndarray, metadata: dict | None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(columns)
+        if metadata:
+            f.write(CSV_METADATA_PREFIX + compact_json(metadata) + "\n")
+        writer.writerows(states.astype(int).tolist())
+
 def write_bin(path: Path, values: Sequence[int], typecode: str) -> None:
     with path.open('wb') as f:
         array(typecode, values).tofile(f)
 
+
+
+def cmd_concat_csv(args):
+    inputs = [Path(value).resolve() for value in args.input_csvs]
+    if not inputs:
+        raise ValueError("At least one input CSV is required.")
+    first_header, first_cols, first_states, first_metadata = read_mel_csv(inputs[0])
+    column_names = [name for _, name in first_cols]
+    signature = metadata_signature(first_metadata)
+    all_states = [first_states]
+    manifest_inputs = []
+    for path, states, metadata in [(inputs[0], first_states, first_metadata)]:
+        manifest_inputs.append({"path": str(path), "frames": int(states.shape[0])})
+    for input_csv in inputs[1:]:
+        _, cols, states, metadata = read_mel_csv(input_csv)
+        names = [name for _, name in cols]
+        if names != column_names:
+            raise ValueError(f"Mel columns in {input_csv} do not match {inputs[0]}.")
+        if signature and metadata_signature(metadata) != signature:
+            raise ValueError(f"Mel metadata settings in {input_csv} do not match {inputs[0]}.")
+        all_states.append(states)
+        manifest_inputs.append({"path": str(input_csv), "frames": int(states.shape[0])})
+    concatenated = np.concatenate(all_states, axis=0)
+    output_metadata = metadata_for_states(first_metadata, concatenated)
+    output_csv = Path(args.output_csv).resolve()
+    write_mel_state_csv(output_csv, column_names, concatenated, output_metadata)
+    if args.manifest_json:
+        with Path(args.manifest_json).open("w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "output_csv": str(output_csv),
+                    "total_frames": int(concatenated.shape[0]),
+                    "mel_columns": len(column_names),
+                    "inputs": manifest_inputs,
+                },
+                f,
+                indent=2,
+            )
+    print(output_csv)
 
 def cmd_prepare(args):
     input_csv = Path(args.input_csv).resolve()
@@ -109,7 +201,7 @@ def cmd_wrap_csv(args):
     input_csv = Path(args.input_csv); ref = read_csv_container(Path(args.reference_mel_csv))
     with input_csv.open(newline='', encoding='utf-8') as f:
         reader=csv.reader(f); header=next(reader); cols=mel_columns(header); states=np.asarray([[int(r[i]) for i,_ in cols] for r in reader if r], dtype=np.int64)
-    md = dict(ref.metadata); md['shape'] = dict(md['shape']); md['shape']['timesteps'] = int(states.shape[0]); md['waveform'] = dict(md['waveform']); md['waveform']['decoded_sample_count'] = int(states.shape[0] * int(md['stft']['hop_length'])); md['integrity'] = dict(md['integrity']); md['integrity']['state_crc32'] = f"{canonical_state_crc(states, int(md['quantizer']['levels'])):08x}"
+    md = metadata_for_states(ref.metadata, states)
     out=Path(args.output_csv); out.parent.mkdir(parents=True, exist_ok=True)
     with input_csv.open('r', encoding='utf-8') as src, out.open('w', encoding='utf-8') as dst:
         dst.write(src.readline()); dst.write(CSV_METADATA_PREFIX + compact_json(md) + '\n'); shutil.copyfileobj(src, dst)
@@ -130,6 +222,7 @@ def cmd_stitch(args):
 
 def main():
     p=argparse.ArgumentParser(); sub=p.add_subparsers(required=True)
+    a=sub.add_parser('concat-csv'); a.add_argument('input_csvs', nargs='+'); a.add_argument('--output_csv', required=True); a.add_argument('--manifest_json'); a.set_defaults(func=cmd_concat_csv)
     a=sub.add_parser('prepare'); a.add_argument('input_csv'); a.add_argument('--output_root',default='mel_mc_int'); a.add_argument('--train_ratio',type=float,default=.9); a.add_argument('--states_per_column',type=int); a.set_defaults(func=cmd_prepare)
     a=sub.add_parser('cut-prompt'); a.add_argument('mel_csv'); a.add_argument('--cutoff_s',type=float,required=True); a.add_argument('--output_dir',default='mel_mc_int_prompt'); a.add_argument('--timestep_ms',type=float,default=15); a.set_defaults(func=cmd_cut_prompt)
     a=sub.add_parser('wrap-csv'); a.add_argument('input_csv'); a.add_argument('--reference_mel_csv',required=True); a.add_argument('--output_csv',required=True); a.set_defaults(func=cmd_wrap_csv)

--- a/data/mel_mc_int/mel_mc_int_tools.py
+++ b/data/mel_mc_int/mel_mc_int_tools.py
@@ -2,7 +2,7 @@
 """Utilities for mel-spectrogram integer multicontext datasets and demos."""
 from __future__ import annotations
 
-import argparse, csv, json, pickle, re, shutil, sys, wave
+import argparse, csv, json, pickle, re, shutil, sys, wave, zlib
 from array import array
 from pathlib import Path
 from typing import Sequence
@@ -53,6 +53,48 @@ def read_mel_csv(path: Path):
     if len(rows) < 2:
         raise ValueError("Need at least two mel rows")
     return header, cols, np.asarray(rows, dtype=np.int64), metadata
+
+
+def inspect_mel_csv(path: Path):
+    """Read only a mel CSV's header and metadata, never its state matrix."""
+    metadata = None
+    header = None
+    with path.open(newline="", encoding="utf-8") as f:
+        for line in f:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if stripped.startswith(CSV_METADATA_PREFIX):
+                metadata = json.loads(stripped[len(CSV_METADATA_PREFIX):])
+                continue
+            if stripped.startswith("#"):
+                continue
+            if header is None:
+                header = next(csv.reader([line]))
+                continue
+            break
+    if header is None:
+        raise ValueError(f"CSV has no header: {path}")
+    return header, mel_columns(header), metadata
+
+
+def iter_mel_states(path: Path, column_indexes: Sequence[int]):
+    """Yield one validated state row at a time with bounded memory usage."""
+    with path.open(newline="", encoding="utf-8") as f:
+        header_seen = False
+        for row in csv.reader(f):
+            if not row:
+                continue
+            first = row[0].strip()
+            if first.startswith("#"):
+                continue
+            if not header_seen:
+                header_seen = True
+                continue
+            try:
+                yield [int(row[index]) for index in column_indexes]
+            except (IndexError, ValueError) as exc:
+                raise ValueError(f"Invalid mel state row in {path}: {row[:4]}") from exc
 
 
 
@@ -115,35 +157,63 @@ def write_bin(path: Path, values: Sequence[int], typecode: str) -> None:
 
 
 def cmd_concat_csv(args):
-    inputs = [Path(value).resolve() for value in args.input_csvs]
+    input_values = list(args.input_csvs)
+    if args.input_list:
+        input_values.extend(
+            line for line in Path(args.input_list).read_text(encoding="utf-8").splitlines() if line
+        )
+    inputs = [Path(value).resolve() for value in input_values]
     if not inputs:
         raise ValueError("At least one input CSV is required.")
-    first_header, first_cols, first_states, first_metadata = read_mel_csv(inputs[0])
+    _, first_cols, first_metadata = inspect_mel_csv(inputs[0])
     column_names = [name for _, name in first_cols]
     signature = metadata_signature(first_metadata)
-    all_states = [first_states]
     manifest_inputs = []
-    for path, states, metadata in [(inputs[0], first_states, first_metadata)]:
-        manifest_inputs.append({"path": str(path), "frames": int(states.shape[0])})
-    for input_csv in inputs[1:]:
-        _, cols, states, metadata = read_mel_csv(input_csv)
+    total_frames = 0
+    state_crc = 0
+    levels = int((first_metadata or {}).get("quantizer", {}).get("levels", 64))
+    crc_dtype = np.uint8 if levels <= 256 else np.dtype("<u2")
+    for input_csv in inputs:
+        _, cols, metadata = inspect_mel_csv(input_csv)
         names = [name for _, name in cols]
         if names != column_names:
             raise ValueError(f"Mel columns in {input_csv} do not match {inputs[0]}.")
         if signature and metadata_signature(metadata) != signature:
             raise ValueError(f"Mel metadata settings in {input_csv} do not match {inputs[0]}.")
-        all_states.append(states)
-        manifest_inputs.append({"path": str(input_csv), "frames": int(states.shape[0])})
-    concatenated = np.concatenate(all_states, axis=0)
-    output_metadata = metadata_for_states(first_metadata, concatenated)
+        frames = 0
+        indexes = [index for index, _ in cols]
+        for row in iter_mel_states(input_csv, indexes):
+            state_crc = zlib.crc32(np.asarray(row, dtype=crc_dtype).tobytes(), state_crc)
+            frames += 1
+        if frames < 2:
+            raise ValueError(f"Need at least two mel rows in {input_csv}")
+        total_frames += frames
+        manifest_inputs.append({"path": str(input_csv), "frames": frames})
+
+    output_metadata = None
+    if first_metadata:
+        output_metadata = dict(first_metadata)
+        output_metadata["shape"] = dict(output_metadata["shape"], timesteps=total_frames)
+        output_metadata["waveform"] = dict(output_metadata["waveform"])
+        output_metadata["waveform"]["decoded_sample_count"] = total_frames * int(output_metadata["stft"]["hop_length"])
+        output_metadata["csv"] = dict(output_metadata.get("csv", {}), time_columns_included=False)
+        output_metadata["integrity"] = dict(output_metadata["integrity"], state_crc32=f"{state_crc & 0xffffffff:08x}")
     output_csv = Path(args.output_csv).resolve()
-    write_mel_state_csv(output_csv, column_names, concatenated, output_metadata)
+    output_csv.parent.mkdir(parents=True, exist_ok=True)
+    with output_csv.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(column_names)
+        if output_metadata:
+            f.write(CSV_METADATA_PREFIX + compact_json(output_metadata) + "\n")
+        for input_csv in inputs:
+            _, cols, _ = inspect_mel_csv(input_csv)
+            writer.writerows(iter_mel_states(input_csv, [index for index, _ in cols]))
     if args.manifest_json:
         with Path(args.manifest_json).open("w", encoding="utf-8") as f:
             json.dump(
                 {
                     "output_csv": str(output_csv),
-                    "total_frames": int(concatenated.shape[0]),
+                    "total_frames": total_frames,
                     "mel_columns": len(column_names),
                     "inputs": manifest_inputs,
                 },
@@ -154,25 +224,51 @@ def cmd_concat_csv(args):
 
 def cmd_prepare(args):
     input_csv = Path(args.input_csv).resolve()
-    _, cols, states, metadata = read_mel_csv(input_csv)
+    if args.buffer_rows < 1:
+        raise ValueError("--buffer_rows must be at least 1")
+    _, cols, metadata = inspect_mel_csv(input_csv)
     levels = args.states_per_column or int((metadata or {}).get('quantizer', {}).get('levels', 64))
-    if states.min() < 0 or states.max() >= levels:
-        raise ValueError(f"Mel states [{states.min()}, {states.max()}] exceed [0,{levels-1}]")
+    indexes = [index for index, _ in cols]
+    rows = 0
+    minimum, maximum = levels, -1
+    for row in iter_mel_states(input_csv, indexes):
+        minimum = min(minimum, min(row)); maximum = max(maximum, max(row)); rows += 1
+    if rows < 2:
+        raise ValueError("Need at least two mel rows")
+    if minimum < 0 or maximum >= levels:
+        raise ValueError(f"Mel states [{minimum}, {maximum}] exceed [0,{levels-1}]")
     out = REPO_ROOT / 'data' / args.output_root
     out.mkdir(parents=True, exist_ok=True)
-    train_n = int(states.shape[0] * args.train_ratio)
+    train_n = int(rows * args.train_ratio)
     typecode, dtype_name = dtype_for_vocab(levels)
-    manifest = {"tokenizer":"mel_integer_range_multicontext_manifest","source_mel_csv":str(input_csv),"rows":int(states.shape[0]),"train_rows":train_n,"val_rows":int(states.shape[0]-train_n),"output_root":args.output_root,"multicontext_datasets":[],"columns":[],"roundtrip_metadata":metadata}
+    manifest = {"tokenizer":"mel_integer_range_multicontext_manifest","source_mel_csv":str(input_csv),"rows":rows,"train_rows":train_n,"val_rows":rows-train_n,"output_root":args.output_root,"multicontext_datasets":[],"columns":[],"roundtrip_metadata":metadata}
     for j, (_, name) in enumerate(cols):
         cdir = out / name
         cdir.mkdir(parents=True, exist_ok=True)
-        vals = states[:, j].astype(int).tolist()
-        write_bin(cdir/'train.bin', vals[:train_n], typecode)
-        write_bin(cdir/'val.bin', vals[train_n:], typecode)
-        meta = {"tokenizer":"csv_integer_range","vocab_size":levels,"source_csv":str(input_csv),"source_column":name,"context_name":name,"column_index":j,"has_header":True,"int_min":0,"int_max":levels-1,"value_encoding":"token_id = raw_integer_value","value_decoding":"raw_integer_value = token_id","dtype":dtype_name,"samples":int(states.shape[0]),"train_ratio":float(args.train_ratio),"mel_mc_int":True}
+        meta = {"tokenizer":"csv_integer_range","vocab_size":levels,"source_csv":str(input_csv),"source_column":name,"context_name":name,"column_index":j,"has_header":True,"int_min":0,"int_max":levels-1,"value_encoding":"token_id = raw_integer_value","value_decoding":"raw_integer_value = token_id","dtype":dtype_name,"samples":rows,"train_ratio":float(args.train_ratio),"mel_mc_int":True}
         with (cdir/'meta.pkl').open('wb') as f: pickle.dump(meta, f)
         manifest['multicontext_datasets'].append(f"{args.output_root}/{name}")
         manifest['columns'].append(meta)
+    # Keep only one bounded buffer per mel band. This is independent of the
+    # number and duration of source tracks (about 3 MiB at the defaults).
+    handles = [(out / name / 'train.bin').open('wb') for _, name in cols]
+    buffers = [array(typecode) for _ in cols]
+    try:
+        for row_number, row in enumerate(iter_mel_states(input_csv, indexes)):
+            if row_number == train_n:
+                for handle, buffer in zip(handles, buffers): buffer.tofile(handle); handle.close()
+                handles = [(out / name / 'val.bin').open('wb') for _, name in cols]
+                buffers = [array(typecode) for _ in cols]
+            for buffer, value in zip(buffers, row): buffer.append(value)
+            if len(buffers[0]) >= args.buffer_rows:
+                for handle, buffer in zip(handles, buffers): buffer.tofile(handle); del buffer[:]
+        for handle, buffer in zip(handles, buffers): buffer.tofile(handle)
+    finally:
+        for handle in handles:
+            if not handle.closed: handle.close()
+    if train_n == rows:
+        for _, name in cols:
+            (out / name / 'val.bin').touch()
     with (out/'manifest.json').open('w', encoding='utf-8') as f: json.dump(manifest, f, indent=2)
     print(out)
 
@@ -222,8 +318,8 @@ def cmd_stitch(args):
 
 def main():
     p=argparse.ArgumentParser(); sub=p.add_subparsers(required=True)
-    a=sub.add_parser('concat-csv'); a.add_argument('input_csvs', nargs='+'); a.add_argument('--output_csv', required=True); a.add_argument('--manifest_json'); a.set_defaults(func=cmd_concat_csv)
-    a=sub.add_parser('prepare'); a.add_argument('input_csv'); a.add_argument('--output_root',default='mel_mc_int'); a.add_argument('--train_ratio',type=float,default=.9); a.add_argument('--states_per_column',type=int); a.set_defaults(func=cmd_prepare)
+    a=sub.add_parser('concat-csv'); a.add_argument('input_csvs', nargs='*'); a.add_argument('--input_list', help='newline-delimited input paths (avoids shell argument limits)'); a.add_argument('--output_csv', required=True); a.add_argument('--manifest_json'); a.set_defaults(func=cmd_concat_csv)
+    a=sub.add_parser('prepare'); a.add_argument('input_csv'); a.add_argument('--output_root',default='mel_mc_int'); a.add_argument('--train_ratio',type=float,default=.9); a.add_argument('--states_per_column',type=int); a.add_argument('--buffer_rows', type=int, default=4096, help='rows buffered per mel band while writing (default: 4096)'); a.set_defaults(func=cmd_prepare)
     a=sub.add_parser('cut-prompt'); a.add_argument('mel_csv'); a.add_argument('--cutoff_s',type=float,required=True); a.add_argument('--output_dir',default='mel_mc_int_prompt'); a.add_argument('--timestep_ms',type=float,default=15); a.set_defaults(func=cmd_cut_prompt)
     a=sub.add_parser('wrap-csv'); a.add_argument('input_csv'); a.add_argument('--reference_mel_csv',required=True); a.add_argument('--output_csv',required=True); a.set_defaults(func=cmd_wrap_csv)
     a=sub.add_parser('stitch-wav'); a.add_argument('--prompt_wav',required=True); a.add_argument('--continuation_wav',required=True); a.add_argument('--output_wav',required=True); a.set_defaults(func=cmd_stitch)

--- a/data/mel_mc_int/mel_mc_int_tools.py
+++ b/data/mel_mc_int/mel_mc_int_tools.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Utilities for mel-spectrogram integer multicontext datasets and demos."""
+from __future__ import annotations
+
+import argparse, csv, json, pickle, re, shutil, subprocess, sys, wave
+from array import array
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MEL_DIR = REPO_ROOT / "data" / "mel_spectrogram"
+sys.path.insert(0, str(MEL_DIR))
+from audio_to_token_mel import CSV_METADATA_PREFIX, compact_json  # noqa: E402
+from token_mel_to_audio import canonical_state_crc, read_csv_container  # noqa: E402
+
+
+def mel_columns(header: Sequence[str]) -> list[tuple[int, str]]:
+    cols = [(i, h.strip()) for i, h in enumerate(header) if re.fullmatch(r"mel_\d+_q", h.strip())]
+    if not cols:
+        raise ValueError("No mel_NNN_q columns found.")
+    return cols
+
+
+def dtype_for_vocab(vocab: int):
+    return ("I", "uint32") if vocab > 65536 else ("H", "uint16")
+
+
+def read_mel_csv(path: Path):
+    metadata = None
+    rows = []
+    with path.open(newline='', encoding='utf-8') as f:
+        header = None
+        for line in f:
+            s = line.strip()
+            if not s:
+                continue
+            if s.startswith(CSV_METADATA_PREFIX):
+                metadata = json.loads(s[len(CSV_METADATA_PREFIX):])
+                continue
+            if s.startswith('#'):
+                continue
+            header = next(csv.reader([line]))
+            break
+        if header is None:
+            raise ValueError("CSV has no header")
+        cols = mel_columns(header)
+        for row in csv.reader(f):
+            if not row or (row[0].startswith('#')):
+                continue
+            rows.append([int(row[i]) for i, _ in cols])
+    if len(rows) < 2:
+        raise ValueError("Need at least two mel rows")
+    return header, cols, np.asarray(rows, dtype=np.int64), metadata
+
+
+def write_bin(path: Path, values: Sequence[int], typecode: str) -> None:
+    with path.open('wb') as f:
+        array(typecode, values).tofile(f)
+
+
+def cmd_prepare(args):
+    input_csv = Path(args.input_csv).resolve()
+    _, cols, states, metadata = read_mel_csv(input_csv)
+    levels = args.states_per_column or int((metadata or {}).get('quantizer', {}).get('levels', 64))
+    if states.min() < 0 or states.max() >= levels:
+        raise ValueError(f"Mel states [{states.min()}, {states.max()}] exceed [0,{levels-1}]")
+    out = REPO_ROOT / 'data' / args.output_root
+    out.mkdir(parents=True, exist_ok=True)
+    train_n = int(states.shape[0] * args.train_ratio)
+    typecode, dtype_name = dtype_for_vocab(levels)
+    manifest = {"tokenizer":"mel_integer_range_multicontext_manifest","source_mel_csv":str(input_csv),"rows":int(states.shape[0]),"train_rows":train_n,"val_rows":int(states.shape[0]-train_n),"output_root":args.output_root,"multicontext_datasets":[],"columns":[],"roundtrip_metadata":metadata}
+    for j, (_, name) in enumerate(cols):
+        cdir = out / name
+        cdir.mkdir(parents=True, exist_ok=True)
+        vals = states[:, j].astype(int).tolist()
+        write_bin(cdir/'train.bin', vals[:train_n], typecode)
+        write_bin(cdir/'val.bin', vals[train_n:], typecode)
+        meta = {"tokenizer":"csv_integer_range","vocab_size":levels,"source_csv":str(input_csv),"source_column":name,"context_name":name,"column_index":j,"has_header":True,"int_min":0,"int_max":levels-1,"value_encoding":"token_id = raw_integer_value","value_decoding":"raw_integer_value = token_id","dtype":dtype_name,"samples":int(states.shape[0]),"train_ratio":float(args.train_ratio),"mel_mc_int":True}
+        with (cdir/'meta.pkl').open('wb') as f: pickle.dump(meta, f)
+        manifest['multicontext_datasets'].append(f"{args.output_root}/{name}")
+        manifest['columns'].append(meta)
+    with (out/'manifest.json').open('w', encoding='utf-8') as f: json.dump(manifest, f, indent=2)
+    print(out)
+
+
+def cmd_cut_prompt(args):
+    src = Path(args.mel_csv).resolve()
+    header, cols, states, metadata = read_mel_csv(src)
+    hop = int(metadata['stft']['hop_length']) if metadata else None
+    sr = int(metadata['waveform']['sample_rate']) if metadata else None
+    if hop and sr:
+        n = max(1, min(states.shape[0], int(np.ceil(args.cutoff_s * sr / hop))))
+    else:
+        n = max(1, min(states.shape[0], int(round(args.cutoff_s / args.timestep_ms * 1000.0))))
+    out_dir = Path(args.output_dir); out_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = out_dir / 'prompt.csv'
+    with csv_path.open('w', newline='', encoding='utf-8') as f:
+        w = csv.writer(f); w.writerow([name for _, name in cols]); w.writerows(states[:n].tolist())
+    bin_dir = out_dir / 'bins'; bin_dir.mkdir(exist_ok=True)
+    levels = int((metadata or {}).get('quantizer', {}).get('levels', 64)); typecode, dtype_name = dtype_for_vocab(levels)
+    for j, (_, name) in enumerate(cols): write_bin(bin_dir / f'{name}.bin', states[:n, j].astype(int).tolist(), typecode)
+    with (out_dir/'prompt_manifest.json').open('w') as f: json.dump({"csv":str(csv_path),"bin_dir":str(bin_dir),"start_files":[str(bin_dir/f'{name}.bin') for _, name in cols],"dtype":dtype_name,"cutoff_s":args.cutoff_s,"prompt_frames":n}, f, indent=2)
+    print(csv_path)
+
+
+def cmd_wrap_csv(args):
+    input_csv = Path(args.input_csv); ref = read_csv_container(Path(args.reference_mel_csv))
+    with input_csv.open(newline='', encoding='utf-8') as f:
+        reader=csv.reader(f); header=next(reader); cols=mel_columns(header); states=np.asarray([[int(r[i]) for i,_ in cols] for r in reader if r], dtype=np.int64)
+    md = dict(ref.metadata); md['shape'] = dict(md['shape']); md['shape']['timesteps'] = int(states.shape[0]); md['waveform'] = dict(md['waveform']); md['waveform']['decoded_sample_count'] = int(states.shape[0] * int(md['stft']['hop_length'])); md['integrity'] = dict(md['integrity']); md['integrity']['state_crc32'] = f"{canonical_state_crc(states, int(md['quantizer']['levels'])):08x}"
+    out=Path(args.output_csv); out.parent.mkdir(parents=True, exist_ok=True)
+    with input_csv.open('r', encoding='utf-8') as src, out.open('w', encoding='utf-8') as dst:
+        dst.write(src.readline()); dst.write(CSV_METADATA_PREFIX + compact_json(md) + '\n'); shutil.copyfileobj(src, dst)
+    print(out)
+
+
+def cmd_stitch(args):
+    def read_wav(p):
+        with wave.open(str(p),'rb') as w:
+            params=w.getparams(); data=w.readframes(w.getnframes())
+        return params, data
+    p1,d1=read_wav(Path(args.prompt_wav)); p2,d2=read_wav(Path(args.continuation_wav))
+    if p1[:3] != p2[:3] or p1.framerate != p2.framerate: raise ValueError('WAV formats differ')
+    out=Path(args.output_wav); out.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(out),'wb') as w: w.setparams(p1); w.writeframes(d1+d2)
+    print(out)
+
+
+def main():
+    p=argparse.ArgumentParser(); sub=p.add_subparsers(required=True)
+    a=sub.add_parser('prepare'); a.add_argument('input_csv'); a.add_argument('--output_root',default='mel_mc_int'); a.add_argument('--train_ratio',type=float,default=.9); a.add_argument('--states_per_column',type=int); a.set_defaults(func=cmd_prepare)
+    a=sub.add_parser('cut-prompt'); a.add_argument('mel_csv'); a.add_argument('--cutoff_s',type=float,required=True); a.add_argument('--output_dir',default='mel_mc_int_prompt'); a.add_argument('--timestep_ms',type=float,default=15); a.set_defaults(func=cmd_cut_prompt)
+    a=sub.add_parser('wrap-csv'); a.add_argument('input_csv'); a.add_argument('--reference_mel_csv',required=True); a.add_argument('--output_csv',required=True); a.set_defaults(func=cmd_wrap_csv)
+    a=sub.add_parser('stitch-wav'); a.add_argument('--prompt_wav',required=True); a.add_argument('--continuation_wav',required=True); a.add_argument('--output_wav',required=True); a.set_defaults(func=cmd_stitch)
+    args=p.parse_args(); args.func(args)
+if __name__=='__main__': main()

--- a/data/mel_mc_int/run.sh
+++ b/data/mel_mc_int/run.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Build a mel integer multicontext dataset from one audio file.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+MEL_DIR="${SCRIPT_DIR}/../mel_spectrogram"
+INPUT="${1:?Usage: bash data/mel_mc_int/run.sh INPUT_AUDIO [OUTPUT_ROOT]}"
+OUTPUT_ROOT="${2:-mel_mc_int}"
+WORK_DIR="${SCRIPT_DIR}/mel_out"
+
+mkdir -p "${WORK_DIR}"
+
+python3 "${MEL_DIR}/audio_to_token_mel.py" "${INPUT}" --force \
+  --preset max \
+  --samples-per-second 48000 \
+  --fmin 10 \
+  --fmax 20000 \
+  --columns-per-timestep 384 \
+  --states-per-column 64 \
+  --timestep-ms 15 \
+  --win-ms 60 \
+  --n-fft 8192 \
+  --top-db 96 \
+  --reference-mode file_percentile \
+  --output-format both \
+  --output-dir "${WORK_DIR}"
+
+stem="$(basename "${INPUT}")"; stem="${stem%.*}"
+MEL_CSV="${WORK_DIR}/${stem}.max.mel.csv"
+python3 "${SCRIPT_DIR}/mel_mc_int_tools.py" prepare "${MEL_CSV}" \
+  --output_root "${OUTPUT_ROOT}" \
+  --states_per_column 64
+
+echo "Dataset manifest: data/${OUTPUT_ROOT}/manifest.json"

--- a/demos/mel_mc_int_music_pipeline.sh
+++ b/demos/mel_mc_int_music_pipeline.sh
@@ -104,7 +104,9 @@ if (( ${#MEL_CSVS[@]} == 0 )); then
   exit 1
 fi
 
-python3 "$TOOLS" concat-csv "${MEL_CSVS[@]}" \
+CSV_INPUT_LIST="$WORK_DIR/encoded_csvs.txt"
+printf '%s\n' "${MEL_CSVS[@]}" > "$CSV_INPUT_LIST"
+python3 "$TOOLS" concat-csv --input_list "$CSV_INPUT_LIST" \
   --output_csv "$CONCAT_CSV" \
   --manifest_json "$CONCAT_MANIFEST"
 

--- a/demos/mel_mc_int_music_pipeline.sh
+++ b/demos/mel_mc_int_music_pipeline.sh
@@ -22,6 +22,7 @@ Environment overrides:
   MEL_MC_MAX_NEW_TOKENS   Inference frames to sample (default: 200)
   MEL_MC_SKIP_ENCODE      Reuse existing per-file CSVs in WORK_DIR/encoded (default: 0)
   MEL_MC_SKIP_TRAIN       Prepare data and run inference with existing OUT_DIR/ckpt.pt (default: 0)
+  MEL_MC_TENSORBOARD      Enable TensorBoard logging during training (default: 0)
 USAGE
 }
 
@@ -50,6 +51,7 @@ MAX_NEW_TOKENS="${MEL_MC_MAX_NEW_TOKENS:-200}"
 COMPILE_FLAG="${MEL_MC_COMPILE:-1}"
 SKIP_ENCODE="${MEL_MC_SKIP_ENCODE:-0}"
 SKIP_TRAIN="${MEL_MC_SKIP_TRAIN:-0}"
+TENSORBOARD_FLAG="${MEL_MC_TENSORBOARD:-0}"
 MEL_DIR="data/mel_spectrogram"
 TOOLS="data/mel_mc_int/mel_mc_int_tools.py"
 
@@ -124,6 +126,11 @@ if [[ "$COMPILE_FLAG" == "1" || "$COMPILE_FLAG" == "true" || "$COMPILE_FLAG" == 
 else
   TRAIN_COMPILE_ARG="--no-compile"
 fi
+if [[ "$TENSORBOARD_FLAG" == "1" || "$TENSORBOARD_FLAG" == "true" || "$TENSORBOARD_FLAG" == "True" ]]; then
+  TRAIN_TENSORBOARD_ARG="--tensorboard_log"
+else
+  TRAIN_TENSORBOARD_ARG="--no-tensorboard_log"
+fi
 
 if [[ "$SKIP_TRAIN" != "1" ]]; then
   python3 train.py \
@@ -145,6 +152,7 @@ if [[ "$SKIP_TRAIN" != "1" ]]; then
     --device "$DEVICE" \
     --dtype "$DTYPE" \
     "$TRAIN_COMPILE_ARG" \
+    "$TRAIN_TENSORBOARD_ARG" \
     --out_dir "$OUT_DIR"
 fi
 

--- a/demos/mel_mc_int_music_pipeline.sh
+++ b/demos/mel_mc_int_music_pipeline.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# End-to-end mel multicontext music demo:
+# 1) encode every audio file in a folder to mel CSV with the mel_spectrogram/run.sh defaults
+# 2) concatenate the mel-state CSV rows into one training CSV
+# 3) split the concatenated CSV into one integer multicontext dataset per mel band
+# 4) train a regular multicontext model
+# 5) run continuation inference from an input audio prefix and build the HTML viewer
+
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: bash demos/mel_mc_int_music_pipeline.sh MUSIC_DIR [PROMPT_AUDIO] [CUTOFF_SECONDS]
+
+Environment overrides:
+  MEL_MC_OUTPUT_ROOT      Dataset folder under data/ (default: mel_mc_int_music)
+  MEL_MC_WORK_DIR         Intermediate outputs (default: data/mel_mc_int/music_pipeline_out)
+  MEL_MC_OUT_DIR          Training checkpoint dir (default: out/mel_mc_int_music)
+  MEL_MC_MAX_ITERS        Training iterations (default: 1000)
+  MEL_MC_DEVICE           Device for train/sample/audio tools (default: cuda:0)
+  MEL_MC_DTYPE            Training/sample dtype (default: bfloat16)
+  MEL_MC_MAX_NEW_TOKENS   Inference frames to sample (default: 200)
+  MEL_MC_SKIP_ENCODE      Reuse existing per-file CSVs in WORK_DIR/encoded (default: 0)
+  MEL_MC_SKIP_TRAIN       Prepare data and run inference with existing OUT_DIR/ckpt.pt (default: 0)
+USAGE
+}
+
+if [[ $# -lt 1 || "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  [[ $# -ge 1 ]] && exit 0
+  exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+MUSIC_DIR="$1"
+PROMPT_AUDIO="${2:-}"
+CUTOFF_SECONDS="${3:-10.0}"
+OUTPUT_ROOT="${MEL_MC_OUTPUT_ROOT:-mel_mc_int_music}"
+WORK_DIR="${MEL_MC_WORK_DIR:-data/mel_mc_int/music_pipeline_out}"
+ENCODED_DIR="${WORK_DIR}/encoded"
+CONCAT_CSV="${WORK_DIR}/all_music.max.mel.csv"
+CONCAT_MANIFEST="${WORK_DIR}/concat_manifest.json"
+OUT_DIR="${MEL_MC_OUT_DIR:-out/mel_mc_int_music}"
+MAX_ITERS="${MEL_MC_MAX_ITERS:-1000}"
+DEVICE="${MEL_MC_DEVICE:-cuda:0}"
+DTYPE="${MEL_MC_DTYPE:-bfloat16}"
+MAX_NEW_TOKENS="${MEL_MC_MAX_NEW_TOKENS:-200}"
+COMPILE_FLAG="${MEL_MC_COMPILE:-1}"
+SKIP_ENCODE="${MEL_MC_SKIP_ENCODE:-0}"
+SKIP_TRAIN="${MEL_MC_SKIP_TRAIN:-0}"
+MEL_DIR="data/mel_spectrogram"
+TOOLS="data/mel_mc_int/mel_mc_int_tools.py"
+
+if [[ ! -d "$MUSIC_DIR" ]]; then
+  echo "Music directory does not exist: $MUSIC_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$ENCODED_DIR" "$WORK_DIR" "$OUT_DIR"
+
+mapfile -d '' AUDIO_FILES < <(
+  find "$MUSIC_DIR" -maxdepth 1 -type f \
+    \( -iname '*.wav' -o -iname '*.flac' -o -iname '*.mp3' -o -iname '*.m4a' -o -iname '*.aac' -o -iname '*.ogg' -o -iname '*.opus' \) \
+    -print0 | sort -z
+)
+
+if (( ${#AUDIO_FILES[@]} == 0 )); then
+  echo "No supported audio files found in $MUSIC_DIR" >&2
+  exit 1
+fi
+
+if [[ -z "$PROMPT_AUDIO" ]]; then
+  PROMPT_AUDIO="${AUDIO_FILES[0]}"
+fi
+
+if [[ "$SKIP_ENCODE" != "1" ]]; then
+  for audio in "${AUDIO_FILES[@]}"; do
+    echo "Encoding $audio"
+    python3 "${MEL_DIR}/audio_to_token_mel.py" "$audio" --force \
+      --preset max \
+      --samples-per-second 48000 \
+      --fmin 10 \
+      --fmax 20000 \
+      --columns-per-timestep 384 \
+      --states-per-column 64 \
+      --timestep-ms 15 \
+      --win-ms 60 \
+      --n-fft 8192 \
+      --top-db 96 \
+      --reference-mode file_percentile \
+      --output-format csv \
+      --output-dir "$ENCODED_DIR" \
+      --device "$DEVICE"
+  done
+fi
+
+mapfile -d '' MEL_CSVS < <(find "$ENCODED_DIR" -maxdepth 1 -type f -name '*.max.mel.csv' -print0 | sort -z)
+if (( ${#MEL_CSVS[@]} == 0 )); then
+  echo "No encoded mel CSVs found in $ENCODED_DIR" >&2
+  exit 1
+fi
+
+python3 "$TOOLS" concat-csv "${MEL_CSVS[@]}" \
+  --output_csv "$CONCAT_CSV" \
+  --manifest_json "$CONCAT_MANIFEST"
+
+python3 "$TOOLS" prepare "$CONCAT_CSV" \
+  --output_root "$OUTPUT_ROOT" \
+  --states_per_column 64
+
+mapfile -t DATASETS < <(python3 - <<PY
+import json
+from pathlib import Path
+manifest = json.loads(Path('data/$OUTPUT_ROOT/manifest.json').read_text())
+for dataset in manifest['multicontext_datasets']:
+    print(dataset)
+PY
+)
+
+if [[ "$COMPILE_FLAG" == "1" || "$COMPILE_FLAG" == "true" || "$COMPILE_FLAG" == "True" ]]; then
+  TRAIN_COMPILE_ARG="--compile"
+else
+  TRAIN_COMPILE_ARG="--no-compile"
+fi
+
+if [[ "$SKIP_TRAIN" != "1" ]]; then
+  python3 train.py \
+    --training_mode multicontext \
+    --dataset "${DATASETS[0]}" \
+    --multicontext \
+    --multicontext_datasets "${DATASETS[@]}" \
+    --n_layer "${MEL_MC_N_LAYER:-8}" \
+    --n_head "${MEL_MC_N_HEAD:-8}" \
+    --n_embd "${MEL_MC_N_EMBD:-512}" \
+    --block_size "${MEL_MC_BLOCK_SIZE:-256}" \
+    --batch_size "${MEL_MC_BATCH_SIZE:-2}" \
+    --gradient_accumulation_steps "${MEL_MC_GRAD_ACCUM:-1}" \
+    --max_iters "$MAX_ITERS" \
+    --eval_interval "${MEL_MC_EVAL_INTERVAL:-100}" \
+    --eval_iters "${MEL_MC_EVAL_ITERS:-10}" \
+    --learning_rate "${MEL_MC_LR:-1e-3}" \
+    --dropout "${MEL_MC_DROPOUT:-0.0}" \
+    --device "$DEVICE" \
+    --dtype "$DTYPE" \
+    "$TRAIN_COMPILE_ARG" \
+    --out_dir "$OUT_DIR"
+fi
+
+bash data/mel_mc_int/demo_infer.sh "$OUT_DIR" "$PROMPT_AUDIO" "$CUTOFF_SECONDS" "$MAX_NEW_TOKENS"

--- a/train.py
+++ b/train.py
@@ -1,6 +1,7 @@
 # train.py
 from contextlib import nullcontext
 import csv
+import importlib
 import json
 import math
 import os
@@ -98,8 +99,6 @@ import torch.onnx
 import torch.nn.functional as F
 from torch.distributed import destroy_process_group, init_process_group
 from torch.nn.parallel import DistributedDataParallel as DDP
-from torch.utils.tensorboard import SummaryWriter
-
 from variations.model_variations import model_variation_dictionary
 
 from model import GPT, GPTConfig
@@ -108,6 +107,11 @@ from model import GPT, GPTConfig
 import tiktoken
 
 from train_args import parse_args
+
+
+def get_summary_writer_class():
+    return importlib.import_module("torch.utils.tensorboard").SummaryWriter
+
 
 class Trainer:
 
@@ -512,7 +516,7 @@ class Trainer:
             if self.args.csv_log:
                 self.args.csv_name = f"{sanitized_dataset}_{run_name}"
             log_subpath = os.path.join(self.args.tensorboard_log_dir, run_name)
-            self.writer = SummaryWriter(log_subpath)
+            self.writer = get_summary_writer_class()(log_subpath)
 
         # Wandb
         if self.args.wandb_log and self.master_process:


### PR DESCRIPTION
### Motivation

- Provide an analogous `mel_mc_int` pipeline that mirrors `data/mel_spectrogram` and the `csv_mc_int` multicontext pattern so mel-band quantized states can be trained and sampled as regular integer multicontext datasets. 
- Make the dataset/demo defaults consistent with `data/mel_spectrogram/run.sh` so high-fidelity settings are used by default for dataset creation and inference.
- Enable easy interactive auditioning and re-running of inference by producing a small static HTML viewer that helps choose an input audio file and cutoff time for prompt extraction.

### Description

- Add `data/mel_mc_int/mel_mc_int_tools.py` which implements utilities and CLI subcommands `prepare`, `cut-prompt`, `wrap-csv`, and `stitch-wav` for converting self-describing mel CSVs into per-band multicontext datasets, extracting a prompt from `0.0` to a chosen cutoff, wrapping generated CSV continuations with reference metadata, and concatenating WAVs. 
- Add `data/mel_mc_int/run.sh` to run `audio_to_token_mel.py` with defaults matching `mel_spectrogram/run.sh` (`preset max`, `48000` Hz, `fmin=10`, `fmax=20000`, `384` columns, `64` states, `timestep-ms=15`, `win-ms=60`, `n-fft=8192`, `top-db=96`, `reference-mode=file_percentile`) and then produce the multicontext manifest. 
- Add `data/mel_mc_int/demo_infer.sh` to encode an input audio file, cut the prompt at a user-specified cutoff, run `sample.py` using the manifest, reconstruct generated audio via `token_mel_to_audio.py`, and emit artifacts for the viewer. 
- Add `data/mel_mc_int/make_viewer.py` which writes a small static `index.html` that plays `generated.wav`, links generated CSV artifacts, and includes a browser-side picker and cutoff/parameters that produce a copyable rerun command. 
- Add `data/mel_mc_int/README.md` documenting the workflow, defaults, dataset creation, and how to run the continuation demo.

### Testing

- Successfully compiled the new Python tools with `python3 -m py_compile data/mel_mc_int/mel_mc_int_tools.py data/mel_mc_int/make_viewer.py`. 
- Shell sanity checks passed with `bash -n` for the added `run.sh` and `demo_infer.sh` scripts. 
- Attempted end-to-end `run.sh` on a generated test WAV, but the run failed due to an environment dependency error (`ModuleNotFoundError: No module named 'numpy'`), so full audio→CSV→dataset generation could not be completed in this environment. 
- Verified presence of the generated files and manifest structure via local inspections (files: `data/mel_mc_int/{run.sh,mel_mc_int_tools.py,demo_infer.sh,make_viewer.py,README.md}`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72f1531870832685323c26260997bf)