### PR TITLE
Add optional per-channel Q/K gains for QK norm scale (with YAML and tests)

### DIFF
--- a/explorations/qk_norm_scale_per_channel_comparison.yaml
+++ b/explorations/qk_norm_scale_per_channel_comparison.yaml
@@ -1,10 +1,15 @@
 # Compare the legacy shared QK norm scale with separate per-channel Q/K gains.
 ---
-parameter_groups:
+named_static_groups:
   - named_group: "shared_scale"
     use_qk_norm_scale_per_channel: [false]
   - named_group: "per_channel_q_and_k_scale"
     use_qk_norm_scale_per_channel: [true]
+
+parameter_groups:
+  - named_group_alternates:
+      - "shared_scale"
+      - "per_channel_q_and_k_scale"
 
 max_iters: [10000]
 eval_interval: [500]

--- a/explorations/qk_norm_scale_per_channel_comparison.yaml
+++ b/explorations/qk_norm_scale_per_channel_comparison.yaml
@@ -23,3 +23,6 @@ use_abs_pos_embeddings: [false]
 
 compile: [true]
 never_save_checkpoint: [true]
+# Keep this architecture comparison independent of optional TensorBoard/
+# TensorFlow binary dependencies. Metrics are still printed by the trainer.
+tensorboard_log: [false]

--- a/explorations/qk_norm_scale_per_channel_comparison.yaml
+++ b/explorations/qk_norm_scale_per_channel_comparison.yaml
@@ -1,0 +1,25 @@
+# Compare the legacy shared QK norm scale with separate per-channel Q/K gains.
+---
+parameter_groups:
+  - named_group: "shared_scale"
+    use_qk_norm_scale_per_channel: [false]
+  - named_group: "per_channel_q_and_k_scale"
+    use_qk_norm_scale_per_channel: [true]
+
+max_iters: [10000]
+eval_interval: [500]
+n_layer: [6]
+n_head: [6]
+n_embd: [384]
+block_size: [256]
+device: ["cuda"]
+dtype: ["float16"]
+dataset: ["minipile"]
+
+use_qk_norm: [true]
+use_qk_norm_scale: [true]
+use_rotary_embeddings: [true]
+use_abs_pos_embeddings: [false]
+
+compile: [true]
+never_save_checkpoint: [true]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -186,6 +186,7 @@ class GPTConfig:
     # QK Norm Options
     use_qk_norm: bool = False
     use_qk_norm_scale: bool = False
+    use_qk_norm_scale_per_channel: bool = False
     use_v_norm: bool = False
 
     ## SSM - Attention Varient (same as Hymba)

--- a/tests/test_qk_norm_scale.py
+++ b/tests/test_qk_norm_scale.py
@@ -1,0 +1,61 @@
+import math
+
+import torch
+
+from gpt_conf import GPTConfig
+from variations.attention_variations import CausalSelfAttention, InfiniteHeadAttention
+
+
+def _config(**overrides):
+    values = dict(
+        block_size=8,
+        n_layer=1,
+        n_head=2,
+        n_kv_group=2,
+        n_embd=8,
+        dropout=0.0,
+        use_qk_norm=True,
+        use_qk_norm_scale=True,
+        disable_flash_attention=True,
+    )
+    values.update(overrides)
+    return GPTConfig(**values)
+
+
+def test_per_channel_qk_scale_has_separate_gains_and_gradients():
+    config = _config(use_qk_norm_scale_per_channel=True)
+    attention = CausalSelfAttention(config)
+
+    expected_gain = math.sqrt(math.log2(config.block_size**2 - config.block_size))
+    torch.testing.assert_close(
+        attention.qk_norm_q_gain,
+        torch.full((config.n_embd // config.n_head,), expected_gain),
+    )
+    torch.testing.assert_close(attention.qk_norm_q_gain, attention.qk_norm_k_gain)
+    assert attention.qk_norm_q_gain is not attention.qk_norm_k_gain
+    assert not hasattr(attention, "qk_norm_factor")
+
+    attention(torch.randn(2, config.block_size, config.n_embd), iter_num=0).sum().backward()
+    assert attention.qk_norm_q_gain.grad is not None
+    assert attention.qk_norm_k_gain.grad is not None
+
+
+def test_legacy_qk_scale_remains_a_scalar():
+    attention = CausalSelfAttention(_config(use_qk_norm_scale_per_channel=False))
+
+    assert attention.qk_norm_factor.shape == torch.Size([])
+    assert not hasattr(attention, "qk_norm_q_gain")
+    assert not hasattr(attention, "qk_norm_k_gain")
+
+
+def test_infinite_attention_uses_configured_qk_channel_dimension():
+    config = _config(
+        use_qk_norm_scale_per_channel=True,
+        n_qk_head_dim=6,
+        n_v_head_dim=4,
+        n_cproj=1,
+    )
+    attention = InfiniteHeadAttention(config)
+
+    assert attention.qk_norm_q_gain.shape == (config.n_qk_head_dim,)
+    assert attention.qk_norm_k_gain.shape == (config.n_qk_head_dim,)

--- a/tests/test_run_experiments.py
+++ b/tests/test_run_experiments.py
@@ -49,5 +49,29 @@ class SweepDefaultAndNullTests(unittest.TestCase):
         self.assertEqual(list(run_experiments.generate_combinations(config)), [({}, set())])
 
 
+class QKNormScaleComparisonTests(unittest.TestCase):
+    def test_named_scale_variants_are_metadata_not_training_arguments(self):
+        config_path = (
+            Path(__file__).parents[1]
+            / "explorations"
+            / "qk_norm_scale_per_channel_comparison.yaml"
+        )
+        config = yaml.safe_load(config_path.read_text())
+
+        combinations = [
+            combo for combo, _common_keys in run_experiments.generate_combinations(config)
+        ]
+
+        self.assertEqual(len(combinations), 2)
+        self.assertEqual(
+            {combo["use_qk_norm_scale_per_channel"] for combo in combinations},
+            {False, True},
+        )
+        for combo in combinations:
+            command = run_experiments.build_command(combo)
+            self.assertNotIn("--named_group", command)
+            self.assertFalse(any("named_group" in argument for argument in command))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/train.py
+++ b/train.py
@@ -98,7 +98,6 @@ import torch.onnx
 import torch.nn.functional as F
 from torch.distributed import destroy_process_group, init_process_group
 from torch.nn.parallel import DistributedDataParallel as DDP
-from torch.utils.tensorboard import SummaryWriter
 
 from variations.model_variations import model_variation_dictionary
 
@@ -113,6 +112,7 @@ class Trainer:
 
     def __init__(self, args, model_group, training_group, logging_group):
         self.args = args
+        self.writer = None
         self.model_group = model_group
         self.training_group = training_group
         self.logging_group = logging_group
@@ -499,6 +499,11 @@ class Trainer:
 
         # Tensorboard
         if self.args.tensorboard_log:
+            # TensorBoard is optional. Import it only when logging is enabled so
+            # experiments that disable it do not load TensorFlow or its binary
+            # dependencies during process startup.
+            from torch.utils.tensorboard import SummaryWriter
+
             # 1) Give the run a safe default name when the user did not supply one
             if self.args.tensorboard_run_name is None:
                 self.args.tensorboard_run_name = f"{timestamp_prefix}"

--- a/train_args.py
+++ b/train_args.py
@@ -1023,6 +1023,7 @@ def parse_args():
     ## qk_norm variations
     model_group.add_argument("--use_qk_norm",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="applies the norm to q and k before attn")
     model_group.add_argument("--use_qk_norm_scale",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="applies norm scale, preloads scale for flash attn, post qk multiplication in manual attn")
+    model_group.add_argument("--use_qk_norm_scale_per_channel", type=bool, default=False, action=argparse.BooleanOptionalAction, help="learns separate per-channel q and k gains instead of one scalar qk norm scale")
     model_group.add_argument("--use_v_norm",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="applies the norm to v before attn output")
 
     ## Flash Lobo

--- a/variations/attention_variations.py
+++ b/variations/attention_variations.py
@@ -39,6 +39,33 @@ def _compute_kv_group_distribution(n_head: int, n_kv_group: int):
         )
 
     return group_sizes, head_to_group
+
+
+def _init_qk_norm_scale(module, config, qk_head_dim):
+    """Initialize either the legacy scalar scale or separate Q/K channel gains."""
+    module.use_qk_norm_scale_per_channel = getattr(
+        config, "use_qk_norm_scale_per_channel", False
+    )
+    if not module.use_qk_norm_scale:
+        return
+
+    sequence_length = config.block_size
+    initial_logit_scale = math.log2(sequence_length * sequence_length - sequence_length)
+    if module.use_qk_norm_scale_per_channel:
+        # Splitting sqrt(g0) evenly between Q and K preserves the legacy initial
+        # logit scale while allowing the two projections to learn independently.
+        initial_gain = math.sqrt(initial_logit_scale)
+        module.qk_norm_q_gain = nn.Parameter(torch.full((qk_head_dim,), initial_gain))
+        module.qk_norm_k_gain = nn.Parameter(torch.full((qk_head_dim,), initial_gain))
+    else:
+        module.qk_norm_factor = nn.Parameter(torch.tensor(initial_logit_scale))
+
+
+def _apply_qk_channel_gains(module, q, k):
+    if module.use_qk_norm_scale and module.use_qk_norm_scale_per_channel:
+        q = q * module.qk_norm_q_gain
+        k = k * module.qk_norm_k_gain
+    return q, k
 # Mamba related imports
 # if torch.cuda.is_available():
 #     from causal_conv1d import causal_conv1d_fn, causal_conv1d_update
@@ -195,11 +222,7 @@ class CausalSelfAttention(nn.Module):
                 self.rotary_emb_q = RotaryEmbedding(config, size=config.n_embd // self.n_head)
                 self.rotary_emb_k = RotaryEmbedding(config, size=config.n_embd // self.n_head)
 
-        # qk norm factor
-        if self.use_qk_norm_scale:
-            L = config.block_size
-            g0 = math.log2(L*L - L)
-            self.qk_norm_factor = nn.Parameter(torch.tensor(g0))
+        _init_qk_norm_scale(self, config, config.n_embd // self.n_head)
 
         self.flash = True
         if self.window_size is not None:
@@ -331,6 +354,7 @@ class CausalSelfAttention(nn.Module):
         if self.use_qk_norm:
             q = q / (q.norm(dim=-1, keepdim=True) + 1e-6)
             k = k / (k.norm(dim=-1, keepdim=True) + 1e-6)
+        q, k = _apply_qk_channel_gains(self, q, k)
 
         if self.use_v_norm:
             v = v / (v.norm(dim=-1, keepdim=True) + 1e-6)
@@ -344,8 +368,10 @@ class CausalSelfAttention(nn.Module):
             # Flash QK Norm
             if self.use_qk_norm_scale:
                 # pre-scale Q so that built-in √dₕ division becomes our g scaling
-                head_dim = math.sqrt(k_attn.size(-1))
-                qk_scaling_factor = self.qk_norm_factor * math.sqrt(head_dim)
+                sqrt_head_dim = math.sqrt(k_attn.size(-1))
+                qk_scaling_factor = sqrt_head_dim
+                if not self.use_qk_norm_scale_per_channel:
+                    qk_scaling_factor *= self.qk_norm_factor
                 q = q * qk_scaling_factor
 
             # Flash Lobo
@@ -377,6 +403,12 @@ class CausalSelfAttention(nn.Module):
             )
         elif self.use_flex_attn and self.window_size is not None:
             block_mask = self.get_block_mask(T, x.device)
+            if self.use_qk_norm_scale:
+                # flex_attention uses the same 1/√dₕ default as SDPA.
+                qk_scaling_factor = math.sqrt(k.size(-1))
+                if not self.use_qk_norm_scale_per_channel:
+                    qk_scaling_factor *= self.qk_norm_factor
+                q = q * qk_scaling_factor
             y = torch.nn.attention.flex_attention.flex_attention(q, k, v, block_mask=block_mask)
         else:
             if self.quantization_attn_dict["quantize_attn_act_qk_mult_q_input"]:
@@ -395,7 +427,8 @@ class CausalSelfAttention(nn.Module):
             att = (q @ k_attn.transpose(-2, -1))
 
             if self.use_qk_norm_scale:
-                att = att * self.qk_norm_factor
+                if not self.use_qk_norm_scale_per_channel:
+                    att = att * self.qk_norm_factor
             else:
                 att = att / head_dim
 
@@ -597,11 +630,7 @@ class EdgeLLMASICAttention(nn.Module):
                 self.rotary_emb_q = RotaryEmbedding(config, size=config.n_embd // self.n_head)
                 self.rotary_emb_k = RotaryEmbedding(config, size=config.n_embd // self.n_head)
 
-        # qk norm factor
-        if self.use_qk_norm_scale:
-            L = config.block_size
-            g0 = math.log2(L*L - L)
-            self.qk_norm_factor = nn.Parameter(torch.tensor(g0))
+        _init_qk_norm_scale(self, config, config.n_embd // self.n_head)
 
         print("WARNING: using slow attention. Flash Attention requires PyTorch >= 2.0")
         # causal mask to ensure that attention is only applied to the left in the input sequence
@@ -666,6 +695,7 @@ class EdgeLLMASICAttention(nn.Module):
         if self.use_qk_norm:
             q = q / (q.norm(dim=-1, keepdim=True) + 1e-6)
             k = k / (k.norm(dim=-1, keepdim=True) + 1e-6)
+        q, k = _apply_qk_channel_gains(self, q, k)
 
         if self.use_v_norm:
             v = v / (v.norm(dim=-1, keepdim=True) + 1e-6)
@@ -686,7 +716,8 @@ class EdgeLLMASICAttention(nn.Module):
         att = (q @ k_attn.transpose(-2, -1))
 
         if self.use_qk_norm_scale:
-            att = att * self.qk_norm_factor
+            if not self.use_qk_norm_scale_per_channel:
+                att = att * self.qk_norm_factor
         else:
             att = att / head_dim
 
@@ -1136,11 +1167,7 @@ class InfiniteHeadAttention(nn.Module):
                 self.rotary_emb_q = RotaryEmbedding(config, size=self.n_qk_head_dim)
                 self.rotary_emb_k = RotaryEmbedding(config, size=self.n_qk_head_dim)
 
-        # qk norm factor
-        if self.use_qk_norm_scale:
-            L = config.block_size
-            g0 = math.log2(L*L - L)
-            self.qk_norm_factor = nn.Parameter(torch.tensor(g0))
+        _init_qk_norm_scale(self, config, self.n_qk_head_dim)
 
         # Softmax Variant Selection
         self.softmax_variant_attn = config.softmax_variant_attn
@@ -1196,6 +1223,7 @@ class InfiniteHeadAttention(nn.Module):
         if self.use_qk_norm:
             q = q / (q.norm(dim=-1, keepdim=True) + 1e-6)
             k = k / (k.norm(dim=-1, keepdim=True) + 1e-6)
+        q, k = _apply_qk_channel_gains(self, q, k)
 
         if self.use_v_norm:
             v = v / (v.norm(dim=-1, keepdim=True) + 1e-6)
@@ -1211,7 +1239,9 @@ class InfiniteHeadAttention(nn.Module):
             if self.use_qk_norm_scale:
                 # pre-scale Q so that built-in √dₕ division becomes our g scaling
                 sqrt_head_dim = math.sqrt(k_attn.size(-1))
-                qk_scaling_factor = self.qk_norm_factor * sqrt_head_dim
+                qk_scaling_factor = sqrt_head_dim
+                if not self.use_qk_norm_scale_per_channel:
+                    qk_scaling_factor *= self.qk_norm_factor
                 q = q * qk_scaling_factor
 
             # Flash Lobo
@@ -1251,8 +1281,9 @@ class InfiniteHeadAttention(nn.Module):
             att = (q @ k_attn.transpose(-2, -1))
 
             if self.use_qk_norm_scale:
-                # utilize learned qk_norm_scaling factor
-                att = att * self.qk_norm_factor
+                if not self.use_qk_norm_scale_per_channel:
+                    # utilize learned qk_norm_scaling factor
+                    att = att * self.qk_norm_factor
             else:
                 sqrt_head_dim = math.sqrt(k_attn.size(-1))
                 # divide by sqrt of head dimension if not


### PR DESCRIPTION
### Motivation
- Provide an opt-in mode for QK normalization that learns independent per-channel gains for queries and keys so experiments can tune Q and K scaling separately while preserving legacy behavior.

### Description
- Add `use_qk_norm_scale_per_channel` to the configuration and CLI (`gpt_conf.py`, `train_args.py`) to enable the new mode.
- Implement `_init_qk_norm_scale` and `_apply_qk_channel_gains` in `variations/attention_variations.py` to initialize either the legacy scalar `qk_norm_factor` or per-channel `qk_norm_q_gain`/`qk_norm_k_gain`, and integrate these gains into `CausalSelfAttention`, `EdgeLLMASICAttention`, and `InfiniteHeadAttention` (including adjustments for flash, flex, and manual attention code paths).
- Add `explorations/qk_norm_scale_per_channel_comparison.yaml` to compare the shared scalar scale vs per-channel Q/K gains.
- Add focused unit tests `tests/test_qk_norm_scale.py` to check initialization, parameter shapes, separation of parameters, and gradient flow for the new gains.

### Testing
- `python -m py_compile gpt_conf.py train_args.py variations/attention_variations.py tests/test_qk_norm_scale.py` succeeded and ensured syntax correctness for modified files.
- Parsed and validated the new exploration YAML with a small Python snippet, which passed.
- Ran `git diff --check` and committed the changes successfully.
- Running `pytest tests/test_qk_norm_scale.py` was attempted but test collection failed because `torch` is not installed in the environment, and running `optimization_and_search/run_from_yaml.py --help` also failed due to a missing optional dependency (`rich`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7609ff9a748326b72ef9e1d66114b4)