### PR TITLE
Introduce attention-only block variant, exploration config, and tests

### DIFF
--- a/explorations/attention_only_san.yaml
+++ b/explorations/attention_only_san.yaml
@@ -1,0 +1,58 @@
+# Parameter-matched comparison of an attention-only Simple Attention Network
+# (SAN) and a regular SwiGLU transformer on a locally prepared OPUS-100 pair.
+#
+# Prepare the desired language pair first (English-Spanish shown here):
+#   cd data/opus-100
+#   python3 get_dataset.py -f en -t es
+#   python3 prepare.py -t input.txt --method sentencepiece --vocab_size 32000
+#
+# Then launch from the repository root:
+#   python3 optimization_and_search/run_experiments.py \
+#     -c explorations/attention_only_san.yaml
+---
+common_group:
+  dataset: ["opus-100"]
+  block_size: [512]
+  n_embd: [512]
+  n_head: [8]
+  n_kv_group: [4]
+
+  # Shared SAN/transformer attention recipe.
+  use_qk_norm: [true]
+  use_rotary_embeddings: [true]
+  use_abs_pos_embeddings: [false]
+  norm_variant_attn: ["rmsnorm"]
+  norm_variant_output: ["rmsnorm"]
+  use_pre_ln: [true]
+  attention_variant: ["causal"]
+  softmax_variant_attn: ["softmax"]
+  bias: [false]
+  dropout: [0.0]
+
+  # Keep data order, budget, and evaluation settings identical between arms.
+  max_iters: [10000]
+  eval_interval: [500]
+  seed: [42, 43, 44]
+  device: ["cuda"]
+  dtype: ["bfloat16"]
+  compile: [true]
+  compute_model_stats: [true]
+  never_save_checkpoint: [true]
+  optimizer: ["muon"]
+  weight_decay: [0.0]
+
+parameter_groups:
+  # Approximately 15.7M non-embedding block parameters: 20 attention layers.
+  # The learning-rate sweep is per arm because the paper finds that sharing a
+  # single tuned rate can bias the architecture comparison.
+  - attention_only: [true]
+    n_layer: [20]
+    learning_rate: [0.01, 0.02, 0.04]
+
+  # Approximately 15.7M non-embedding block parameters: four attention +
+  # width-2048 SwiGLU layers. This is the paper's iso-parameter control.
+  - attention_only: [false]
+    n_layer: [4]
+    mlp_variant: ["swiglu"]
+    mlp_size: [2048]
+    learning_rate: [0.02, 0.04, 0.08]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -207,6 +207,8 @@ class GPTConfig:
 
     # MLP Options
     use_parallel_mlp: bool = False
+    # Remove the token-wise feed-forward sublayer from every transformer block.
+    attention_only: bool = False
     mlp_variant: str = "mlp"
     mlp_expansion_factor: int = 4
     mlp_size: int = None

--- a/model.py
+++ b/model.py
@@ -55,6 +55,8 @@ class GPT(nn.Module):
         super().__init__()
         assert config.vocab_size is not None
         assert config.block_size is not None
+        if config.attention_only and config.attention_residual_variant != "standard":
+            raise ValueError("attention_only currently requires standard attention residuals")
 
         self.config = config
 

--- a/shared_param_utils.py
+++ b/shared_param_utils.py
@@ -62,6 +62,11 @@ class SharedParamGroupCreator:
             list of layer_blocks
         """
 
+        if layer_type == "mlp" and self.config.attention_only:
+            # Attention-only blocks do not own an MLP. Avoid constructing an
+            # otherwise unused set of feed-forward parameters here.
+            return [None] * self.config.n_layer
+
         if layer_type == "mlp":
             shared_size = self.config.shared_mlp_size
             shared_sym  = self.config.shared_mlp_sym

--- a/tests/test_attention_only.py
+++ b/tests/test_attention_only.py
@@ -1,0 +1,45 @@
+import torch
+
+from gpt_conf import GPTConfig
+from model import GPT
+
+
+def _config(**overrides):
+    values = dict(
+        vocab_size=32,
+        block_size=8,
+        n_layer=2,
+        n_head=2,
+        n_kv_group=1,
+        n_embd=16,
+        attention_only=True,
+        use_abs_pos_embeddings=False,
+        use_rotary_embeddings=True,
+        use_qk_norm=True,
+        dropout=0.0,
+    )
+    values.update(overrides)
+    return GPTConfig(**values)
+
+
+def test_attention_only_model_has_no_mlp_parameters_and_trains():
+    model = GPT(_config())
+
+    assert all(block.mlp is None for block in model.transformer.h)
+    assert not any(".mlp." in name for name, _ in model.named_parameters())
+
+    tokens = torch.randint(0, 32, (2, 8))
+    logits, loss = model(tokens, tokens, iter_num=0)
+    assert logits.shape == (2, 8, 32)
+    assert torch.isfinite(loss)
+    loss.backward()
+    assert model.transformer.h[0].attn.c_proj.weight.grad is not None
+
+
+def test_attention_only_rejects_parallel_mlp():
+    try:
+        GPT(_config(use_parallel_mlp=True))
+    except ValueError as error:
+        assert "use_parallel_mlp" in str(error)
+    else:
+        raise AssertionError("expected incompatible configuration to fail")

--- a/tests/test_attention_only.py
+++ b/tests/test_attention_only.py
@@ -1,3 +1,6 @@
+import ast
+from pathlib import Path
+
 import torch
 
 from gpt_conf import GPTConfig
@@ -43,3 +46,22 @@ def test_attention_only_rejects_parallel_mlp():
         assert "use_parallel_mlp" in str(error)
     else:
         raise AssertionError("expected incompatible configuration to fail")
+
+
+def test_attention_only_is_available_from_training_cli():
+    tree = ast.parse((Path(__file__).parents[1] / "train_args.py").read_text())
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+        and node.args[0].value == "--attention_only"
+    ]
+    assert len(calls) == 1
+
+    keywords = {keyword.arg: keyword.value for keyword in calls[0].keywords}
+    assert isinstance(keywords["default"], ast.Constant)
+    assert keywords["default"].value is False
+    assert isinstance(keywords["action"], ast.Attribute)
+    assert keywords["action"].attr == "BooleanOptionalAction"

--- a/tests/test_attention_only_exploration.py
+++ b/tests/test_attention_only_exploration.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import yaml
+
+
+def test_opus_attention_only_exploration_has_matched_comparison_arms():
+    config_path = (
+        Path(__file__).parents[1] / "explorations" / "attention_only_san.yaml"
+    )
+    config = yaml.safe_load(config_path.read_text())
+
+    assert config["common_group"]["dataset"] == ["opus-100"]
+    assert config["common_group"]["seed"] == [42, 43, 44]
+
+    san, transformer = config["parameter_groups"]
+    assert san["attention_only"] == [True]
+    assert san["n_layer"] == [20]
+
+    assert transformer["attention_only"] == [False]
+    assert transformer["n_layer"] == [4]
+    assert transformer["mlp_variant"] == ["swiglu"]
+    assert transformer["mlp_size"] == [2048]
+
+    # Each arm must tune its own learning rate rather than inheriting one rate.
+    assert len(san["learning_rate"]) > 1
+    assert len(transformer["learning_rate"]) > 1

--- a/train_args.py
+++ b/train_args.py
@@ -726,8 +726,14 @@ def parse_args():
             "dual_path",
             "dual_path_swiglu",
             "identity",
-            ]
+    ]
 
+    model_group.add_argument(
+        '--attention_only',
+        default=False,
+        action=argparse.BooleanOptionalAction,
+        help='Remove the token-wise MLP/FFN sublayer from every transformer block.',
+    )
     model_group.add_argument('--use_parallel_mlp', default=False, action=argparse.BooleanOptionalAction)
     model_group.add_argument("--mlp_variant", type=str, default="mlp", choices=mlp_variants, help="MLP variation type")
     model_group.add_argument("--mlp_expansion_factor", type=int, default=4, help="If MLP like variant is used, set the expansion factor for the linear transformations, default is 4.")

--- a/variations/block_variations.py
+++ b/variations/block_variations.py
@@ -167,6 +167,22 @@ def attn_then_mlp_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor
     return x
 
 
+def attention_only_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor:
+    """Pre-norm attention and its residual connection, with no FFN sublayer."""
+    x_attn_in = block.pre_ln_attn(x) if block.use_pre_ln_attn else x
+    attn_out = block.attn(x_attn_in, iter_num)
+
+    if block.use_peri_ln_attn:
+        attn_out = block.peri_ln_attn(attn_out)
+    if block.attn_resid_scaler is not None:
+        attn_out = block.attn_resid_scaler(attn_out)
+
+    x = block._combine_resid("attn", x, attn_out)
+    if block.use_post_ln_attn:
+        x = block.post_ln_attn(x)
+    return x
+
+
 def edgellm_asic_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor:
     """EdgeLLM ASIC forward: Attention followed by MLP with skip connection accumulation between blocks."""
 
@@ -256,6 +272,7 @@ def edgellm_asic_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor:
 block_forward_variations = {
     "parallel_mlp": parallel_mlp_forward,
     "attn_then_mlp": attn_then_mlp_forward,
+    "attention_only": attention_only_forward,
     "edgellm_asic": edgellm_asic_forward,
 }
 
@@ -321,9 +338,20 @@ def _setup_norms_sequential(self, config, norm_cls) -> None:
         self.post_ln_mlp = norm_cls(config)
 
 
+def _setup_norms_attention_only(self, config, norm_cls) -> None:
+    """Build only normalization modules used by an attention-only block."""
+    if getattr(self, "use_pre_ln_attn", False):
+        self.pre_ln_attn = norm_cls(config)
+    if getattr(self, "use_peri_ln_attn", False):
+        self.peri_ln_attn = norm_cls(config)
+    if getattr(self, "use_post_ln_attn", False):
+        self.post_ln_attn = norm_cls(config)
+
+
 normalization_setup_variations = {
     "parallel_mlp": _setup_norms_parallel,
     "attn_then_mlp": _setup_norms_sequential,
+    "attention_only": _setup_norms_attention_only,
     "edgellm_asic": _setup_norms_sequential,
 }
 
@@ -361,9 +389,19 @@ def _setup_resid_scalers_sequential(self, config) -> None:
         self.mlp_resid_scaler = cls(config, prefix="mlp")
 
 
+def _setup_resid_scalers_attention_only(self, config) -> None:
+    """Build only the residual scaler used by the attention branch."""
+    self.attn_resid_scaler = None
+    self.mlp_resid_scaler = None
+    if getattr(config, "use_attn_resid_scaling", False):
+        cls = learned_confidence_dictionary[config.attn_confidence_variant]
+        self.attn_resid_scaler = cls(config, prefix="attn")
+
+
 resid_scaler_setup_variations = {
     "parallel_mlp": _setup_resid_scalers_parallel,
     "attn_then_mlp": _setup_resid_scalers_sequential,
+    "attention_only": _setup_resid_scalers_attention_only,
     "edgellm_asic": _setup_resid_scalers_sequential,
 }
 
@@ -373,6 +411,12 @@ class Block(nn.Module):
 
     def __init__(self, config, mlp=None, attn=None):
         super().__init__()
+
+        self.attention_only = getattr(config, "attention_only", False)
+        if self.attention_only and getattr(config, "use_parallel_mlp", False):
+            raise ValueError("attention_only is incompatible with use_parallel_mlp")
+        if self.attention_only and getattr(config, "use_edgellm_asic", False):
+            raise ValueError("attention_only is incompatible with use_edgellm_asic")
 
         # Choose norm class for attention/MLP blocks
         norm_cls = norm_dictionary[config.norm_variant_attn]
@@ -391,7 +435,9 @@ class Block(nn.Module):
 
         self.use_flash_norm = getattr(config, "use_flash_norm", False)
 
-        if self.use_parallel_mlp:
+        if self.attention_only:
+            variant = "attention_only"
+        elif self.use_parallel_mlp:
             variant = "parallel_mlp"
         elif self.use_edgellm_asic:
             variant = "edgellm_asic"
@@ -423,7 +469,9 @@ class Block(nn.Module):
         else:
             self.attn = attn
 
-        if mlp is None:
+        if self.attention_only:
+            self.mlp = None
+        elif mlp is None:
             self.mlp = get_mlp_instance(config)
         else:
             self.mlp = mlp


### PR DESCRIPTION
### Motivation
- Add support for attention-only transformer blocks (remove per-block MLP) for controlled architecture comparisons and experiments.
- Provide an exploration recipe to compare an attention-only Simple Attention Network (SAN) with a SwiGLU transformer on OPUS-100.
- Ensure configuration-level guards and tests to prevent incompatible combinations and regressions.

### Description
- Add `attention_only` option to `GPTConfig` and validate that `attention_only` requires standard attention residuals in `model.GPT` by raising a `ValueError` for incompatible residual variants.
- Update `shared_param_utils.SharedParamGroupCreator.create_shared_param_group` to skip constructing MLP parameter groups when `attention_only` is set by returning a list of `None` for MLP blocks.
- Implement attention-only forward logic in `variations.block_variations` with `attention_only_forward`, a dedicated normalization setup `_setup_norms_attention_only`, and residual scaler setup `_setup_resid_scalers_attention_only`, and register them in the relevant dispatch tables.
- Extend `Block.__init__` to detect `attention_only`, forbid incompatible block modes (`use_parallel_mlp` and `use_edgellm_asic`), select the `attention_only` forward variant, and avoid instantiating an MLP for attention-only blocks.
- Add an exploration config `explorations/attention_only_san.yaml` that sets up matched-parameter comparisons between attention-only SAN and SwiGLU transformer arms and tunes per-arm learning rates.
- Add unit tests `tests/test_attention_only.py` and `tests/test_attention_only_exploration.py` to verify model structure, basic forward/backward behavior, configuration rejection for incompatible flags, and that the exploration YAML contains matched arms.

### Testing
- Ran unit tests `tests/test_attention_only.py::test_attention_only_model_has_no_mlp_parameters_and_trains` and `tests/test_attention_only.py::test_attention_only_rejects_parallel_mlp`, which passed.
- Ran `tests/test_attention_only_exploration.py` to validate the exploration YAML layout and per-arm learning-rate tuning, which passed.
- No other automated tests were modified; all added tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7aa5a932cc832694cfe4a9ec99b1c7)