### PR TITLE
Add ReLU2Max weighting option for full attention residuals

### DIFF
--- a/documentation/Attention_Residuals.md
+++ b/documentation/Attention_Residuals.md
@@ -34,6 +34,13 @@ combination `ones` and a scale of `1.0` initializes every query component to
 one. `zeros` is provided as an ablation but will start ReLU2Max at its
 zero-gradient point.
 
+For ReLU2Max routing, `attention_residual_use_qk_norm` replaces the default
+RMS-normalized keys with the same L2-normalized query/key calculation used by
+token attention. `attention_residual_use_qk_norm_scale` additionally uses the
+same learned logit-scale scheme, initialized from the maximum routing depth.
+The comparison YAML includes plain routing, QK-normalized routing, and
+QK-normalized routing with the learned scale.
+
 The comparison exploration disables TensorBoard logging so the architecture
 sweep does not require optional TensorBoard/TensorFlow binary dependencies.
 Remove `tensorboard_log: [false]` from the YAML if TensorBoard is desired and

--- a/documentation/Attention_Residuals.md
+++ b/documentation/Attention_Residuals.md
@@ -12,10 +12,18 @@ For each Transformer block, the implementation:
 4. appends the raw MLP output.
 
 One final mixture is passed to `ln_f`. Each destination owns a learned
-pseudo-query. Queries are initialized to zero, so every mixture initially is an
-equal-weight average. Keys are parameter-free RMS-normalized source vectors,
+pseudo-query. With the default softmax, queries are initialized to zero, so
+every mixture initially is an equal-weight average. Keys are parameter-free RMS-normalized source vectors,
 values are the raw vectors, and softmax is only over depth. Consequently this
 feature does not replace causal token-to-token self-attention.
+
+The depth weighting defaults to `softmax`. Set
+`attention_residual_weighting: relu2max` (or pass
+`--attention_residual_weighting relu2max`) to use the repository's ReLU2Max
+implementation instead. Its scale follows `relu2max_divisor` and
+`div_by_seq_len`, just as it does for token-to-token attention. ReLU2Max routing
+queries use a small random initialization instead of zero initialization to
+avoid ReLU2's zero-gradient point.
 
 Full Attention Residuals store the embedding and all `2 * n_layer` sublayer
 outputs, and perform quadratic work in the number of sublayers. The current

--- a/documentation/Attention_Residuals.md
+++ b/documentation/Attention_Residuals.md
@@ -25,6 +25,15 @@ implementation instead. Its scale follows `relu2max_divisor` and
 queries use a small random initialization instead of zero initialization to
 avoid ReLU2's zero-gradient point.
 
+ReLU2Max query initialization can be explored with
+`attention_residual_relu2max_query_init`. Supported styles are `zeros`, `ones`,
+`constant`, `normal`, `uniform`, `positive_uniform`, `xavier_normal`, and
+`xavier_uniform`. Set `attention_residual_relu2max_query_init_scale` to control
+the constant value, distribution width, or Xavier gain. In particular, the
+combination `ones` and a scale of `1.0` initializes every query component to
+one. `zeros` is provided as an ablation but will start ReLU2Max at its
+zero-gradient point.
+
 Full Attention Residuals store the embedding and all `2 * n_layer` sublayer
 outputs, and perform quadratic work in the number of sublayers. The current
 implementation supports sequential attention-then-MLP blocks without post-LN;

--- a/documentation/Attention_Residuals.md
+++ b/documentation/Attention_Residuals.md
@@ -34,6 +34,11 @@ combination `ones` and a scale of `1.0` initializes every query component to
 one. `zeros` is provided as an ablation but will start ReLU2Max at its
 zero-gradient point.
 
+The comparison exploration disables TensorBoard logging so the architecture
+sweep does not require optional TensorBoard/TensorFlow binary dependencies.
+Remove `tensorboard_log: [false]` from the YAML if TensorBoard is desired and
+compatible with the local NumPy environment.
+
 Full Attention Residuals store the embedding and all `2 * n_layer` sublayer
 outputs, and perform quadratic work in the number of sublayers. The current
 implementation supports sequential attention-then-MLP blocks without post-LN;

--- a/explorations/attention_residual_weighting_comparison.yaml
+++ b/explorations/attention_residual_weighting_comparison.yaml
@@ -1,7 +1,18 @@
 ---
 # Compare Softmax and ReLU2Max depth weighting for Full Attention Residuals.
 parameter_groups:
-  - attention_residual_weighting: ["softmax", "relu2max"]
+  - attention_residual_weighting: ["softmax"]
+  - attention_residual_weighting: ["relu2max"]
+    relu2max_divisor: [1.0]
+    attention_residual_relu2max_query_init:
+      - "ones"
+      - "constant"
+      - "normal"
+      - "uniform"
+      - "positive_uniform"
+      - "xavier_normal"
+      - "xavier_uniform"
+    attention_residual_relu2max_query_init_scale: [1.0, 0.1, 0.02]
 
 common_group:
   attention_residual_variant: ["full"]

--- a/explorations/attention_residual_weighting_comparison.yaml
+++ b/explorations/attention_residual_weighting_comparison.yaml
@@ -29,3 +29,6 @@ common_group:
   eval_interval: [500]
   never_save_checkpoint: [true]
   compile: [true]
+  # Keep this architecture sweep independent of optional TensorBoard/TensorFlow
+  # binary dependencies. Remove this setting to enable TensorBoard explicitly.
+  tensorboard_log: [false]

--- a/explorations/attention_residual_weighting_comparison.yaml
+++ b/explorations/attention_residual_weighting_comparison.yaml
@@ -1,0 +1,20 @@
+---
+# Compare Softmax and ReLU2Max depth weighting for Full Attention Residuals.
+parameter_groups:
+  - attention_residual_weighting: ["softmax", "relu2max"]
+
+common_group:
+  attention_residual_variant: ["full"]
+  dataset: ["minipile"]
+  block_size: [256]
+  n_layer: [12]
+  n_head: [6]
+  n_embd: [384]
+  use_rotary_embeddings: [true]
+  use_abs_pos_embeddings: [false]
+  max_iters: [10000]
+  lr_decay_iters: [10000]
+  warmup_iters: [1000]
+  eval_interval: [500]
+  never_save_checkpoint: [true]
+  compile: [true]

--- a/explorations/attention_residual_weighting_comparison.yaml
+++ b/explorations/attention_residual_weighting_comparison.yaml
@@ -4,6 +4,11 @@ parameter_groups:
   - attention_residual_weighting: ["softmax"]
   - attention_residual_weighting: ["relu2max"]
     relu2max_divisor: [1.0]
+    attention_residual_use_qk_norm: [false, true]
+    attention_residual_use_qk_norm_scale:
+      conditions:
+        attention_residual_use_qk_norm: true
+      options: [false, true]
     attention_residual_relu2max_query_init:
       - "ones"
       - "constant"

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -111,6 +111,8 @@ class GPTConfig:
     attention_residual_variant: str = "standard"
     attention_residual_eps: float = 1e-6
     attention_residual_weighting: str = "softmax"
+    attention_residual_relu2max_query_init: str = "normal"
+    attention_residual_relu2max_query_init_scale: float = 0.02
 
     # Attention Variation Specific
 

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -110,6 +110,7 @@ class GPTConfig:
     # Depth-wise residual routing. "full" stores every attention/MLP output.
     attention_residual_variant: str = "standard"
     attention_residual_eps: float = 1e-6
+    attention_residual_weighting: str = "softmax"
 
     # Attention Variation Specific
 

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -113,6 +113,8 @@ class GPTConfig:
     attention_residual_weighting: str = "softmax"
     attention_residual_relu2max_query_init: str = "normal"
     attention_residual_relu2max_query_init_scale: float = 0.02
+    attention_residual_use_qk_norm: bool = False
+    attention_residual_use_qk_norm_scale: bool = False
 
     # Attention Variation Specific
 

--- a/model.py
+++ b/model.py
@@ -156,6 +156,8 @@ class GPT(nn.Module):
                 config.n_embd,
                 config.attention_residual_eps,
                 weighting=residual_weighting,
+                use_qk_norm=config.attention_residual_use_qk_norm,
+                use_qk_norm_scale=config.attention_residual_use_qk_norm_scale,
             )
             # ReLU2Max has zero derivative at zero, so zero queries would leave
             # every route permanently inactive.

--- a/model.py
+++ b/model.py
@@ -146,9 +146,21 @@ class GPT(nn.Module):
         self.transformer['h'] = nn.ModuleList([Block(config, mlp=shared_mlp_array[i], attn=shared_attn_array[i]) for i in range(config.n_layer)])
         self.attention_residual_variant = config.attention_residual_variant
         if self.attention_residual_variant == "full":
+            residual_weighting = None
+            if config.attention_residual_weighting != "softmax":
+                residual_weighting = softmax_dictionary[config.attention_residual_weighting](
+                    config, dim=0
+                )
             self.attention_residual = FullAttentionResidual(
-                2 * config.n_layer + 1, config.n_embd, config.attention_residual_eps
+                2 * config.n_layer + 1,
+                config.n_embd,
+                config.attention_residual_eps,
+                weighting=residual_weighting,
             )
+            # ReLU2Max has zero derivative at zero, so zero queries would leave
+            # every route permanently inactive.
+            if residual_weighting is not None:
+                nn.init.normal_(self.attention_residual.queries, std=0.02)
         elif self.attention_residual_variant != "standard":
             raise ValueError(f"unknown attention_residual_variant: {self.attention_residual_variant}")
         self.transformer['ln_f'] = norm_dictionary[config.norm_variant_output](config)

--- a/model.py
+++ b/model.py
@@ -160,7 +160,10 @@ class GPT(nn.Module):
             # ReLU2Max has zero derivative at zero, so zero queries would leave
             # every route permanently inactive.
             if residual_weighting is not None:
-                nn.init.normal_(self.attention_residual.queries, std=0.02)
+                self.attention_residual.initialize_queries(
+                    config.attention_residual_relu2max_query_init,
+                    config.attention_residual_relu2max_query_init_scale,
+                )
         elif self.attention_residual_variant != "standard":
             raise ValueError(f"unknown attention_residual_variant: {self.attention_residual_variant}")
         self.transformer['ln_f'] = norm_dictionary[config.norm_variant_output](config)

--- a/tests/test_attention_residual.py
+++ b/tests/test_attention_residual.py
@@ -3,6 +3,7 @@ import torch
 from gpt_conf import GPTConfig
 from model import GPT
 from variations.attention_residual_variations import FullAttentionResidual
+from variations.softmax_variations import ReLU2Max
 
 
 def test_zero_queries_start_as_equal_weight_average():
@@ -15,6 +16,25 @@ def test_zero_queries_start_as_equal_weight_average():
     result = mixer(sources, destination=0)
 
     torch.testing.assert_close(result, torch.tensor([[[3.0, 5.0]]]))
+
+
+def test_relu2max_can_weight_full_attention_residuals():
+    config = GPTConfig(relu2max_divisor=1.0, div_by_seq_len=False)
+    mixer = FullAttentionResidual(
+        n_destinations=1,
+        n_embd=2,
+        weighting=ReLU2Max(config, dim=0),
+    )
+    with torch.no_grad():
+        mixer.queries[0].copy_(torch.tensor([1.0, 0.0]))
+    sources = [
+        torch.tensor([[[1.0, 0.0]]]),
+        torch.tensor([[[-1.0, 0.0]]]),
+    ]
+
+    result = mixer(sources, destination=0)
+
+    torch.testing.assert_close(result, torch.tensor([[[2.0, 0.0]]]))
 
 
 def test_full_attention_residual_model_forward_and_backward():
@@ -38,3 +58,22 @@ def test_full_attention_residual_model_forward_and_backward():
     assert logits.shape == (2, config.block_size, config.vocab_size)
     assert model.attention_residual.queries.shape == (2 * config.n_layer + 1, config.n_embd)
     assert model.attention_residual.queries.grad is not None
+
+
+def test_full_attention_residual_model_uses_relu2max_weighting():
+    config = GPTConfig(
+        block_size=4,
+        vocab_size=32,
+        n_layer=1,
+        n_head=2,
+        n_kv_group=2,
+        n_embd=8,
+        attention_residual_variant="full",
+        attention_residual_weighting="relu2max",
+    )
+
+    model = GPT(config)
+
+    assert isinstance(model.attention_residual.weighting, ReLU2Max)
+    assert model.attention_residual.weighting.dim == 0
+    assert torch.count_nonzero(model.attention_residual.queries) > 0

--- a/tests/test_attention_residual.py
+++ b/tests/test_attention_residual.py
@@ -1,4 +1,5 @@
 import torch
+import pytest
 
 from gpt_conf import GPTConfig
 from model import GPT
@@ -37,6 +38,34 @@ def test_relu2max_can_weight_full_attention_residuals():
     torch.testing.assert_close(result, torch.tensor([[[2.0, 0.0]]]))
 
 
+@pytest.mark.parametrize(
+    ("variant", "scale"),
+    [
+        ("zeros", 1.0),
+        ("ones", 1.0),
+        ("constant", 0.5),
+        ("normal", 0.1),
+        ("uniform", 0.1),
+        ("positive_uniform", 0.1),
+        ("xavier_normal", 1.0),
+        ("xavier_uniform", 1.0),
+    ],
+)
+def test_relu2max_query_initialization_options(variant, scale):
+    mixer = FullAttentionResidual(n_destinations=3, n_embd=4)
+
+    with torch.no_grad():
+        mixer.initialize_queries(variant, scale)
+
+    assert torch.isfinite(mixer.queries).all()
+    if variant == "zeros":
+        torch.testing.assert_close(mixer.queries, torch.zeros_like(mixer.queries))
+    elif variant == "ones":
+        torch.testing.assert_close(mixer.queries, torch.full_like(mixer.queries, scale))
+    elif variant == "constant":
+        torch.testing.assert_close(mixer.queries, torch.full_like(mixer.queries, scale))
+
+
 def test_full_attention_residual_model_forward_and_backward():
     config = GPTConfig(
         block_size=4,
@@ -70,10 +99,15 @@ def test_full_attention_residual_model_uses_relu2max_weighting():
         n_embd=8,
         attention_residual_variant="full",
         attention_residual_weighting="relu2max",
+        attention_residual_relu2max_query_init="ones",
+        attention_residual_relu2max_query_init_scale=1.0,
     )
 
     model = GPT(config)
 
     assert isinstance(model.attention_residual.weighting, ReLU2Max)
     assert model.attention_residual.weighting.dim == 0
-    assert torch.count_nonzero(model.attention_residual.queries) > 0
+    torch.testing.assert_close(
+        model.attention_residual.queries,
+        torch.ones_like(model.attention_residual.queries),
+    )

--- a/tests/test_attention_residual.py
+++ b/tests/test_attention_residual.py
@@ -1,3 +1,5 @@
+import math
+
 import torch
 import pytest
 
@@ -36,6 +38,38 @@ def test_relu2max_can_weight_full_attention_residuals():
     result = mixer(sources, destination=0)
 
     torch.testing.assert_close(result, torch.tensor([[[2.0, 0.0]]]))
+
+
+def test_relu2max_can_use_attention_qk_norm_implementation():
+    config = GPTConfig(relu2max_divisor=1.0, div_by_seq_len=False)
+    mixer = FullAttentionResidual(
+        n_destinations=2,
+        n_embd=2,
+        weighting=ReLU2Max(config, dim=0),
+        use_qk_norm=True,
+    )
+    with torch.no_grad():
+        mixer.queries[0].copy_(torch.tensor([3.0, 4.0]))
+    sources = [
+        torch.tensor([[[6.0, 8.0]]]),
+        torch.tensor([[[-8.0, 6.0]]]),
+    ]
+
+    result = mixer(sources, destination=0)
+
+    # QK norm produces cosine logits, followed by the usual sqrt(d) scale.
+    torch.testing.assert_close(result, sources[0] / 2.0)
+
+
+def test_attention_residual_qk_norm_scale_matches_attention_initialization():
+    mixer = FullAttentionResidual(
+        n_destinations=3,
+        n_embd=4,
+        use_qk_norm=True,
+        use_qk_norm_scale=True,
+    )
+
+    torch.testing.assert_close(mixer.qk_norm_factor, torch.tensor(math.log2(6.0)))
 
 
 @pytest.mark.parametrize(
@@ -101,12 +135,16 @@ def test_full_attention_residual_model_uses_relu2max_weighting():
         attention_residual_weighting="relu2max",
         attention_residual_relu2max_query_init="ones",
         attention_residual_relu2max_query_init_scale=1.0,
+        attention_residual_use_qk_norm=True,
+        attention_residual_use_qk_norm_scale=True,
     )
 
     model = GPT(config)
 
     assert isinstance(model.attention_residual.weighting, ReLU2Max)
     assert model.attention_residual.weighting.dim == 0
+    assert model.attention_residual.use_qk_norm
+    assert model.attention_residual.use_qk_norm_scale
     torch.testing.assert_close(
         model.attention_residual.queries,
         torch.ones_like(model.attention_residual.queries),

--- a/tests/test_attention_residual_exploration.py
+++ b/tests/test_attention_residual_exploration.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+import yaml
+
+
+EXPLORATION_PATH = (
+    Path(__file__).parents[1]
+    / "explorations"
+    / "attention_residual_weighting_comparison.yaml"
+)
+
+
+def test_attention_residual_comparison_avoids_optional_tensorboard_dependency():
+    config = yaml.safe_load(EXPLORATION_PATH.read_text())
+
+    assert config["common_group"]["tensorboard_log"] == [False]
+
+
+def test_relu2max_comparison_uses_unit_divisor_and_initialization_sweep():
+    config = yaml.safe_load(EXPLORATION_PATH.read_text())
+    relu2max_group = config["parameter_groups"][1]
+
+    assert relu2max_group["attention_residual_weighting"] == ["relu2max"]
+    assert relu2max_group["relu2max_divisor"] == [1.0]
+    assert relu2max_group["attention_residual_relu2max_query_init_scale"] == [
+        1.0,
+        0.1,
+        0.02,
+    ]

--- a/tests/test_attention_residual_exploration.py
+++ b/tests/test_attention_residual_exploration.py
@@ -22,6 +22,11 @@ def test_relu2max_comparison_uses_unit_divisor_and_initialization_sweep():
 
     assert relu2max_group["attention_residual_weighting"] == ["relu2max"]
     assert relu2max_group["relu2max_divisor"] == [1.0]
+    assert relu2max_group["attention_residual_use_qk_norm"] == [False, True]
+    assert relu2max_group["attention_residual_use_qk_norm_scale"] == {
+        "conditions": {"attention_residual_use_qk_norm": True},
+        "options": [False, True],
+    }
     assert relu2max_group["attention_residual_relu2max_query_init_scale"] == [
         1.0,
         0.1,

--- a/train.py
+++ b/train.py
@@ -98,7 +98,6 @@ import torch.onnx
 import torch.nn.functional as F
 from torch.distributed import destroy_process_group, init_process_group
 from torch.nn.parallel import DistributedDataParallel as DDP
-from torch.utils.tensorboard import SummaryWriter
 
 from variations.model_variations import model_variation_dictionary
 
@@ -142,6 +141,7 @@ class Trainer:
         self.evaluations_remaining: int = 0 # will be updated after the current iter is loaded
         self.formatted_completion_eta: str = "waiting for calculation"
         self.iter_latency_avg: float = 0.0  # running mean ms / iteration
+        self.writer = None
 
         # track latest evaluation metrics for progress bar
         self.latest_top1_prob = float('nan')
@@ -499,6 +499,11 @@ class Trainer:
 
         # Tensorboard
         if self.args.tensorboard_log:
+            # TensorBoard is optional. Import it only when logging is enabled so
+            # --no-tensorboard_log can run without TensorFlow/TensorBoard binary
+            # compatibility affecting model training.
+            from torch.utils.tensorboard import SummaryWriter
+
             # 1) Give the run a safe default name when the user did not supply one
             if self.args.tensorboard_run_name is None:
                 self.args.tensorboard_run_name = f"{timestamp_prefix}"

--- a/train_args.py
+++ b/train_args.py
@@ -29,6 +29,10 @@ def parse_args():
     )
     model_group.add_argument('--attention_residual_eps', default=1e-6, type=float,
                              help='RMSNorm epsilon used for Full Attention Residual routing keys.')
+    model_group.add_argument(
+        '--attention_residual_weighting', default='softmax', choices=['softmax', 'relu2max'],
+        help='Depth-routing weighting used by Full Attention Residuals.',
+    )
 
     # MLP Bias Configuration
     model_group.add_argument('--mlp_up_bias', default=None, action=argparse.BooleanOptionalAction, help='Whether to use bias in MLP up projections. If None, uses global bias setting.')

--- a/train_args.py
+++ b/train_args.py
@@ -46,6 +46,16 @@ def parse_args():
         '--attention_residual_relu2max_query_init_scale', default=0.02, type=float,
         help='Scale, constant, or gain (depending on style) for ReLU2Max query initialization.',
     )
+    model_group.add_argument(
+        '--attention_residual_use_qk_norm', default=False,
+        action=argparse.BooleanOptionalAction,
+        help='L2-normalize Full Attention Residual routing queries and keys.',
+    )
+    model_group.add_argument(
+        '--attention_residual_use_qk_norm_scale', default=False,
+        action=argparse.BooleanOptionalAction,
+        help='Apply the learned QK norm logit scale to Full Attention Residual routing.',
+    )
 
     # MLP Bias Configuration
     model_group.add_argument('--mlp_up_bias', default=None, action=argparse.BooleanOptionalAction, help='Whether to use bias in MLP up projections. If None, uses global bias setting.')

--- a/train_args.py
+++ b/train_args.py
@@ -33,6 +33,19 @@ def parse_args():
         '--attention_residual_weighting', default='softmax', choices=['softmax', 'relu2max'],
         help='Depth-routing weighting used by Full Attention Residuals.',
     )
+    attention_residual_query_inits = [
+        'zeros', 'ones', 'constant', 'normal', 'uniform', 'positive_uniform',
+        'xavier_normal', 'xavier_uniform',
+    ]
+    model_group.add_argument(
+        '--attention_residual_relu2max_query_init', default='normal',
+        choices=attention_residual_query_inits,
+        help='Initialization style for Full Attention Residual ReLU2Max queries.',
+    )
+    model_group.add_argument(
+        '--attention_residual_relu2max_query_init_scale', default=0.02, type=float,
+        help='Scale, constant, or gain (depending on style) for ReLU2Max query initialization.',
+    )
 
     # MLP Bias Configuration
     model_group.add_argument('--mlp_up_bias', default=None, action=argparse.BooleanOptionalAction, help='Whether to use bias in MLP up projections. If None, uses global bias setting.')

--- a/variations/attention_residual_variations.py
+++ b/variations/attention_residual_variations.py
@@ -27,6 +27,25 @@ class FullAttentionResidual(nn.Module):
         self.eps = eps
         self.weighting = weighting
 
+    @torch.no_grad()
+    def initialize_queries(self, variant: str, scale: float) -> None:
+        """Initialize routing queries for non-softmax weighting functions."""
+        initializers = {
+            "zeros": lambda tensor: nn.init.zeros_(tensor),
+            "ones": lambda tensor: nn.init.ones_(tensor),
+            "constant": lambda tensor: nn.init.constant_(tensor, scale),
+            "normal": lambda tensor: nn.init.normal_(tensor, std=scale),
+            "uniform": lambda tensor: nn.init.uniform_(tensor, -scale, scale),
+            "positive_uniform": lambda tensor: nn.init.uniform_(tensor, 0.0, scale),
+            "xavier_normal": lambda tensor: nn.init.xavier_normal_(tensor, gain=scale),
+            "xavier_uniform": lambda tensor: nn.init.xavier_uniform_(tensor, gain=scale),
+        }
+        if variant not in initializers:
+            raise ValueError(f"unknown attention residual query initialization: {variant}")
+        initializers[variant](self.queries)
+        if variant == "ones":
+            self.queries.mul_(scale)
+
     def forward(self, sources: list[torch.Tensor], destination: int) -> torch.Tensor:
         if not sources:
             raise ValueError("attention residuals require at least one source")

--- a/variations/attention_residual_variations.py
+++ b/variations/attention_residual_variations.py
@@ -14,11 +14,18 @@ from torch.nn import functional as F
 class FullAttentionResidual(nn.Module):
     """Mix earlier sublayer outputs with zero-initialized pseudo-queries."""
 
-    def __init__(self, n_destinations: int, n_embd: int, eps: float = 1e-6):
+    def __init__(
+        self,
+        n_destinations: int,
+        n_embd: int,
+        eps: float = 1e-6,
+        weighting: nn.Module | None = None,
+    ):
         super().__init__()
         # Includes one destination for each attention/MLP and one for ln_f.
         self.queries = nn.Parameter(torch.zeros(n_destinations, n_embd))
         self.eps = eps
+        self.weighting = weighting
 
     def forward(self, sources: list[torch.Tensor], destination: int) -> torch.Tensor:
         if not sources:
@@ -26,5 +33,5 @@ class FullAttentionResidual(nn.Module):
         values = torch.stack(sources, dim=0)  # depth, batch, time, channels
         keys = F.rms_norm(values, (values.size(-1),), eps=self.eps)
         scores = torch.einsum("dbtc,c->dbt", keys, self.queries[destination])
-        weights = scores.softmax(dim=0)
+        weights = scores.softmax(dim=0) if self.weighting is None else self.weighting(scores)
         return torch.einsum("dbt,dbtc->btc", weights, values)

--- a/variations/attention_residual_variations.py
+++ b/variations/attention_residual_variations.py
@@ -6,6 +6,8 @@ is token-local (the softmax dimension is depth), so sequence mixing remains the
 responsibility of the normal self-attention module.
 """
 
+import math
+
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
@@ -20,12 +22,20 @@ class FullAttentionResidual(nn.Module):
         n_embd: int,
         eps: float = 1e-6,
         weighting: nn.Module | None = None,
+        use_qk_norm: bool = False,
+        use_qk_norm_scale: bool = False,
     ):
         super().__init__()
         # Includes one destination for each attention/MLP and one for ln_f.
         self.queries = nn.Parameter(torch.zeros(n_destinations, n_embd))
         self.eps = eps
         self.weighting = weighting
+        self.use_qk_norm = use_qk_norm
+        self.use_qk_norm_scale = use_qk_norm_scale
+        if self.use_qk_norm_scale:
+            depth = max(n_destinations, 2)
+            initial_scale = math.log2(depth * depth - depth)
+            self.qk_norm_factor = nn.Parameter(torch.tensor(initial_scale))
 
     @torch.no_grad()
     def initialize_queries(self, variant: str, scale: float) -> None:
@@ -50,7 +60,17 @@ class FullAttentionResidual(nn.Module):
         if not sources:
             raise ValueError("attention residuals require at least one source")
         values = torch.stack(sources, dim=0)  # depth, batch, time, channels
-        keys = F.rms_norm(values, (values.size(-1),), eps=self.eps)
-        scores = torch.einsum("dbtc,c->dbt", keys, self.queries[destination])
+        query = self.queries[destination]
+        if self.use_qk_norm:
+            # Match the repository's token-attention QK norm implementation.
+            query = query / (query.norm(dim=-1, keepdim=True) + self.eps)
+            keys = values / (values.norm(dim=-1, keepdim=True) + self.eps)
+        else:
+            keys = F.rms_norm(values, (values.size(-1),), eps=self.eps)
+        scores = torch.einsum("dbtc,c->dbt", keys, query)
+        if self.use_qk_norm_scale:
+            scores = scores * self.qk_norm_factor
+        elif self.use_qk_norm:
+            scores = scores / math.sqrt(values.size(-1))
         weights = scores.softmax(dim=0) if self.weighting is None else self.weighting(scores)
         return torch.einsum("dbt,dbtc->btc", weights, values)


### PR DESCRIPTION
### Motivation
- Provide an alternative depth-wise routing weighting for Full Attention Residuals so the residual mixer can use the repository's `relu2max` variant in addition to the default `softmax` for apples-to-apples comparisons.
- Avoid the zero-gradient pitfall of ReLU-based routing by ensuring queries are initialized non‑zero when a ReLU-style weighting is selected.
- Expose the option via configuration/CLI and add an exploration YAML so experiments can compare weighting variants easily.

### Description
- Add `attention_residual_weighting` to `GPTConfig` and `--attention_residual_weighting` to the CLI with choices `softmax` and `relu2max` and default `softmax`.
- Extend `FullAttentionResidual` to accept an optional `weighting` module and apply that module across the residual-depth dimension when provided, otherwise fall back to `scores.softmax(dim=0)`.
- Wire weighting instantiation in `model.py` by selecting `softmax_dictionary[config.attention_residual_weighting](config, dim=0)` when non‑softmax is requested and pass it to `FullAttentionResidual`, and initialize `queries` with small random noise for non‑softmax weighting to avoid ReLU2's zero-gradient point.
- Add unit tests exercising default softmax averaging, using `ReLU2Max` as a weighting module, and model-level selection/initialization; update documentation to describe the new option; add `explorations/attention_residual_weighting_comparison.yaml` to expand both variants.

### Testing
- Ran `python -m py_compile variations/attention_residual_variations.py model.py gpt_conf.py train_args.py tests/test_attention_residual.py`, which succeeded.
- Ran repository checks (`git diff --check`) which reported no issues.
- Verified the new exploration YAML expands to both `softmax` and `relu2max` via `optimization_and_search.run_experiments` combinatorics, which succeeded.
- Attempted to run `pytest tests/test_attention_residual.py` but collection failed because the execution environment lacked PyTorch (`ModuleNotFoundError: No module named 'torch'`), so the new unit tests were not executed end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76b5128840832684d37ee790681e84)