### PR TITLE
feat(tokenizer): emit factored char BPE vocabularies

### DIFF
--- a/data/template/README.md
+++ b/data/template/README.md
@@ -169,6 +169,24 @@ additional parameters for tokenization strategy and their parameters.
 - `input_file`: Path to the input text file.
 - `--method`: Tokenization method (`sentencepiece`, `tiktoken`, `char`). Default is `sentencepiece`.
 - `--vocab_size`: Vocabulary size for the SentencePiece model. Default is 500.
+- `--vocab_size_increment`: With `--method char_bpe`, emit vocabulary sizes at
+  this interval through `--vocab_size`. This mode requires `-s`; the largest
+  vocabulary is trained once and the smaller, factored vocabularies reuse its
+  ordered token prefixes rather than training BPE from scratch.
+
+For example, this creates `char_bpe_factored_1000` through
+`char_bpe_factored_9000` in steps of 1000 (and includes the requested maximum
+even when it is not divisible by the increment):
+
+```bash
+python3 prepare.py -t input.txt --method char_bpe --vocab_size 9000 \
+  --vocab_size_increment 1000 -T -s -S factored
+```
+
+Each directory contains its own `meta.pkl`, `train.bin`, `val.bin`,
+`char_bpe_vocab.json`, and (with `-T`) `char_bpe_token_counts.json`. The custom
+`-S` tag precedes the vocabulary size, so the final directory in this example
+is `char_bpe_factored_9000`.
 
 #### `prepare.py` Generated File Descriptions
 

--- a/data/template/nanogpt_tokenizers.py
+++ b/data/template/nanogpt_tokenizers.py
@@ -524,8 +524,17 @@ class CharBPETokenizerWithByteFallback(Tokenizer):
         self.incomplete_coverage_uses_bpe = getattr(args, "char_bpe_incomplete_coverage_uses_bpe", True)
         if self.reuse_meta_path:
             meta = self._load_char_bpe_meta(self.reuse_meta_path)
-            self.desired_vocab_size = meta["vocab_size"]
-            self.char_tokens = meta["char_tokens"]
+            source_vocab_size = meta["vocab_size"]
+            self.desired_vocab_size = getattr(args, "vocab_size", None) or source_vocab_size
+            if not 256 < self.desired_vocab_size <= source_vocab_size:
+                raise ValueError(
+                    "A reused char_bpe vocabulary size must be greater than 256 "
+                    f"and no larger than its source vocabulary ({source_vocab_size})."
+                )
+            # BPE learns tokens in merge order, so every prefix is a usable,
+            # factored vocabulary.  Taking a prefix lets prepare.py emit smaller
+            # variants without repeating the expensive merge training.
+            self.char_tokens = meta["char_tokens"][:self.desired_vocab_size - 256]
             self.sorted_char_tokens = meta.get(
                 "char_tokens_sorted",
                 sorted(self.char_tokens, key=lambda t: len(t), reverse=True),
@@ -750,12 +759,16 @@ class CharBPETokenizerWithByteFallback(Tokenizer):
         self._write_vocab_jsons(meta)
 
     def _write_vocab_jsons(self, meta):
+        output_dir = os.path.dirname(getattr(self.args, "meta_output_path", ""))
+        if output_dir:
+            os.makedirs(output_dir, exist_ok=True)
         vocab_json = []
         for idx in range(self.vocab_size):
             token = self.itos[idx]
             vocab_json.append(self._format_token_for_json(token))
 
-        with open("char_bpe_vocab.json", "w", encoding="utf-8") as f:
+        vocab_path = os.path.join(output_dir, "char_bpe_vocab.json")
+        with open(vocab_path, "w", encoding="utf-8") as f:
             json.dump(vocab_json, f, ensure_ascii=False, indent=2)
 
         if self.token_counts is not None:
@@ -768,7 +781,8 @@ class CharBPETokenizerWithByteFallback(Tokenizer):
                     "token": self._format_token_for_json(token),
                     "count": counts.get(idx, 0)
                 })
-            with open("char_bpe_token_counts.json", "w", encoding="utf-8") as f:
+            counts_path = os.path.join(output_dir, "char_bpe_token_counts.json")
+            with open(counts_path, "w", encoding="utf-8") as f:
                 json.dump(counts_json, f, ensure_ascii=False, indent=2)
 
     @staticmethod

--- a/data/template/prepare.py
+++ b/data/template/prepare.py
@@ -19,6 +19,7 @@ from nanogpt_tokenizers import (
 )
 from tqdm import tqdm
 import pickle
+import copy
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description="Tokenize text data using different methods.")
@@ -98,6 +99,8 @@ def parse_arguments():
 
     # SentencePiece arguments
     parser.add_argument("--vocab_size", type=int, default=500, help="Vocabulary size for SentencePiece model")
+    parser.add_argument("--vocab_size_increment", type=int, default=None,
+                        help="For char_bpe, emit factored vocabularies at this increment up to --vocab_size; the maximum vocabulary is trained only once")
     parser.add_argument("--spm_model_file", type=str, default=None, help="Path to the pre-trained SentencePiece model file")
     parser.add_argument("--spm_vocab_file", type=str, default=None, help="Path to the SentencePiece vocabulary file")
     parser.add_argument("--skip_tokenization", action="store_true", help="Skip creation of .bin files")
@@ -203,8 +206,7 @@ def _update_meta_with_byte_metrics(meta_path, byte_metrics):
     with open(meta_path, "wb") as f:
         pickle.dump(meta, f)
 
-def main():
-    args = parse_arguments()
+def _output_dir_for_args(args):
     output_dir = None
     if args.output_tokenization_subdir:
         if args.method == "json_byte_fallback" and args.json_tokens_file:
@@ -218,6 +220,12 @@ def main():
             output_dir = args.method
         if args.output_subdir_suffix:
             output_dir = f"{output_dir}_{args.output_subdir_suffix}"
+        if args.method == "char_bpe" and args.vocab_size_increment:
+            output_dir = f"{output_dir}_{args.vocab_size}"
+    return output_dir
+
+def _prepare_one(args):
+    output_dir = _output_dir_for_args(args)
     if output_dir:
         args.meta_output_path = os.path.join(output_dir, "meta.pkl")
         args.train_output = os.path.join(output_dir, os.path.basename(args.train_output))
@@ -373,6 +381,41 @@ def main():
 
     if byte_metrics is not None:
         _update_meta_with_byte_metrics(args.meta_output_path, byte_metrics)
+
+def _factored_vocab_sizes(maximum, increment):
+    if increment <= 0:
+        raise ValueError("--vocab_size_increment must be greater than zero.")
+    if maximum <= 256:
+        raise ValueError("--vocab_size must be greater than 256 for char_bpe.")
+    sizes = list(range(increment, maximum + 1, increment))
+    sizes = [size for size in sizes if size > 256]
+    if not sizes or sizes[-1] != maximum:
+        sizes.append(maximum)
+    return sizes
+
+def main():
+    args = parse_arguments()
+    if args.vocab_size_increment is None:
+        _prepare_one(args)
+        return
+    if args.method != "char_bpe":
+        raise ValueError("--vocab_size_increment is only supported with --method char_bpe.")
+    if not args.output_tokenization_subdir:
+        raise ValueError("--vocab_size_increment requires -s/--output_tokenization_subdir.")
+    if args.char_bpe_vocab_path:
+        raise ValueError("--vocab_size_increment cannot be combined with --char_bpe_vocab_path.")
+
+    sizes = _factored_vocab_sizes(args.vocab_size, args.vocab_size_increment)
+    source_meta = None
+    # Train the largest vocabulary first. Smaller variants reuse prefixes of its
+    # ordered merge list, avoiding independent BPE training runs.
+    for vocab_size in reversed(sizes):
+        variant_args = copy.deepcopy(args)
+        variant_args.vocab_size = vocab_size
+        variant_args.char_bpe_vocab_path = source_meta
+        _prepare_one(variant_args)
+        if source_meta is None:
+            source_meta = os.path.join(_output_dir_for_args(variant_args), "meta.pkl")
 
 if __name__ == "__main__":
     main()

--- a/data/template/tests.py
+++ b/data/template/tests.py
@@ -310,6 +310,47 @@ class TestTokenizers(unittest.TestCase):
         if os.path.exists(reuse_meta_path):
             os.remove(reuse_meta_path)
 
+    def test_char_bpe_reuse_can_take_vocab_prefix(self):
+        corpus = "abababababababababababababababab"
+        meta_path = "char_bpe_factored_source.pkl"
+        tokenizer = CharBPETokenizerWithByteFallback(
+            Namespace(vocab_size=264, track_token_counts=False, meta_output_path=meta_path),
+            corpus,
+            None,
+        )
+        tokenizer.tokenize(corpus)
+
+        smaller_meta_path = "char_bpe_factored_smaller.pkl"
+        smaller = CharBPETokenizerWithByteFallback(
+            Namespace(
+                vocab_size=260,
+                char_bpe_vocab_path=meta_path,
+                track_token_counts=False,
+                meta_output_path=smaller_meta_path,
+            ),
+            corpus,
+            None,
+        )
+        ids = smaller.tokenize(corpus)
+
+        self.assertEqual(smaller.vocab_size, 260)
+        self.assertEqual(smaller.detokenize(ids), corpus)
+        self.temp_paths.extend([meta_path, smaller_meta_path])
+
+    def test_factored_vocab_sizes_and_directory_names(self):
+        self.assertEqual(prepare._factored_vocab_sizes(9000, 1000), list(range(1000, 10000, 1000)))
+        self.assertEqual(prepare._factored_vocab_sizes(2500, 1000), [1000, 2000, 2500])
+        args = Namespace(
+            output_tokenization_subdir=True,
+            method="char_bpe",
+            output_subdir_suffix="factored",
+            vocab_size_increment=1000,
+            vocab_size=9000,
+            json_tokens_file=None,
+            hf_tokenizer_name=None,
+        )
+        self.assertEqual(prepare._output_dir_for_args(args), "char_bpe_factored_9000")
+
 
     def test_char_bpe_incomplete_coverage_uses_byte_fallback(self):
         corpus = "aaaaabbbbcccdde🙂🙃"


### PR DESCRIPTION
### Motivation

- Provide a way to produce multiple char-BPE vocabulary sizes (factored prefixes) up to a maximum without retraining BPE from scratch for each size. 
- Place each variant into its own tokenization subdirectory named with the custom tag and final vocab size (e.g. `char_bpe_factored_9000`) to match existing `-s`/`-S` patterns.

### Description

- Added `--vocab_size_increment` to `prepare.py` and implemented `_factored_vocab_sizes`, `_output_dir_for_args`, and `_prepare_one` helpers so `prepare.py` can emit factored char-BPE variants in increments up to `--vocab_size` and orchestrate training the largest vocabulary once while reusing it for smaller variants. 
- Updated `prepare.py` `main()` to validate flags and run variants in descending order, passing a `char_bpe_vocab_path` (the trained largest meta) to smaller variants so they can take ordered prefixes. 
- Modified `CharBPETokenizerWithByteFallback` in `data/template/nanogpt_tokenizers.py` to accept a reused meta and select a prefix of `char_tokens` for a smaller `vocab_size`, including validation that the requested reuse size is >256 and <= source size. 
- Ensure `char_bpe_vocab.json` and `char_bpe_token_counts.json` are written into the tokenization output directory alongside `meta.pkl`, `train.bin`, and `val.bin` instead of the current working directory. 
- Added unit tests to `data/template/tests.py` for prefix reuse, factored-size calculation, and directory naming, and documented the feature and example usage in `data/template/README.md`.

### Testing

- Ran targeted unit tests `tests.TestTokenizers.test_char_bpe_reuse_can_take_vocab_prefix` and `tests.TestTokenizers.test_factored_vocab_sizes_and_directory_names`, which passed. 
- Executed the integrated prepare workflow in a temporary directory with `python data/template/prepare.py -t input.txt --method char_bpe --vocab_size 263 --vocab_size_increment 260 -T -s -S factored`, and asserted that each produced directory contains `meta.pkl`, `train.bin`, `val.bin`, `char_bpe_vocab.json`, and `char_bpe_token_counts.json`, which succeeded. 
- Ran full `python data/template/tests.py` which passed all non-network tests and the newly added Char-BPE tests, while two `tiktoken` tests failed due to TLS certificate verification errors when attempting to download external encoding assets (cause: `CERTIFICATE_VERIFY_FAILED` contacting `openaipublic.blob.core.windows.net`). 
- Verified `python -m py_compile` on the modified files and `git diff --check`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b432de198832692a62d62965bbcfe)