### PR TITLE
Support configurable depth-routing for Full Attention Residuals (softmax or ReLU2Max) with docs, config, CLI, model, and tests

### DIFF
--- a/documentation/Attention_Residuals.md
+++ b/documentation/Attention_Residuals.md
@@ -22,3 +22,80 @@ outputs, and perform quadratic work in the number of sublayers. The current
 implementation supports sequential attention-then-MLP blocks without post-LN;
 the usual PreNorm configuration is supported. Use `standard` (the default) for
 the existing additive residual architecture and checkpoint compatibility.
+
+## Comparison with Kimi K3
+
+The `full` variant implements the Full Attention Residuals equations described
+in the Kimi K3 report, but it is **not an exact reproduction of Kimi K3's
+deployed residual topology**. The following pieces agree:
+
+- routing is independently computed for every token and destination;
+- the embedding and earlier transformation outputs are used as values;
+- keys are RMS-normalized while values remain unnormalized;
+- a learned, destination-specific pseudo-query scores the keys; and
+- a separate final depth mixture is computed before the output norm.
+
+The important differences are:
+
+1. **Kimi K3 uses Block Attention Residuals.** Its released configuration uses
+   a 12-layer residual block size. Completed blocks are represented by sums,
+   while the current block contributes its running partial sum. K3 therefore
+   routes over block-level states rather than retaining every transformation
+   output. The K3 report describes eight 12-layer blocks (with a partial final
+   block) and nine routing sources when the embedding is counted. This
+   repository currently offers only the full, per-sublayer form.
+2. **The source granularity differs.** Here, attention and MLP outputs are each
+   stored as independent sources, producing `2 * n_layer + 1` destinations.
+   K3's block implementation keeps ordinary additive accumulation within each
+   12-layer group and exposes completed block sums plus the current partial sum
+   to both the attention and MLP routing points.
+3. **K3's released scorer has an affine RMSNorm.** Its effective pseudo-query
+   is the elementwise product of a destination-specific RMSNorm scale and a
+   bias-free scalar projection. This implementation uses parameter-free
+   RMSNorm and one query vector. The two parameterizations can express the same
+   score, but do not have identical parameters or optimization dynamics.
+4. **Initialization is different.** This implementation zero-initializes each
+   query, deliberately starting with uniform depth weights. K3's released code
+   applies its normal linear-layer initialization to the scalar projection, so
+   K3 does not explicitly enforce an initially uniform mixture. The K3 report's
+   equations do not prescribe an initialization.
+5. **Routing precision is different.** K3's released implementation converts
+   values, normalization, scores, softmax, and the weighted reduction to FP32,
+   then casts the result back to the activation dtype. This implementation
+   does not explicitly promote the routing calculation to FP32.
+
+Consequently, no term is missing from the documented **Full Attention
+Residuals equation**, but block aggregation, K3's scorer parameterization and
+initialization, and its explicit FP32 routing path are missing for strict Kimi
+K3 parity. Adding a `block` variant should be preferred over changing `full`,
+so existing experiments and checkpoints retain their present semantics.
+
+## ReLU2Max routing
+
+Set `attention_residual_weight_variant: relu2max` (or pass
+`--attention_residual_weight_variant relu2max`) to replace the depth softmax
+with normalized squared-ReLU weights. For depth scores `s`, the implementation
+uses
+
+```text
+c_i = s_i - mean_depth(s)
+t_i = relu(c_i + shift)^2
+w_i = t_i / sum_depth(t)
+```
+
+The default `shift` is `1.0` and can be changed with
+`--attention_residual_relu2max_shift`. Centering preserves invariance to a
+constant score offset. The shift is important because pseudo-queries are
+zero-initialized: an unshifted squared ReLU would produce all-zero weights and
+zero query gradients, whereas the shifted form begins as the same uniform
+mixture as softmax and remains trainable. Normalizing by the sum, rather than
+using the fixed divisor of the token-attention `ReLU2Max` variation, keeps the
+depth result a convex combination and prevents its scale from growing with the
+number of retained residual sources. If every squared-ReLU term is zero, the
+implementation safely falls back to uniform weights.
+
+References:
+
+- [Kimi K3 technical report, section 2.2](https://arxiv.org/abs/2607.24653)
+- [Released Kimi K3 configuration](https://huggingface.co/moonshotai/Kimi-K3/blob/main/config.json)
+- [Released Kimi K3 text-model implementation](https://huggingface.co/moonshotai/Kimi-K3/blob/main/modeling_kimi_linear.py)

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -110,6 +110,8 @@ class GPTConfig:
     # Depth-wise residual routing. "full" stores every attention/MLP output.
     attention_residual_variant: str = "standard"
     attention_residual_eps: float = 1e-6
+    attention_residual_weight_variant: str = "softmax"
+    attention_residual_relu2max_shift: float = 1.0
 
     # Attention Variation Specific
 

--- a/model.py
+++ b/model.py
@@ -147,7 +147,11 @@ class GPT(nn.Module):
         self.attention_residual_variant = config.attention_residual_variant
         if self.attention_residual_variant == "full":
             self.attention_residual = FullAttentionResidual(
-                2 * config.n_layer + 1, config.n_embd, config.attention_residual_eps
+                2 * config.n_layer + 1,
+                config.n_embd,
+                config.attention_residual_eps,
+                config.attention_residual_weight_variant,
+                config.attention_residual_relu2max_shift,
             )
         elif self.attention_residual_variant != "standard":
             raise ValueError(f"unknown attention_residual_variant: {self.attention_residual_variant}")

--- a/tests/test_attention_residual.py
+++ b/tests/test_attention_residual.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from gpt_conf import GPTConfig
@@ -17,6 +18,50 @@ def test_zero_queries_start_as_equal_weight_average():
     torch.testing.assert_close(result, torch.tensor([[[3.0, 5.0]]]))
 
 
+def test_relu2max_zero_queries_are_uniform_and_trainable():
+    mixer = FullAttentionResidual(
+        n_destinations=1,
+        n_embd=2,
+        weight_variant="relu2max",
+    )
+    sources = [
+        torch.tensor([[[1.0, 3.0]]]),
+        torch.tensor([[[5.0, 7.0]]]),
+    ]
+
+    result = mixer(sources, destination=0)
+    result.sum().backward()
+
+    torch.testing.assert_close(result, torch.tensor([[[3.0, 5.0]]]))
+    assert mixer.queries.grad is not None
+    assert torch.count_nonzero(mixer.queries.grad) > 0
+
+
+def test_relu2max_weights_are_nonnegative_and_normalized():
+    mixer = FullAttentionResidual(
+        n_destinations=1,
+        n_embd=2,
+        weight_variant="relu2max",
+    )
+    scores = torch.tensor([[[-2.0]], [[0.0]], [[3.0]]])
+
+    weights = mixer._weights(scores)
+
+    assert torch.all(weights >= 0)
+    torch.testing.assert_close(weights.sum(dim=0), torch.ones(1, 1))
+    assert weights[0].item() == 0.0
+
+
+def test_relu2max_requires_positive_shift():
+    with pytest.raises(ValueError, match="shift must be positive"):
+        FullAttentionResidual(
+            n_destinations=1,
+            n_embd=2,
+            weight_variant="relu2max",
+            relu2max_shift=0.0,
+        )
+
+
 def test_full_attention_residual_model_forward_and_backward():
     config = GPTConfig(
         block_size=4,
@@ -27,6 +72,7 @@ def test_full_attention_residual_model_forward_and_backward():
         n_embd=8,
         dropout=0.0,
         attention_residual_variant="full",
+        attention_residual_weight_variant="relu2max",
     )
     model = GPT(config)
     tokens = torch.randint(0, config.vocab_size, (2, config.block_size))
@@ -36,5 +82,6 @@ def test_full_attention_residual_model_forward_and_backward():
     loss.backward()
 
     assert logits.shape == (2, config.block_size, config.vocab_size)
+    assert model.attention_residual.weight_variant == "relu2max"
     assert model.attention_residual.queries.shape == (2 * config.n_layer + 1, config.n_embd)
     assert model.attention_residual.queries.grad is not None

--- a/train_args.py
+++ b/train_args.py
@@ -29,6 +29,14 @@ def parse_args():
     )
     model_group.add_argument('--attention_residual_eps', default=1e-6, type=float,
                              help='RMSNorm epsilon used for Full Attention Residual routing keys.')
+    model_group.add_argument(
+        '--attention_residual_weight_variant', default='softmax', choices=['softmax', 'relu2max'],
+        help='Normalization used for Full Attention Residual depth-routing weights.',
+    )
+    model_group.add_argument(
+        '--attention_residual_relu2max_shift', default=1.0, type=float,
+        help='Positive shift applied to centered scores before squared ReLU depth routing.',
+    )
 
     # MLP Bias Configuration
     model_group.add_argument('--mlp_up_bias', default=None, action=argparse.BooleanOptionalAction, help='Whether to use bias in MLP up projections. If None, uses global bias setting.')

--- a/variations/attention_residual_variations.py
+++ b/variations/attention_residual_variations.py
@@ -14,11 +14,41 @@ from torch.nn import functional as F
 class FullAttentionResidual(nn.Module):
     """Mix earlier sublayer outputs with zero-initialized pseudo-queries."""
 
-    def __init__(self, n_destinations: int, n_embd: int, eps: float = 1e-6):
+    def __init__(
+        self,
+        n_destinations: int,
+        n_embd: int,
+        eps: float = 1e-6,
+        weight_variant: str = "softmax",
+        relu2max_shift: float = 1.0,
+    ):
         super().__init__()
         # Includes one destination for each attention/MLP and one for ln_f.
         self.queries = nn.Parameter(torch.zeros(n_destinations, n_embd))
         self.eps = eps
+        self.weight_variant = weight_variant
+        self.relu2max_shift = relu2max_shift
+        if weight_variant not in ("softmax", "relu2max"):
+            raise ValueError(f"unknown attention residual weight variant: {weight_variant}")
+        if weight_variant == "relu2max" and relu2max_shift <= 0:
+            raise ValueError("attention residual relu2max shift must be positive")
+
+    def _weights(self, scores: torch.Tensor) -> torch.Tensor:
+        if self.weight_variant == "softmax":
+            return scores.softmax(dim=0)
+
+        # Centering retains softmax's invariance to a common score offset.  The
+        # positive shift gives zero-initialized queries a uniform distribution
+        # with a nonzero gradient; plain relu(scores) ** 2 would be dead at zero.
+        centered_scores = scores - scores.mean(dim=0, keepdim=True)
+        terms = torch.relu(centered_scores + self.relu2max_shift).square()
+        denominator = terms.sum(dim=0, keepdim=True)
+        normalized = terms / denominator.clamp_min(torch.finfo(terms.dtype).tiny)
+
+        # Retain a finite fallback for non-finite/extreme inputs and preserve
+        # the residual mixer's convex-combination invariant.
+        uniform = torch.full_like(terms, 1.0 / terms.size(0))
+        return torch.where(denominator > 0, normalized, uniform)
 
     def forward(self, sources: list[torch.Tensor], destination: int) -> torch.Tensor:
         if not sources:
@@ -26,5 +56,5 @@ class FullAttentionResidual(nn.Module):
         values = torch.stack(sources, dim=0)  # depth, batch, time, channels
         keys = F.rms_norm(values, (values.size(-1),), eps=self.eps)
         scores = torch.einsum("dbtc,c->dbt", keys, self.queries[destination])
-        weights = scores.softmax(dim=0)
+        weights = self._weights(scores)
         return torch.einsum("dbt,dbtc->btc", weights, values)


### PR DESCRIPTION
### Motivation

- Introduce a configurable depth-routing normalization for the Full Attention Residuals mixer so experiments can use an alternative squared-ReLU routing (`ReLU2Max`) in addition to the existing depth `softmax`.
- Document the relationship to the Kimi K3 report and describe the new `ReLU2Max` behavior and parameterization for reproducibility.

### Description

- Add `attention_residual_weight_variant` and `attention_residual_relu2max_shift` to `GPTConfig` and wire them through the model so `FullAttentionResidual` is constructed with the selected routing variant and shift parameter.
- Extend the CLI in `train_args.py` with `--attention_residual_weight_variant` and `--attention_residual_relu2max_shift` options to control routing at runtime.
- Implement `ReLU2Max` routing in `variations/attention_residual_variations.py` with input validation, a `_weights` helper, centering, shifted squared-ReLU normalization, a safe fallback to uniform weights, and keep `softmax` as the default path.
- Expand documentation in `documentation/Attention_Residuals.md` with a comparison to Kimi K3 and a detailed description of the `ReLU2Max` routing math and rationale.

### Testing

- Ran the updated unit tests in `tests/test_attention_residual.py`, which include `test_zero_queries_start_as_equal_weight_average`, `test_relu2max_zero_queries_are_uniform_and_trainable`, `test_relu2max_weights_are_nonnegative_and_normalized`, `test_relu2max_requires_positive_shift`, and `test_full_attention_residual_model_forward_and_backward`, and they passed.
- Executed a model forward/backward smoke test via the `test_full_attention_residual_model_forward_and_backward` which verified construction, forward pass, and gradient flow for the `relu2max` variant and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a796353b99083268c1617642adc3dfa)