### PR TITLE
feat(loss): add NLL "surprise" objective family and comparison exploration

### DIFF
--- a/explorations/surprise_loss_comparison.yaml
+++ b/explorations/surprise_loss_comparison.yaml
@@ -1,0 +1,47 @@
+# Compare NLL surprise objectives V0--V7 under a shared training setup.
+---
+common_group:
+  dataset: ["minipile"]
+  max_iters: [10000]
+  eval_interval: [500]
+  device: ["cuda"]
+  dtype: ["bfloat16"]
+  compile: [true]
+  never_save_checkpoint: [true]
+  loss_aggregation: ["token"]
+
+parameter_groups:
+  # V0 and V1
+  - loss_fn: ["cross_entropy"]
+  - loss_fn: ["median_nll"]
+
+  # V2 and its nat-scaled V2R form
+  - loss_fn: ["second_moment_nll"]
+  - loss_fn: ["rms_surprise"]
+
+  # V3 recommended initial lambda sweep (c=1).
+  - loss_fn: ["hybrid_ce_squared"]
+    surprise_lambda: [0.1, 0.25, 0.5, 1.0]
+    surprise_scale: [1.0]
+
+  # V4 recommended focal sweep.
+  - loss_fn: ["focal"]
+    focal_gamma: [0.5, 1.0, 2.0]
+
+  # V5 and V6 expose q independently from focal gamma.
+  - loss_fn: ["power_surprise"]
+    loss_power_q: [1.5, 2.0, 3.0]
+  - loss_fn: ["focal_power"]
+    focal_gamma: [0.5, 1.0, 2.0]
+    loss_power_q: [1.0, 2.0]
+
+  # V7 bounded hard-token emphasis.
+  - loss_fn: ["capped_tail"]
+    surprise_lambda: [0.1, 0.25, 0.5, 1.0]
+    surprise_scale: [1.0]
+    loss_tail_cap: [4.0]
+
+  # Compare the aggregation axes using V2 while holding its objective fixed.
+  - loss_fn: ["second_moment_nll"]
+    loss_aggregation: ["sequence", "position", "window"]
+    loss_window_size: [16]

--- a/tests/test_surprise_losses.py
+++ b/tests/test_surprise_losses.py
@@ -1,0 +1,72 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from train_variations.loss_variants import build_loss_function, surprise_loss
+
+
+def _fixture():
+    logits = torch.tensor(
+        [[[2.0, 0.0, -1.0], [0.0, 1.0, 2.0]], [[1.0, 0.0, 0.0], [3.0, -1.0, 0.0]]],
+        requires_grad=True,
+    )
+    targets = torch.tensor([[0, 1], [2, -1]])
+    nll = F.cross_entropy(logits.reshape(-1, 3), targets.reshape(-1), reduction="none", ignore_index=-1)
+    return logits, targets, nll[targets.reshape(-1) != -1]
+
+
+@pytest.mark.parametrize(
+    ("variant", "expected"),
+    [
+        ("median_nll", lambda x: x.median()),
+        ("second_moment_nll", lambda x: x.square().mean()),
+        ("rms_surprise", lambda x: x.square().mean().sqrt()),
+        ("hybrid_ce_squared", lambda x: (x + 0.125 * x.square()).mean()),
+        ("power_surprise", lambda x: x.square().mean().sqrt()),
+        ("focal_power", lambda x: ((1 - torch.exp(-x)) ** 2 * x.square()).mean()),
+        ("capped_tail", lambda x: (x * (1 + 0.25 * torch.minimum(x, x.new_tensor(4.0)))).mean()),
+    ],
+)
+def test_surprise_loss_tokenwise_formulas(variant, expected):
+    logits, targets, nll = _fixture()
+    actual = surprise_loss(logits, targets, variant=variant)
+    torch.testing.assert_close(actual, expected(nll))
+    actual.backward()
+    assert torch.isfinite(logits.grad).all()
+
+
+def test_second_moment_aggregation_axes():
+    logits, targets, nll = _fixture()
+    sequence_means = torch.stack((nll[:2].mean(), nll[2]))
+    position_means = torch.stack((torch.stack((nll[0], nll[2])).mean(), nll[1]))
+    torch.testing.assert_close(
+        surprise_loss(logits, targets, variant="second_moment_nll", aggregation="sequence"),
+        sequence_means.square().mean(),
+    )
+    torch.testing.assert_close(
+        surprise_loss(logits, targets, variant="second_moment_nll", aggregation="position"),
+        position_means.square().mean(),
+    )
+    torch.testing.assert_close(
+        surprise_loss(logits, targets, variant="second_moment_nll", aggregation="window", window_size=2),
+        sequence_means.square().mean(),
+    )
+
+
+def test_builder_configures_focal_and_ignores_invalid_tokens():
+    logits, targets, _ = _fixture()
+    args = SimpleNamespace(loss_fn="focal", loss_schedule=None, focal_gamma=1.0, focal_alpha=0.5)
+    built = build_loss_function(args)
+    expected = surprise_loss(logits, targets, variant="focal", focal_gamma=1.0, focal_alpha=0.5)
+    torch.testing.assert_close(built(logits, targets), expected)
+
+
+def test_all_invalid_batch_has_differentiable_zero_loss():
+    logits = torch.randn(2, 3, 5, requires_grad=True)
+    targets = torch.full((2, 3), -1)
+    loss = surprise_loss(logits, targets)
+    loss.backward()
+    assert loss.item() == 0.0
+    assert torch.count_nonzero(logits.grad) == 0

--- a/train_args.py
+++ b/train_args.py
@@ -161,6 +161,20 @@ def parse_args():
         default=2.0,
         help='Gamma parameter for focal-style losses.',
     )
+    training_group.add_argument('--focal_alpha', type=float, default=1.0,
+                                help='Scalar alpha multiplier for focal NLL.')
+    training_group.add_argument('--surprise_lambda', type=float, default=0.25,
+                                help='Hard-token weight for hybrid and capped-tail losses.')
+    training_group.add_argument('--surprise_scale', type=float, default=1.0,
+                                help='Scale c used by hybrid and capped-tail losses.')
+    training_group.add_argument('--loss_power_q', type=float, default=2.0,
+                                help='Power q used by power-surprise losses.')
+    training_group.add_argument('--loss_tail_cap', type=float, default=4.0,
+                                help='Maximum tail multiplier input for capped-tail loss.')
+    training_group.add_argument('--loss_aggregation', choices=['token', 'sequence', 'position', 'window'],
+                                default='token', help='Axis on which surprise losses are aggregated.')
+    training_group.add_argument('--loss_window_size', type=int, default=16,
+                                help='Non-overlapping window width for window loss aggregation.')
     training_group.add_argument(
         '--top1_focus_alpha',
         type=float,

--- a/train_variations/loss_variants.py
+++ b/train_variations/loss_variants.py
@@ -13,6 +13,7 @@ provided that more strongly encourage correct top-1 predictions.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from functools import partial
 from typing import Callable, Dict, Iterable, List, Tuple
 
 import math
@@ -29,6 +30,104 @@ from utils.bit_usage import compute_total_bit_usage
 def cross_entropy_loss(logits: torch.Tensor, targets: torch.Tensor, *, iter_num: int | None = None) -> torch.Tensor:
     """Standard cross-entropy loss used by the original codebase."""
     return F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1), ignore_index=-1)
+
+
+def _token_nll(logits: torch.Tensor, targets: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return per-token NLL in batch/sequence shape and its validity mask."""
+    flat_targets = targets.reshape(-1)
+    nll = F.cross_entropy(
+        logits.reshape(-1, logits.size(-1)), flat_targets, reduction="none", ignore_index=-1
+    ).reshape_as(targets)
+    return nll, targets != -1
+
+
+def _group_values(
+    values: torch.Tensor,
+    mask: torch.Tensor,
+    aggregation: str,
+    window_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Aggregate token values and return group means plus valid group sizes."""
+    if aggregation == "token":
+        return values[mask], torch.ones_like(values[mask])
+
+    if values.ndim == 1:
+        values, mask = values.unsqueeze(0), mask.unsqueeze(0)
+    elif values.ndim != 2:
+        values, mask = values.reshape(-1, values.shape[-1]), mask.reshape(-1, mask.shape[-1])
+
+    weighted = values * mask
+    if aggregation == "sequence":
+        counts = mask.sum(dim=1)
+        valid = counts > 0
+        return weighted.sum(dim=1)[valid] / counts[valid], counts[valid]
+    if aggregation == "position":
+        counts = mask.sum(dim=0)
+        valid = counts > 0
+        return weighted.sum(dim=0)[valid] / counts[valid], counts[valid]
+    if aggregation == "window":
+        if window_size <= 0:
+            raise ValueError("loss_window_size must be positive")
+        groups, counts = [], []
+        for start in range(0, values.size(1), window_size):
+            window_mask = mask[:, start : start + window_size]
+            window_counts = window_mask.sum(dim=1)
+            valid = window_counts > 0
+            window_sum = weighted[:, start : start + window_size].sum(dim=1)
+            groups.append(window_sum[valid] / window_counts[valid])
+            counts.append(window_counts[valid])
+        return torch.cat(groups), torch.cat(counts)
+    raise ValueError(f"Unknown loss aggregation axis: {aggregation}")
+
+
+def surprise_loss(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    *,
+    iter_num: int | None = None,
+    variant: str = "second_moment_nll",
+    aggregation: str = "token",
+    window_size: int = 16,
+    surprise_lambda: float = 0.25,
+    surprise_scale: float = 1.0,
+    focal_gamma: float = 2.0,
+    focal_alpha: float = 1.0,
+    power_q: float = 2.0,
+    tail_cap: float = 4.0,
+) -> torch.Tensor:
+    """NLL objectives V1--V7 with token, sequence, position, or window aggregation."""
+    nll, mask = _token_nll(logits, targets)
+    grouped, _ = _group_values(nll, mask, aggregation, window_size)
+    if grouped.numel() == 0:
+        return logits.sum() * 0.0
+    if variant == "median_nll":
+        return grouped.median()
+    if variant == "second_moment_nll":
+        return grouped.square().mean()
+    if variant == "rms_surprise":
+        return grouped.square().mean().sqrt()
+    if variant == "hybrid_ce_squared":
+        if surprise_scale <= 0:
+            raise ValueError("surprise_scale must be positive")
+        return (grouped + (surprise_lambda / (2.0 * surprise_scale)) * grouped.square()).mean()
+    if variant == "focal":
+        return (focal_alpha * (-torch.expm1(-grouped)).pow(focal_gamma) * grouped).mean()
+    if variant == "power_surprise":
+        if power_q <= 0:
+            raise ValueError("loss_power_q must be positive")
+        return grouped.pow(power_q).mean().pow(1.0 / power_q)
+    if variant == "focal_power":
+        if power_q <= 0:
+            raise ValueError("loss_power_q must be positive")
+        return ((-torch.expm1(-grouped)).pow(focal_gamma) * grouped.pow(power_q)).mean()
+    if variant == "capped_tail":
+        if tail_cap < 0:
+            raise ValueError("loss_tail_cap must be non-negative")
+        if surprise_scale <= 0:
+            raise ValueError("surprise_scale must be positive")
+        weight = 1.0 + surprise_lambda * torch.minimum(grouped / surprise_scale, grouped.new_tensor(tail_cap))
+        return (grouped * weight).mean()
+    raise ValueError(f"Unknown surprise loss variant: {variant}")
 
 
 class BitBalancedCrossEntropy:
@@ -503,6 +602,10 @@ LOSS_VARIANTS: Dict[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] =
     "rank_distance_focal": rank_distance_focal_loss,
     "entropy_rank_distance_focal": entropy_rank_distance_focal_loss,
     "bit_balanced_cross_entropy": BitBalancedCrossEntropy(),
+    **{name: partial(surprise_loss, variant=name) for name in (
+        "median_nll", "second_moment_nll", "rms_surprise", "hybrid_ce_squared",
+        "power_surprise", "focal_power", "capped_tail",
+    )},
 }
 
 
@@ -596,14 +699,25 @@ def build_loss_function(args) -> Callable[[torch.Tensor, torch.Tensor], torch.Te
     def rank_gamma(iter_num: int | None) -> float:
         return scaler(iter_num) if scaler else base
 
+    def build_surprise(name: str):
+        return lambda l, t, *, iter_num=None: surprise_loss(
+            l, t, iter_num=iter_num, variant=name,
+            aggregation=getattr(args, "loss_aggregation", "token"),
+            window_size=getattr(args, "loss_window_size", 16),
+            surprise_lambda=getattr(args, "surprise_lambda", 0.25),
+            surprise_scale=getattr(args, "surprise_scale", 1.0),
+            focal_gamma=getattr(args, "focal_gamma", 2.0),
+            focal_alpha=getattr(args, "focal_alpha", 1.0),
+            power_q=getattr(args, "loss_power_q", 2.0),
+            tail_cap=getattr(args, "loss_tail_cap", 4.0),
+        )
+
     built_losses: Dict[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = {
         "cross_entropy": LOSS_VARIANTS["cross_entropy"],
         "label_smoothing": lambda l, t, *, iter_num=None: LOSS_VARIANTS["label_smoothing"](
             l, t, iter_num=iter_num, smoothing=getattr(args, "label_smoothing", 0.1)
         ),
-        "focal": lambda l, t, *, iter_num=None: LOSS_VARIANTS["focal"](
-            l, t, iter_num=iter_num, gamma=getattr(args, "focal_gamma", 2.0)
-        ),
+        "focal": build_surprise("focal"),
         "top1_focus": lambda l, t, *, iter_num=None: LOSS_VARIANTS["top1_focus"](
             l, t, iter_num=iter_num, alpha=getattr(args, "top1_focus_alpha", 0.5)
         ),
@@ -662,6 +776,10 @@ def build_loss_function(args) -> Callable[[torch.Tensor, torch.Tensor], torch.Te
             bit_penalty=getattr(args, "bit_loss_weight", 0.0),
             normalize_by_params=getattr(args, "bit_loss_normalize", False),
         ),
+        **{name: build_surprise(name) for name in (
+            "median_nll", "second_moment_nll", "rms_surprise", "hybrid_ce_squared",
+            "power_surprise", "focal_power", "capped_tail",
+        )},
     }
 
     if schedule_str:
@@ -670,4 +788,3 @@ def build_loss_function(args) -> Callable[[torch.Tensor, torch.Tensor], torch.Te
 
     loss_name = getattr(args, "loss_fn", "cross_entropy")
     return built_losses.get(loss_name, LOSS_VARIANTS["cross_entropy"])
-


### PR DESCRIPTION
### Motivation
- Provide a set of alternative NLL-based objectives (V1–V7) that upweight surprising tokens and allow controlled trade-offs vs ordinary cross-entropy. 
- Enable systematic comparison of these objectives across aggregation axes (token, sequence, position, window) in the existing explorations framework.

### Description
- Implemented a unified `surprise_loss` in `train_variations/loss_variants.py` that exposes variants: `median_nll`, `second_moment_nll`, `rms_surprise`, `hybrid_ce_squared`, `focal`, `power_surprise`, `focal_power`, and `capped_tail`, with masking for invalid targets and a differentiable zero when all tokens are invalid. 
- Added token/sequence/position/window aggregation support and non-overlapping window grouping logic used by these objectives. 
- Integrated the new variants into the loss factory (`LOSS_VARIANTS`) and `build_loss_function` so they are selectable and parameterized at runtime. 
- Exposed hyperparameters in `train_args.py` (`--focal_alpha`, `--surprise_lambda`, `--surprise_scale`, `--loss_power_q`, `--loss_tail_cap`, `--loss_aggregation`, `--loss_window_size`) to control each family member. 
- Added an exploration spec `explorations/surprise_loss_comparison.yaml` that enumerates the recommended sweeps for V0–V7 and compares aggregation axes. 
- Added unit tests `tests/test_surprise_losses.py` covering tokenwise formulas, aggregation axes, builder wiring, gradient behavior, masking, and the all-invalid-batch case.

### Testing
- Ran `python -m py_compile train_variations/loss_variants.py train_args.py tests/test_surprise_losses.py` which succeeded. 
- Performed AST parsing and YAML validation via a small validation script which confirmed the new exploration file and Python syntax. 
- Ran static checks (`git diff --check`) and basic repository checks which reported no issues. 
- Attempted `pytest -q tests/test_surprise_losses.py tests/test_bit_balanced_loss.py` but test collection failed because `torch` is not available in the execution environment (ModuleNotFoundError), so the unit tests could not be executed end-to-end in CI here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a766e5173cc8326a167d52e93305946)